### PR TITLE
fix: read difficulty from Pinia store instead of snapshot

### DIFF
--- a/documentation/docs/journey/pictionary.md
+++ b/documentation/docs/journey/pictionary.md
@@ -154,3 +154,7 @@ On disconnect, the player's score is cached in a `Map<peerId, number>` and a sys
 ## Tie handling
 
 The summary phase computes `topPlayers` (all players sharing the highest score). If more than one, the banner shows "It's a tie! Alice and Bob share 300 points" using Oxford-comma joining for 3+.
+
+## Difficulty selection fix
+
+The difficulty dropdown in the lobby wasn't affecting word selection. Root cause: `difficulty` was passed as a plain value snapshot (`options.difficulty`) at session init time. When the host changed the dropdown, the session still used the initial value (`'easy'`). Fix: moved `difficulty` into the Pinia store (`usePictionaryStore`) so it's reactive and shared. `broadcastConfig` and `startRoundForContext` now read `ctx.store.difficulty`, which always reflects the current dropdown selection. The config channel also writes to the store on receive, keeping peers in sync.

--- a/src/stores/pictionary.ts
+++ b/src/stores/pictionary.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import type { ChatMessage } from '@webgamekit/chat'
+import type { DictionaryDifficulty } from '@webgamekit/dictionary'
 
 export type PictionaryPlayer = {
   id: string
@@ -35,6 +36,7 @@ export const usePictionaryStore = defineStore('pictionary', () => {
   const roundDuration = ref(60)
   const wordCount = ref(1)
   const hintCount = ref(2)
+  const difficulty = ref<DictionaryDifficulty>('easy')
   const intermissionEndsAt = ref<number | null>(null)
   const revealedHintIndices = ref<number[]>([])
 
@@ -88,6 +90,7 @@ export const usePictionaryStore = defineStore('pictionary', () => {
     roundDuration,
     wordCount,
     hintCount,
+    difficulty,
     intermissionEndsAt,
     revealedHintIndices,
     playerList,

--- a/src/views/Games/Pictionary/Pictionary.vue
+++ b/src/views/Games/Pictionary/Pictionary.vue
@@ -3,7 +3,6 @@ import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { usePictionaryStore } from '@/stores/pictionary'
-import type { DictionaryDifficulty } from '@webgamekit/dictionary'
 import type { StrokeEvent } from '@webgamekit/canvas-editor'
 import { usePictionarySession } from './usePictionarySession'
 import { usePictionaryTimer } from './usePictionaryTimer'
@@ -36,13 +35,13 @@ const {
   wordCount,
   hintCount,
   intermissionEndsAt,
-  revealedHintIndices
+  revealedHintIndices,
+  difficulty
 } = storeToRefs(store)
 
 const playerName = ref(`${randomPick(NAME_ADJECTIVES)}${randomPick(NAME_ANIMALS)}`)
 const playerColor = ref(randomPick(PLAYER_COLORS))
 const backgroundStyle = { background: buildRandomGradient() }
-const difficulty = ref<DictionaryDifficulty>('easy')
 const drawingReference = ref<InstanceType<typeof PictionaryDrawing> | null>(null)
 
 const resolvedRoomId = ((): string => {
@@ -66,7 +65,6 @@ const session = usePictionarySession({
   name: playerName.value,
   color: playerColor.value,
   roomId: resolvedRoomId,
-  difficulty: difficulty.value,
   onRemoteStroke: (payload) => drawingReference.value?.renderSegment(payload),
   onRemoteClear: () => drawingReference.value?.silentClear()
 })

--- a/src/views/Games/Pictionary/usePictionarySession.ts
+++ b/src/views/Games/Pictionary/usePictionarySession.ts
@@ -79,7 +79,6 @@ type UsePictionarySessionOptions = {
   name: string
   color: string
   roomId: string
-  difficulty: DictionaryDifficulty
   onRemoteStroke: (payload: PictionaryStrokePayload) => void
   onRemoteClear: () => void
 }
@@ -107,7 +106,7 @@ const broadcastConfig = (ctx: PictionaryContext, target: P2PSession): void => {
     roundDuration: ctx.store.roundDuration,
     wordCount: ctx.store.wordCount,
     hintCount: ctx.store.hintCount,
-    difficulty: ctx.options.difficulty
+    difficulty: ctx.store.difficulty
   }
   p2pSendData(target, CONFIG_CHANNEL, payload)
 }
@@ -153,7 +152,7 @@ const startRoundForContext = (ctx: PictionaryContext): void => {
   const drawerId = ids[(nextNumber - 1) % ids.length]
   const buildChoice = (): string =>
     Array.from({ length: ctx.store.wordCount }, () =>
-      dictionaryPickRandom(ctx.options.difficulty)
+      dictionaryPickRandom(ctx.store.difficulty)
     ).join(' ')
   const choices = [...new Set(Array.from({ length: WORD_CHOICE_COUNT * 3 }, buildChoice))].slice(
     0,
@@ -319,7 +318,7 @@ const bindPeerEvents = (ctx: PictionaryContext, joined: P2PSession): void => {
     ctx.store.roundDuration = payload.roundDuration
     ctx.store.wordCount = payload.wordCount
     ctx.store.hintCount = payload.hintCount
-    ctx.options.difficulty = payload.difficulty
+    ctx.store.difficulty = payload.difficulty
   })
 }
 


### PR DESCRIPTION
Closes #82

## Summary
- Moved `difficulty` from session options (plain value snapshot) to the Pinia store so it stays reactive when the host changes the dropdown
- `broadcastConfig` and `startRoundForContext` now read `ctx.store.difficulty` instead of `ctx.options.difficulty`
- Peers receive difficulty updates via the config channel and write to the store

## Key Changes
- `src/stores/pictionary.ts` — added `difficulty` ref with `DictionaryDifficulty` type
- `src/views/Games/Pictionary/usePictionarySession.ts` — replaced all `ctx.options.difficulty` with `ctx.store.difficulty`, removed `difficulty` from options type
- `src/views/Games/Pictionary/Pictionary.vue` — use `storeToRefs` for difficulty instead of local ref
- `documentation/docs/journey/pictionary.md` — added section documenting the fix

## Test plan
- [ ] Set difficulty to "hard" in lobby, start a round — verify word choices are multi-word or 10+ letters
- [ ] Set difficulty to "medium" — verify words are 7+ letters
- [ ] Change difficulty between rounds — verify new difficulty applies
- [ ] Join as peer — verify difficulty syncs from host

🤖 Generated with [Claude Code](https://claude.com/claude-code)