### PR TITLE
fix: move overflow-y to sheet-content for independent panel scrolling

### DIFF
--- a/src/components/panels/PanelContainer.vue
+++ b/src/components/panels/PanelContainer.vue
@@ -59,10 +59,12 @@ defineProps<{
   align-items: flex-start;
   z-index: calc(var(--z-overlay) + 1);
   pointer-events: none;
-  overflow-y: auto;
-
   > * {
     pointer-events: auto;
+  }
+
+  @media (max-width: 768px) {
+    overflow-y: auto;
   }
 }
 
@@ -81,6 +83,7 @@ defineProps<{
   background-color: var(--color-background);
   padding: var(--spacing-2);
   overflow-x: hidden;
+  overflow-y: auto;
   max-height: 100%;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Closes #93

## Summary

- Removed `overflow-y: auto` from `.panel-container` so the whole panel stack no longer scrolls as one unit on desktop
- Added `overflow-y: auto` to `.sheet-content` so each panel scrolls independently within its own `max-height`
- Mobile preserves container scroll via `@media (max-width: 768px)`

## Test Plan

- [ ] Open a view with a tall config panel — the panel scrolls on its own; other panels are unaffected
- [ ] Resize to mobile width — container scroll is restored
- [ ] 815 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)