### PR TITLE
feat: persist Pictionary player profile in localStorage

### DIFF
--- a/documentation/docs/journey/pictionary.md
+++ b/documentation/docs/journey/pictionary.md
@@ -40,6 +40,30 @@ restart         — { ts }
 
 `lobby → choosing → drawing → intermission → …` looping until `round.number === totalRounds`, then `summary`. The host is the owner of the canonical state; every transition (`startRound`, `pickWord`, `endRound`, `restartGame`) writes locally via an `apply*` function **and** broadcasts to peers. Peers run the same `apply*` on receive. This keeps the host/peer code paths symmetric.
 
+## WebRTC connection hiccups
+
+Trystero's P2P signaling has an inherent delay — when peer A joins, peer B may not immediately see them, and avatar data sent during that window is lost. This caused "ghost players" (connected but showing no name/color) and missing player entries in the sidebar.
+
+Two complementary strategies fixed this:
+
+1. **HELLO channel echo**: when a peer joins, the existing peer sends a `hello` message. On receiving `hello`, every peer re-broadcasts their avatar data. This ensures late-arriving avatar info is retransmitted after both sides have established the data channel.
+
+2. **Delayed re-announce**: after `announceSelf`, a second avatar broadcast fires after 2 seconds (`REANNOUNCE_DELAY_MS`). This covers the case where the signaling completes but the data channel isn't ready for the first few hundred milliseconds — common on mobile networks.
+
+```ts
+// On peer join — trigger re-broadcast from all existing peers
+p2pOnData(joined, HELLO_CHANNEL, () => {
+  p2pSendData(joined, AVATAR_CHANNEL, { name, color })
+})
+
+// On self join — delayed retry
+setTimeout(() => {
+  p2pSendData(joined, AVATAR_CHANNEL, { name, color })
+}, REANNOUNCE_DELAY_MS)
+```
+
+The score cache (`Map<peerId, number>`) also helps here: if a peer disconnects and reconnects (getting a new peer ID from the same browser), the avatar handler restores their score via `existing?.score ?? cachedScore`. A system message is posted to chat on disconnect so players know what happened.
+
 ## Close-guess detection
 
 Chat guesses off by one character show a system hint (`"Alice is very close!"`). `chatEditDistance` is a pure-functional Levenshtein in `packages/chat/src/match.ts` — written as nested `reduce` returning new arrays to satisfy `functional/immutable-data`. The `CLOSE_MAX_DISTANCE = 1` constant makes the threshold easy to tune.

--- a/src/views/Games/Pictionary/Pictionary.vue
+++ b/src/views/Games/Pictionary/Pictionary.vue
@@ -10,6 +10,8 @@ import { usePictionaryTimer } from './usePictionaryTimer'
 import {
   buildRandomGradient,
   randomPick,
+  loadProfile,
+  saveProfile,
   NAME_ADJECTIVES,
   NAME_ANIMALS,
   PLAYER_COLORS
@@ -39,8 +41,11 @@ const {
   revealedHintIndices
 } = storeToRefs(store)
 
-const playerName = ref(`${randomPick(NAME_ADJECTIVES)}${randomPick(NAME_ANIMALS)}`)
-const playerColor = ref(randomPick(PLAYER_COLORS))
+const storedProfile = loadProfile()
+const playerName = ref(
+  storedProfile?.name ?? `${randomPick(NAME_ADJECTIVES)}${randomPick(NAME_ANIMALS)}`
+)
+const playerColor = ref(storedProfile?.color ?? randomPick(PLAYER_COLORS))
 const backgroundStyle = { background: buildRandomGradient() }
 const difficulty = ref<DictionaryDifficulty>('easy')
 const drawingReference = ref<InstanceType<typeof PictionaryDrawing> | null>(null)
@@ -101,11 +106,13 @@ const handleNameChange = (): void => {
   const trimmed = playerName.value.trim()
   if (!trimmed) return
   session.updateProfile(trimmed, playerColor.value)
+  saveProfile(trimmed, playerColor.value)
 }
 
 const handleColorChange = (color: string): void => {
   playerColor.value = color
   session.updateProfile(playerName.value.trim() || playerName.value, color)
+  saveProfile(playerName.value.trim() || playerName.value, color)
 }
 
 const handleStroke = (event: StrokeEvent): void => {

--- a/src/views/Games/Pictionary/constants.ts
+++ b/src/views/Games/Pictionary/constants.ts
@@ -55,3 +55,33 @@ export const HINT_COUNT_OPTIONS = [0, 1, 2, 3, 4, 5]
 export const POINTS_BASE = 100
 export const POINTS_FIRST_BONUS = 50
 export const POINTS_DRAWER_PER_GUESS = 25
+
+export const PROFILE_STORAGE_KEY = 'pictionary-profile'
+
+type StoredProfile = { name: string; color: string }
+
+/**
+ * Load a persisted player profile from localStorage.
+ * @returns The stored profile or null if not found or invalid.
+ */
+export const loadProfile = (): StoredProfile | null => {
+  try {
+    const raw = localStorage.getItem(PROFILE_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<StoredProfile>
+    if (typeof parsed.name !== 'string' || typeof parsed.color !== 'string') return null
+    if (!PLAYER_COLORS.includes(parsed.color)) return null
+    return { name: parsed.name, color: parsed.color }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Persist a player profile to localStorage.
+ * @param name - Player display name.
+ * @param color - Player color hex string.
+ */
+export const saveProfile = (name: string, color: string): void => {
+  localStorage.setItem(PROFILE_STORAGE_KEY, JSON.stringify({ name, color }))
+}


### PR DESCRIPTION
Closes #80

## Summary
- Load saved player name and color from `localStorage` on init, fall back to random for first-time visitors
- Persist on every name or color change via `saveProfile()`
- Validates stored color against `PLAYER_COLORS` before using
- Journey docs: added section on WebRTC connection hiccups (HELLO channel echo + delayed re-announce strategy)

## Key Changes
- `constants.ts`: `loadProfile()`, `saveProfile()`, `PROFILE_STORAGE_KEY`
- `Pictionary.vue`: init from stored profile, save on change
- `pictionary.md`: new "WebRTC connection hiccups" section

## Test plan
- [ ] Set name and color → reload → name and color persist
- [ ] Clear `localStorage` → reload → random name/color generated
- [ ] Invalid stored color (not in palette) → falls back to random
- [ ] Invalid JSON in storage → falls back to random

🤖 Generated with [Claude Code](https://claude.com/claude-code)