### PR TITLE
feat: Matchmaker — P2P lobby with per-player request/accept/ignore

### DIFF
--- a/documentation/docs/journey/multiplayer-p2p.md
+++ b/documentation/docs/journey/multiplayer-p2p.md
@@ -261,3 +261,59 @@ const configControls = {
 ```
 
 The config value stores the object URL from `URL.createObjectURL(file)`. The control renders a styled `<input type="file">` in `ConfigControls.vue`.
+
+## Matchmaker: room ID strategy matters
+
+When building `p2pLobbyJoin`-based matchmaking, the first instinct was to auto-generate a fresh game room ID from the two peer IDs (deterministic, race-condition free):
+
+```ts
+const gameRoomId = [localPeerId, remotePeerId].sort().join('--')
+```
+
+**Problem:** this creates a private room no one outside the matchmaker can reach. The share link (`?room=<originalId>`) now points to an empty room. Players who joined via the link and players who found the game via the matchmaker are on different rooms.
+
+**Fix:** the requester advertises their _existing_ game room ID in the request:
+
+```ts
+handle.sendRequest(peerId, currentGameRoomId)
+```
+
+The acceptor navigates to `request.gameRoomId` (the host's room). The host stays in their room and keeps the matchmaker running — the share link remains valid, and the host can find additional players simultaneously.
+
+**Key rule:** never create a new room for a match. Reuse the host's current room.
+
+## Matchmaker: host role and searching state conflict
+
+When a new player joins a game room via the share link, Trystero assigns the host role to the peer with the lexicographically smallest peer ID. If the newcomer has a smaller ID, they inherit the host role even though the original host was actively searching.
+
+**Symptoms observed:**
+
+- Original host loses the `isHost` flag mid-session
+- Matchmaker widget was still visible (lobbyHandle still set) but `isHost` was false
+- Both the matchmaker searching UI and the guest-waiting UI rendered simultaneously
+
+**Fix:** `watch(() => props.isHost, (isHost) => { if (!isHost) stopSearching() })` in `PictionaryLobby`. The former host immediately leaves the matchmaker lobby and shows the guest-waiting UI.
+
+**Secondary fix:** changed the matchmaker section condition from `isHost && (lobbyHandle !== null || playerList.length <= 1)` to simply `isHost`. The host can always see the "Find players" button regardless of how many players are already present — supporting the pattern of continuing to search for more players after the first match.
+
+## Matchmaker: lobby room must stay separate from the game room
+
+The matchmaker and the game both use Trystero rooms. They must use different room IDs:
+
+| Room       | ID                              | Purpose                                                |
+| ---------- | ------------------------------- | ------------------------------------------------------ |
+| Game room  | `<uuid>` (from URL query param) | Real-time game state: positions, drawing strokes, chat |
+| Lobby room | `pictionary-matchmaker`         | Discovery: who is searching for a match                |
+
+If both used the same room ID, game events (positions, strokes) would flood the lobby's request/response channels, and players could not reliably negotiate matches.
+
+## `p2pMatchmake` vs `p2pLobbyJoin`
+
+Two matchmaking APIs were built during this feature, serving different use cases:
+
+| API            | When to use                                                                                                                                                               |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `p2pMatchmake` | Auto-connect: first peer in the shared room triggers `'matched'`. No UI negotiation needed. Good for games where any opponent is fine.                                    |
+| `p2pLobbyJoin` | Explicit approval: players see a list of candidates and choose. Needed when room identity matters (e.g. Pictionary — joining the wrong room means losing the share link). |
+
+`p2pMatchmake` is a thin wrapper around `p2pJoin` + `p2pOnPeerJoin` that exposes only a status callback and a `stop()`. `p2pLobbyJoin` adds three targeted data channels (`lobby-req`, `lobby-res`, `lobby-name`) on top of the base session for request/response/name negotiation.

--- a/documentation/docs/packages/multiplayer-p2p.md
+++ b/documentation/docs/packages/multiplayer-p2p.md
@@ -1,0 +1,360 @@
+---
+sidebar_position: 8
+---
+
+# Package: @webgamekit/multiplayer-p2p
+
+Serverless P2P multiplayer for browser games using WebRTC via [Trystero](https://github.com/dmotz/trystero) (NOSTR signaling — no dedicated server required).
+
+## Installation
+
+```bash
+pnpm add @webgamekit/multiplayer-p2p
+```
+
+## Requirements
+
+- **Secure context**: `crypto.subtle` is only available on HTTPS or `localhost`. Call `p2pIsSupported()` before joining any room.
+- **Vite**: Exclude Trystero from the optimizer (see [vite.config.ts setup](#viteconfigts)).
+
+## Core concepts
+
+| Concept     | Description                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------------------------- |
+| **Room**    | A named shared space identified by a string. All peers in the same room can communicate directly.       |
+| **Session** | The handle returned by `p2pJoin()`. Carries `peerId`, the Trystero `room`, and a `destroy()` function.  |
+| **Channel** | A typed data stream within a room, created via `makeAction`. Send to all peers or target specific ones. |
+
+## Quick start
+
+```typescript
+import {
+  p2pIsSupported,
+  p2pJoin,
+  p2pLeave,
+  p2pGetPeerIds,
+  p2pOnPeerJoin,
+  p2pOnPeerLeave,
+  p2pSendData,
+  p2pOnData
+} from '@webgamekit/multiplayer-p2p'
+
+if (!p2pIsSupported()) {
+  console.warn('P2P unavailable — serve over HTTPS or localhost')
+}
+
+const session = p2pJoin('my-game-room')
+
+// Catch peers already in the room before we joined
+p2pGetPeerIds(session).forEach((peerId) => console.log('already here:', peerId))
+
+// Listen for future joins/leaves
+p2pOnPeerJoin(session, (peerId) => console.log('joined:', peerId))
+p2pOnPeerLeave(session, (peerId) => console.log('left:', peerId))
+
+// Send typed data
+p2pSendData(session, 'game:event', { type: 'score', value: 42 })
+p2pOnData<{ type: string; value: number }>(session, 'game:event', (payload, fromPeerId) => {
+  console.log(fromPeerId, 'scored', payload.value)
+})
+
+// Cleanup
+p2pLeave(session)
+```
+
+## API reference
+
+### Session
+
+```typescript
+p2pIsSupported(): boolean
+p2pJoin(roomId: string, config?: P2PConfig): P2PSession
+p2pLeave(session: P2PSession): void
+p2pGetPeerIds(session: P2PSession): string[]
+p2pOnPeerJoin(session: P2PSession, callback: (peerId: string) => void): void
+p2pOnPeerLeave(session: P2PSession, callback: (peerId: string) => void): void
+```
+
+### Player position / rotation (built-in throttling)
+
+```typescript
+p2pSendPosition(session, position, rotation, config?): void  // throttled 30 ms
+p2pOnPlayers(session, callback: (state: PlayerState) => void): () => void
+```
+
+### Actions (animations, events)
+
+```typescript
+p2pSendAction(session, actionName: string): void
+p2pOnAction(session, callback: (peerId: string, action: PlayerAction) => void): () => void
+```
+
+### Generic typed channels
+
+```typescript
+p2pSendData<T extends DataPayload>(session, channel: string, payload: T): void
+p2pOnData<T>(session, channel: string, callback: (payload: T, peerId: string) => void): () => void
+```
+
+### Matchmaking
+
+See the [Matchmaker tutorial](#tutorial-matchmaker) below.
+
+```typescript
+p2pMatchmake(roomId, config?, onStatusChange): MatchmakeHandle
+p2pLobbyJoin(lobbyRoomId, config?, callbacks: LobbyCallbacks): LobbyHandle
+```
+
+## Tutorial: Matchmaker
+
+The matchmaker solves two separate needs:
+
+| Need                                                                       | API            |
+| -------------------------------------------------------------------------- | -------------- |
+| **Status-only**: know when ≥1 peer is present in a shared room             | `p2pMatchmake` |
+| **Request/accept flow**: browse online players and accept specific matches | `p2pLobbyJoin` |
+
+---
+
+### Simple matchmaking with `p2pMatchmake`
+
+`p2pMatchmake` joins a shared room and emits `'searching'` / `'matched'` as peers arrive or leave. The caller decides what to do on each status change.
+
+```typescript
+import { p2pMatchmake, type MatchmakeStatus } from '@webgamekit/multiplayer-p2p'
+
+const handle = p2pMatchmake(
+  'my-game-lobby',
+  undefined,
+  (status: MatchmakeStatus, peerCount: number) => {
+    if (status === 'matched') {
+      console.log(`Matched! ${peerCount} other player(s) in the room.`)
+      // start game using handle.session
+    } else {
+      console.log('Searching…')
+    }
+  }
+)
+
+// When the user clicks Cancel:
+handle.stop()
+```
+
+**State machine**
+
+```
+idle  ──[join]──►  searching  ──[peer joins]──►  matched
+                      ▲                             │
+                      └────────[all peers leave]────┘
+```
+
+**`MatchmakeHandle`**
+
+| Property  | Type         | Description                   |
+| --------- | ------------ | ----------------------------- |
+| `session` | `P2PSession` | Use to send/receive game data |
+| `stop()`  | `() => void` | Leave the room and tear down  |
+
+---
+
+### Lobby with `p2pLobbyJoin`
+
+`p2pLobbyJoin` provides a full request/accept/ignore negotiation layer on top of the room.  
+Use it when players need to choose who they play with rather than auto-connecting.
+
+```typescript
+import { p2pLobbyJoin, type LobbyHandle, type MatchRequest } from '@webgamekit/multiplayer-p2p'
+
+const handle: LobbyHandle = p2pLobbyJoin('my-game-lobby', undefined, {
+  onPeerJoin: (peerId) => {
+    // A new candidate appeared — send them a request
+    handle.sendRequest(peerId, myCurrentGameRoomId)
+  },
+  onPeerLeave: (peerId) => {
+    // Remove from candidate list
+  },
+  onRequest: (request: MatchRequest, fromPeerId: string) => {
+    // Received a request from fromPeerId
+    // Show in UI: "Player X wants to play" + Accept / Ignore buttons
+    pendingRequests.push({ request, fromPeerId })
+  },
+  onAccepted: (requestId: string) => {
+    // Our request was accepted — the peer is coming to our game room
+    // No navigation needed for us; we can keep searching for more players
+  },
+  onIgnored: (requestId: string) => {
+    // Our request was declined
+  },
+  onPeerName: (peerId, name) => {
+    // The peer broadcast their display name
+    peerNames[peerId] = name
+  }
+})
+
+// Announce your own display name to all peers
+handle.setName('Alice')
+
+// Catch peers already in the lobby
+handle.getPeerIds().forEach((peerId) => handle.sendRequest(peerId, myGameRoomId))
+
+// --- When the user clicks Accept ---
+handle.acceptRequest(pendingRequests[0].request, pendingRequests[0].fromPeerId)
+// Then navigate to the request's gameRoomId:
+// router.push(`?room=${pendingRequests[0].request.gameRoomId}`)
+
+// --- When the user clicks Ignore ---
+handle.ignoreRequest(pendingRequests[0].request, pendingRequests[0].fromPeerId)
+
+// --- Cleanup ---
+handle.stop()
+```
+
+**`LobbyHandle`**
+
+| Method                                   | Description                                                                  |
+| ---------------------------------------- | ---------------------------------------------------------------------------- |
+| `getPeerIds()`                           | All peers currently in the lobby                                             |
+| `setName(name)`                          | Broadcast a display name; auto-sent to future joiners                        |
+| `sendRequest(targetPeerId, gameRoomId?)` | Send a targeted match request; `gameRoomId` defaults to an auto-generated ID |
+| `acceptRequest(request, fromPeerId)`     | Accept an incoming request; the sender will receive `onAccepted`             |
+| `ignoreRequest(request, fromPeerId)`     | Ignore; the sender will receive `onIgnored`                                  |
+| `stop()`                                 | Leave the lobby                                                              |
+
+**`LobbyCallbacks`**
+
+| Callback                         | When it fires                       |
+| -------------------------------- | ----------------------------------- |
+| `onPeerJoin(peerId)`             | A new peer entered the lobby        |
+| `onPeerLeave(peerId)`            | A peer left the lobby               |
+| `onRequest(request, fromPeerId)` | Received a targeted match request   |
+| `onAccepted(requestId)`          | Our outgoing request was accepted   |
+| `onIgnored(requestId)`           | Our outgoing request was ignored    |
+| `onPeerName(peerId, name)`       | A peer broadcast their display name |
+
+---
+
+### Room ID strategy
+
+The `gameRoomId` carried in a request is the ID both sides will use for the game.  
+**Do not auto-generate a new room** — pass the host's existing game room ID so the shared link keeps working:
+
+```typescript
+// ✅ Advertise your existing room
+handle.sendRequest(peerId, currentGameRoomId)
+
+// ❌ Generates a fresh room neither player can reach via share link
+handle.sendRequest(peerId)
+```
+
+When the acceptor receives `onRequest`, they should navigate to `request.gameRoomId`:
+
+```typescript
+onRequest: (request, fromPeerId) => {
+  if (userClicksAccept) {
+    handle.acceptRequest(request, fromPeerId)
+    handle.stop()
+    router.push(`?room=${request.gameRoomId}`)
+  }
+}
+```
+
+The requester stays in their room and keeps searching — additional players can join via the share link or the matchmaker.
+
+---
+
+### Vue integration example (Pictionary pattern)
+
+```typescript
+// In a Vue component
+const lobbyHandle = ref<LobbyHandle | null>(null)
+const pendingRequests = ref<Array<{ request: MatchRequest; fromPeerId: string }>>([])
+
+const startSearching = (): void => {
+  if (!p2pIsSupported() || lobbyHandle.value) return
+
+  const handle = p2pLobbyJoin('pictionary-matchmaker', undefined, {
+    onPeerJoin: (peerId) => handle.sendRequest(peerId, props.roomId),
+    onPeerLeave: (peerId) => {
+      pendingRequests.value = pendingRequests.value.filter((r) => r.fromPeerId !== peerId)
+    },
+    onRequest: (request, fromPeerId) => {
+      pendingRequests.value = [...pendingRequests.value, { request, fromPeerId }]
+    },
+    onAccepted: () => {
+      /* peer is coming to our room — keep searching */
+    },
+    onIgnored: () => {},
+    onPeerName: (peerId, name) => {
+      peerNames.value[peerId] = name
+    }
+  })
+
+  handle.getPeerIds().forEach((peerId) => handle.sendRequest(peerId, props.roomId))
+  handle.setName(props.playerName)
+  lobbyHandle.value = handle
+}
+
+const acceptRequest = (entry: { request: MatchRequest; fromPeerId: string }): void => {
+  lobbyHandle.value?.acceptRequest(entry.request, entry.fromPeerId)
+  lobbyHandle.value?.stop()
+  lobbyHandle.value = null
+  router.push(`?room=${entry.request.gameRoomId}`)
+}
+
+onUnmounted(() => {
+  lobbyHandle.value?.stop()
+  lobbyHandle.value = null
+})
+```
+
+---
+
+## vite.config.ts
+
+Trystero must be excluded from Vite's pre-bundling — it calls `crypto.subtle` at module initialization, which fails in Node during the optimizer phase:
+
+```typescript
+// vite.config.ts
+export default defineConfig({
+  optimizeDeps: {
+    exclude: ['trystero', 'trystero/nostr']
+  }
+})
+```
+
+## Types
+
+```typescript
+interface P2PSession {
+  peerId: string // Local peer ID assigned by Trystero
+  room: Room // Underlying Trystero Room
+  destroy: () => void
+}
+
+interface P2PConfig {
+  appId?: string // Default: 'webgamekit'
+  throttleMs?: number // Position broadcast throttle, default: 30 ms
+}
+
+type MatchmakeStatus = 'searching' | 'matched'
+
+interface MatchmakeHandle {
+  session: P2PSession
+  stop: () => void
+}
+
+interface MatchRequest {
+  requestId: string
+  gameRoomId: string
+}
+
+interface LobbyHandle {
+  session: P2PSession
+  getPeerIds: () => string[]
+  setName: (name: string) => void
+  sendRequest: (targetPeerId: string, gameRoomId?: string) => MatchRequest
+  acceptRequest: (request: MatchRequest, fromPeerId: string) => void
+  ignoreRequest: (request: MatchRequest, fromPeerId: string) => void
+  stop: () => void
+}
+```

--- a/packages/multiplayer-p2p/src/index.test.ts
+++ b/packages/multiplayer-p2p/src/index.test.ts
@@ -328,3 +328,170 @@ describe('p2pMatchmake', () => {
     expect(onStatusChange).toHaveBeenLastCalledWith('searching', 0)
   })
 })
+
+// ── Lobby helpers ──────────────────────────────────────────────────────────
+// In the mock, actionCallbacks stores the *receive* side of makeAction by channel.
+// We expose two helpers to simulate incoming lobby messages.
+const fireLobbyRequest = (payload: { requestId: string; gameRoomId: string }, fromPeerId: string) =>
+  (actionCallbacks.get('lobby-req') as ((d: unknown, p: string) => void) | undefined)?.(
+    payload,
+    fromPeerId
+  )
+
+const fireLobbyResponse = (payload: { requestId: string; accepted: string }) =>
+  (actionCallbacks.get('lobby-res') as ((d: unknown, p: string) => void) | undefined)?.(
+    payload,
+    'some-peer'
+  )
+
+import { p2pLobbyJoin } from './index'
+
+describe('p2pLobbyJoin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    actionCallbacks.clear()
+    peerJoinCallbacks.length = 0
+    peerLeaveCallbacks.length = 0
+    mockGetPeers.mockReturnValue({})
+  })
+
+  it('returns a handle with session, getPeerIds, sendRequest, acceptRequest, ignoreRequest, stop', () => {
+    const handle = p2pLobbyJoin('lobby-1', undefined, {
+      onPeerJoin: vi.fn(),
+      onPeerLeave: vi.fn(),
+      onRequest: vi.fn(),
+      onAccepted: vi.fn(),
+      onIgnored: vi.fn()
+    })
+    expect(typeof handle.session).toBe('object')
+    expect(typeof handle.getPeerIds).toBe('function')
+    expect(typeof handle.sendRequest).toBe('function')
+    expect(typeof handle.acceptRequest).toBe('function')
+    expect(typeof handle.ignoreRequest).toBe('function')
+    expect(typeof handle.stop).toBe('function')
+  })
+
+  it('calls onPeerJoin when a peer joins the lobby', () => {
+    const onPeerJoin = vi.fn()
+    p2pLobbyJoin('lobby-1', undefined, {
+      onPeerJoin,
+      onPeerLeave: vi.fn(),
+      onRequest: vi.fn(),
+      onAccepted: vi.fn(),
+      onIgnored: vi.fn()
+    })
+    simulatePeerJoin('peer-a')
+    expect(onPeerJoin).toHaveBeenCalledWith('peer-a')
+  })
+
+  it('calls onPeerLeave when a peer leaves the lobby', () => {
+    const onPeerLeave = vi.fn()
+    p2pLobbyJoin('lobby-1', undefined, {
+      onPeerJoin: vi.fn(),
+      onPeerLeave,
+      onRequest: vi.fn(),
+      onAccepted: vi.fn(),
+      onIgnored: vi.fn()
+    })
+    simulatePeerLeave('peer-a')
+    expect(onPeerLeave).toHaveBeenCalledWith('peer-a')
+  })
+
+  it('calls onRequest when a match request arrives', () => {
+    const onRequest = vi.fn()
+    p2pLobbyJoin('lobby-1', undefined, {
+      onPeerJoin: vi.fn(),
+      onPeerLeave: vi.fn(),
+      onRequest,
+      onAccepted: vi.fn(),
+      onIgnored: vi.fn()
+    })
+    fireLobbyRequest({ requestId: 'req-1', gameRoomId: 'room-abc' }, 'peer-b')
+    expect(onRequest).toHaveBeenCalledWith({ requestId: 'req-1', gameRoomId: 'room-abc' }, 'peer-b')
+  })
+
+  it('calls onAccepted with requestId when acceptance response arrives', () => {
+    const onAccepted = vi.fn()
+    p2pLobbyJoin('lobby-1', undefined, {
+      onPeerJoin: vi.fn(),
+      onPeerLeave: vi.fn(),
+      onRequest: vi.fn(),
+      onAccepted,
+      onIgnored: vi.fn()
+    })
+    fireLobbyResponse({ requestId: 'req-1', accepted: 'true' })
+    expect(onAccepted).toHaveBeenCalledWith('req-1')
+  })
+
+  it('calls onIgnored with requestId when ignore response arrives', () => {
+    const onIgnored = vi.fn()
+    p2pLobbyJoin('lobby-1', undefined, {
+      onPeerJoin: vi.fn(),
+      onPeerLeave: vi.fn(),
+      onRequest: vi.fn(),
+      onAccepted: vi.fn(),
+      onIgnored
+    })
+    fireLobbyResponse({ requestId: 'req-2', accepted: 'false' })
+    expect(onIgnored).toHaveBeenCalledWith('req-2')
+  })
+
+  it('sendRequest sends payload to target peer and returns a MatchRequest', () => {
+    const handle = p2pLobbyJoin('lobby-1', undefined, {
+      onPeerJoin: vi.fn(),
+      onPeerLeave: vi.fn(),
+      onRequest: vi.fn(),
+      onAccepted: vi.fn(),
+      onIgnored: vi.fn()
+    })
+    const request = handle.sendRequest('peer-b')
+    expect(request).toHaveProperty('requestId')
+    expect(request).toHaveProperty('gameRoomId')
+    expect(mockSend).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: request.requestId, gameRoomId: request.gameRoomId }),
+      'peer-b'
+    )
+  })
+
+  it('acceptRequest sends accepted=true response to the requester', () => {
+    const handle = p2pLobbyJoin('lobby-1', undefined, {
+      onPeerJoin: vi.fn(),
+      onPeerLeave: vi.fn(),
+      onRequest: vi.fn(),
+      onAccepted: vi.fn(),
+      onIgnored: vi.fn()
+    })
+    handle.acceptRequest({ requestId: 'req-1', gameRoomId: 'room-x' }, 'peer-b')
+    expect(mockSend).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: 'req-1', accepted: 'true' }),
+      'peer-b'
+    )
+  })
+
+  it('ignoreRequest sends accepted=false response to the requester', () => {
+    const handle = p2pLobbyJoin('lobby-1', undefined, {
+      onPeerJoin: vi.fn(),
+      onPeerLeave: vi.fn(),
+      onRequest: vi.fn(),
+      onAccepted: vi.fn(),
+      onIgnored: vi.fn()
+    })
+    handle.ignoreRequest({ requestId: 'req-2', gameRoomId: 'room-y' }, 'peer-c')
+    expect(mockSend).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: 'req-2', accepted: 'false' }),
+      'peer-c'
+    )
+  })
+
+  it('stop() leaves the room', () => {
+    const handle = p2pLobbyJoin('lobby-1', undefined, {
+      onPeerJoin: vi.fn(),
+      onPeerLeave: vi.fn(),
+      onRequest: vi.fn(),
+      onAccepted: vi.fn(),
+      onIgnored: vi.fn()
+    })
+    handle.stop()
+    expect(mockLeave).toHaveBeenCalled()
+  })
+})

--- a/packages/multiplayer-p2p/src/index.test.ts
+++ b/packages/multiplayer-p2p/src/index.test.ts
@@ -45,7 +45,8 @@ import {
   p2pSendData,
   p2pOnData,
   p2pOnPeerJoin,
-  p2pOnPeerLeave
+  p2pOnPeerLeave,
+  p2pMatchmake
 } from './index'
 
 describe('p2pJoin', () => {
@@ -253,5 +254,77 @@ describe('p2pOnData', () => {
     const session = p2pJoin('room-1')
     const unsubscribe = p2pOnData(session, 'game:event', vi.fn())
     expect(typeof unsubscribe).toBe('function')
+  })
+})
+
+describe('p2pMatchmake', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    actionCallbacks.clear()
+    peerJoinCallbacks.length = 0
+    peerLeaveCallbacks.length = 0
+    mockGetPeers.mockReturnValue({})
+  })
+
+  it('calls onStatusChange with searching immediately when no peers present', () => {
+    const onStatusChange = vi.fn()
+    p2pMatchmake('room-1', undefined, onStatusChange)
+    expect(onStatusChange).toHaveBeenCalledWith('searching', 0)
+  })
+
+  it('calls onStatusChange with matched immediately when peers already present', () => {
+    mockGetPeers.mockReturnValue({ 'peer-existing': {} })
+    const onStatusChange = vi.fn()
+    p2pMatchmake('room-1', undefined, onStatusChange)
+    expect(onStatusChange).toHaveBeenCalledWith('matched', 1)
+  })
+
+  it.each([
+    ['peer-a', 'matched', 1],
+    ['peer-b', 'matched', 1]
+  ])('transitions to matched when peer %s joins', (peerId, expectedStatus, expectedCount) => {
+    const onStatusChange = vi.fn()
+    p2pMatchmake('room-1', undefined, onStatusChange)
+    simulatePeerJoin(peerId)
+    expect(onStatusChange).toHaveBeenLastCalledWith(expectedStatus, expectedCount)
+  })
+
+  it('reverts to searching when last peer leaves', () => {
+    const onStatusChange = vi.fn()
+    p2pMatchmake('room-1', undefined, onStatusChange)
+    simulatePeerJoin('peer-a')
+    simulatePeerLeave('peer-a')
+    expect(onStatusChange).toHaveBeenLastCalledWith('searching', 0)
+  })
+
+  it('stays matched when one of multiple peers leaves', () => {
+    const onStatusChange = vi.fn()
+    p2pMatchmake('room-1', undefined, onStatusChange)
+    simulatePeerJoin('peer-a')
+    simulatePeerJoin('peer-b')
+    simulatePeerLeave('peer-a')
+    expect(onStatusChange).toHaveBeenLastCalledWith('matched', 1)
+  })
+
+  it('returns a session with the correct peerId', () => {
+    const { session } = p2pMatchmake('room-1', undefined, vi.fn())
+    expect(session.peerId).toBe('local-peer')
+  })
+
+  it('stop() calls p2pLeave and cleans up the room', () => {
+    const { stop } = p2pMatchmake('room-1', undefined, vi.fn())
+    stop()
+    expect(mockLeave).toHaveBeenCalled()
+  })
+
+  it('tracks multiple peers correctly by ID', () => {
+    const onStatusChange = vi.fn()
+    p2pMatchmake('room-1', undefined, onStatusChange)
+    simulatePeerJoin('peer-a')
+    simulatePeerJoin('peer-b')
+    simulatePeerLeave('peer-b')
+    expect(onStatusChange).toHaveBeenLastCalledWith('matched', 1)
+    simulatePeerLeave('peer-a')
+    expect(onStatusChange).toHaveBeenLastCalledWith('searching', 0)
   })
 })

--- a/packages/multiplayer-p2p/src/index.test.ts
+++ b/packages/multiplayer-p2p/src/index.test.ts
@@ -465,6 +465,23 @@ describe('p2pLobbyJoin', () => {
     )
   })
 
+  it('sendRequest uses a custom gameRoomId when provided', () => {
+    const handle = p2pLobbyJoin('lobby-1', undefined, {
+      onPeerJoin: vi.fn(),
+      onPeerLeave: vi.fn(),
+      onRequest: vi.fn(),
+      onAccepted: vi.fn(),
+      onIgnored: vi.fn(),
+      onPeerName: vi.fn()
+    })
+    const request = handle.sendRequest('peer-b', 'my-existing-room-id')
+    expect(request.gameRoomId).toBe('my-existing-room-id')
+    expect(mockSend).toHaveBeenCalledWith(
+      expect.objectContaining({ gameRoomId: 'my-existing-room-id' }),
+      'peer-b'
+    )
+  })
+
   it('acceptRequest sends accepted=true response to the requester', () => {
     const handle = p2pLobbyJoin('lobby-1', undefined, {
       onPeerJoin: vi.fn(),

--- a/packages/multiplayer-p2p/src/index.test.ts
+++ b/packages/multiplayer-p2p/src/index.test.ts
@@ -344,6 +344,12 @@ const fireLobbyResponse = (payload: { requestId: string; accepted: string }) =>
     'some-peer'
   )
 
+const fireLobbyName = (payload: { name: string }, fromPeerId: string) =>
+  (actionCallbacks.get('lobby-name') as ((d: unknown, p: string) => void) | undefined)?.(
+    payload,
+    fromPeerId
+  )
+
 import { p2pLobbyJoin } from './index'
 
 describe('p2pLobbyJoin', () => {
@@ -355,16 +361,18 @@ describe('p2pLobbyJoin', () => {
     mockGetPeers.mockReturnValue({})
   })
 
-  it('returns a handle with session, getPeerIds, sendRequest, acceptRequest, ignoreRequest, stop', () => {
+  it('returns a handle with session, getPeerIds, setName, sendRequest, acceptRequest, ignoreRequest, stop', () => {
     const handle = p2pLobbyJoin('lobby-1', undefined, {
       onPeerJoin: vi.fn(),
       onPeerLeave: vi.fn(),
       onRequest: vi.fn(),
       onAccepted: vi.fn(),
-      onIgnored: vi.fn()
+      onIgnored: vi.fn(),
+      onPeerName: vi.fn()
     })
     expect(typeof handle.session).toBe('object')
     expect(typeof handle.getPeerIds).toBe('function')
+    expect(typeof handle.setName).toBe('function')
     expect(typeof handle.sendRequest).toBe('function')
     expect(typeof handle.acceptRequest).toBe('function')
     expect(typeof handle.ignoreRequest).toBe('function')
@@ -378,7 +386,8 @@ describe('p2pLobbyJoin', () => {
       onPeerLeave: vi.fn(),
       onRequest: vi.fn(),
       onAccepted: vi.fn(),
-      onIgnored: vi.fn()
+      onIgnored: vi.fn(),
+      onPeerName: vi.fn()
     })
     simulatePeerJoin('peer-a')
     expect(onPeerJoin).toHaveBeenCalledWith('peer-a')
@@ -391,7 +400,8 @@ describe('p2pLobbyJoin', () => {
       onPeerLeave,
       onRequest: vi.fn(),
       onAccepted: vi.fn(),
-      onIgnored: vi.fn()
+      onIgnored: vi.fn(),
+      onPeerName: vi.fn()
     })
     simulatePeerLeave('peer-a')
     expect(onPeerLeave).toHaveBeenCalledWith('peer-a')
@@ -404,7 +414,8 @@ describe('p2pLobbyJoin', () => {
       onPeerLeave: vi.fn(),
       onRequest,
       onAccepted: vi.fn(),
-      onIgnored: vi.fn()
+      onIgnored: vi.fn(),
+      onPeerName: vi.fn()
     })
     fireLobbyRequest({ requestId: 'req-1', gameRoomId: 'room-abc' }, 'peer-b')
     expect(onRequest).toHaveBeenCalledWith({ requestId: 'req-1', gameRoomId: 'room-abc' }, 'peer-b')
@@ -442,7 +453,8 @@ describe('p2pLobbyJoin', () => {
       onPeerLeave: vi.fn(),
       onRequest: vi.fn(),
       onAccepted: vi.fn(),
-      onIgnored: vi.fn()
+      onIgnored: vi.fn(),
+      onPeerName: vi.fn()
     })
     const request = handle.sendRequest('peer-b')
     expect(request).toHaveProperty('requestId')
@@ -459,7 +471,8 @@ describe('p2pLobbyJoin', () => {
       onPeerLeave: vi.fn(),
       onRequest: vi.fn(),
       onAccepted: vi.fn(),
-      onIgnored: vi.fn()
+      onIgnored: vi.fn(),
+      onPeerName: vi.fn()
     })
     handle.acceptRequest({ requestId: 'req-1', gameRoomId: 'room-x' }, 'peer-b')
     expect(mockSend).toHaveBeenCalledWith(
@@ -474,7 +487,8 @@ describe('p2pLobbyJoin', () => {
       onPeerLeave: vi.fn(),
       onRequest: vi.fn(),
       onAccepted: vi.fn(),
-      onIgnored: vi.fn()
+      onIgnored: vi.fn(),
+      onPeerName: vi.fn()
     })
     handle.ignoreRequest({ requestId: 'req-2', gameRoomId: 'room-y' }, 'peer-c')
     expect(mockSend).toHaveBeenCalledWith(
@@ -489,9 +503,65 @@ describe('p2pLobbyJoin', () => {
       onPeerLeave: vi.fn(),
       onRequest: vi.fn(),
       onAccepted: vi.fn(),
-      onIgnored: vi.fn()
+      onIgnored: vi.fn(),
+      onPeerName: vi.fn()
     })
     handle.stop()
     expect(mockLeave).toHaveBeenCalled()
+  })
+
+  it('setName() broadcasts name to all peers', () => {
+    const handle = p2pLobbyJoin('lobby-1', undefined, {
+      onPeerJoin: vi.fn(),
+      onPeerLeave: vi.fn(),
+      onRequest: vi.fn(),
+      onAccepted: vi.fn(),
+      onIgnored: vi.fn(),
+      onPeerName: vi.fn()
+    })
+    handle.setName('Alice')
+    expect(mockSend).toHaveBeenCalledWith({ name: 'Alice' })
+  })
+
+  it('onPeerName is called when a peer broadcasts their name', () => {
+    const onPeerName = vi.fn()
+    p2pLobbyJoin('lobby-1', undefined, {
+      onPeerJoin: vi.fn(),
+      onPeerLeave: vi.fn(),
+      onRequest: vi.fn(),
+      onAccepted: vi.fn(),
+      onIgnored: vi.fn(),
+      onPeerName
+    })
+    fireLobbyName({ name: 'Bob' }, 'peer-b')
+    expect(onPeerName).toHaveBeenCalledWith('peer-b', 'Bob')
+  })
+
+  it('auto-sends name to a peer that joins after setName was called', () => {
+    const handle = p2pLobbyJoin('lobby-1', undefined, {
+      onPeerJoin: vi.fn(),
+      onPeerLeave: vi.fn(),
+      onRequest: vi.fn(),
+      onAccepted: vi.fn(),
+      onIgnored: vi.fn(),
+      onPeerName: vi.fn()
+    })
+    handle.setName('Alice')
+    vi.clearAllMocks()
+    simulatePeerJoin('peer-late')
+    expect(mockSend).toHaveBeenCalledWith({ name: 'Alice' }, 'peer-late')
+  })
+
+  it('does not send name on peer join when no name has been set', () => {
+    p2pLobbyJoin('lobby-1', undefined, {
+      onPeerJoin: vi.fn(),
+      onPeerLeave: vi.fn(),
+      onRequest: vi.fn(),
+      onAccepted: vi.fn(),
+      onIgnored: vi.fn(),
+      onPeerName: vi.fn()
+    })
+    simulatePeerJoin('peer-a')
+    expect(mockSend).not.toHaveBeenCalledWith(expect.objectContaining({ name: expect.any(String) }))
   })
 })

--- a/packages/multiplayer-p2p/src/index.ts
+++ b/packages/multiplayer-p2p/src/index.ts
@@ -18,3 +18,5 @@ export { p2pSendPosition, p2pOnPlayers, p2pSendAction, p2pOnAction } from './pla
 export { p2pSendData, p2pOnData } from './data'
 export { p2pMatchmake } from './matchmaker'
 export type { MatchmakeStatus, MatchmakeHandle } from './matchmaker'
+export { p2pLobbyJoin } from './lobby'
+export type { MatchRequest, LobbyCallbacks, LobbyHandle } from './lobby'

--- a/packages/multiplayer-p2p/src/index.ts
+++ b/packages/multiplayer-p2p/src/index.ts
@@ -16,3 +16,5 @@ export {
 } from './room'
 export { p2pSendPosition, p2pOnPlayers, p2pSendAction, p2pOnAction } from './players'
 export { p2pSendData, p2pOnData } from './data'
+export { p2pMatchmake } from './matchmaker'
+export type { MatchmakeStatus, MatchmakeHandle } from './matchmaker'

--- a/packages/multiplayer-p2p/src/lobby.ts
+++ b/packages/multiplayer-p2p/src/lobby.ts
@@ -35,8 +35,11 @@ export interface LobbyHandle {
   getPeerIds: () => string[]
   /** Broadcast a display name to all current peers and auto-send it to future joiners */
   setName: (name: string) => void
-  /** Send a match request to a specific peer — returns the request for tracking */
-  sendRequest: (targetPeerId: string) => MatchRequest
+  /**
+   * Send a match request to a specific peer — returns the request for tracking.
+   * Pass `gameRoomId` to advertise the caller's existing room; omit to auto-generate one.
+   */
+  sendRequest: (targetPeerId: string, gameRoomId?: string) => MatchRequest
   /** Accept an incoming match request */
   acceptRequest: (request: MatchRequest, fromPeerId: string) => void
   /** Ignore an incoming match request */
@@ -103,12 +106,12 @@ export const p2pLobbyJoin = (
       localName = name
       sendName({ name })
     },
-    sendRequest: (targetPeerId: string): MatchRequest => {
+    sendRequest: (targetPeerId: string, gameRoomId?: string): MatchRequest => {
       const requestId = `${session.peerId}-${Date.now()}`
-      const gameRoomId = `${lobbyRoomId}-game-${requestId}`
-      const payload: RequestPayload = { requestId, gameRoomId }
+      const resolvedGameRoomId = gameRoomId ?? `${lobbyRoomId}-game-${requestId}`
+      const payload: RequestPayload = { requestId, gameRoomId: resolvedGameRoomId }
       sendRequest(payload, targetPeerId)
-      return { requestId, gameRoomId }
+      return { requestId, gameRoomId: resolvedGameRoomId }
     },
     acceptRequest: (request: MatchRequest, fromPeerId: string): void => {
       const payload: ResponsePayload = { requestId: request.requestId, accepted: 'true' }

--- a/packages/multiplayer-p2p/src/lobby.ts
+++ b/packages/multiplayer-p2p/src/lobby.ts
@@ -3,6 +3,7 @@ import type { P2PConfig, P2PSession } from './types'
 
 const REQUEST_CHANNEL = 'lobby-req'
 const RESPONSE_CHANNEL = 'lobby-res'
+const NAME_CHANNEL = 'lobby-name'
 
 export interface MatchRequest {
   requestId: string
@@ -11,6 +12,7 @@ export interface MatchRequest {
 
 type RequestPayload = { requestId: string; gameRoomId: string } & Record<string, string>
 type ResponsePayload = { requestId: string; accepted: string } & Record<string, string>
+type NamePayload = { name: string } & Record<string, string>
 
 export interface LobbyCallbacks {
   /** A new peer appeared in the lobby */
@@ -23,12 +25,16 @@ export interface LobbyCallbacks {
   onAccepted: (requestId: string) => void
   /** The peer we requested ignored the match */
   onIgnored: (requestId: string) => void
+  /** A peer broadcast their display name */
+  onPeerName: (peerId: string, name: string) => void
 }
 
 export interface LobbyHandle {
   session: P2PSession
   /** IDs of all peers currently in the lobby */
   getPeerIds: () => string[]
+  /** Broadcast a display name to all current peers and auto-send it to future joiners */
+  setName: (name: string) => void
   /** Send a match request to a specific peer — returns the request for tracking */
   sendRequest: (targetPeerId: string) => MatchRequest
   /** Accept an incoming match request */
@@ -42,14 +48,14 @@ export interface LobbyHandle {
 /**
  * Join a lobby room for peer discovery and match negotiation.
  *
- * Peers in the lobby can send targeted match requests to each other.
- * The recipient can accept or ignore each request individually.
+ * Peers in the lobby can broadcast a display name, send targeted match
+ * requests to each other, and accept or ignore each request individually.
  * On acceptance, both sides receive the shared `gameRoomId` to join.
  *
  * @param lobbyRoomId - Well-known room ID all players join to discover each other
  * @param config - Optional P2P configuration
- * @param callbacks - Event handlers for peer and request lifecycle events
- * @returns A handle to send requests, respond, and leave the lobby
+ * @param callbacks - Event handlers for peer, name, and request lifecycle events
+ * @returns A handle to set a name, send requests, respond, and leave the lobby
  */
 export const p2pLobbyJoin = (
   lobbyRoomId: string,
@@ -60,8 +66,15 @@ export const p2pLobbyJoin = (
 
   const [sendRequest, onRequest] = session.room.makeAction<RequestPayload>(REQUEST_CHANNEL)
   const [sendResponse, onResponse] = session.room.makeAction<ResponsePayload>(RESPONSE_CHANNEL)
+  const [sendName, onName] = session.room.makeAction<NamePayload>(NAME_CHANNEL)
 
-  p2pOnPeerJoin(session, callbacks.onPeerJoin)
+  let localName = ''
+
+  p2pOnPeerJoin(session, (peerId) => {
+    if (localName) sendName({ name: localName }, peerId)
+    callbacks.onPeerJoin(peerId)
+  })
+
   p2pOnPeerLeave(session, callbacks.onPeerLeave)
 
   onRequest((payload: RequestPayload, fromPeerId: string) => {
@@ -79,9 +92,17 @@ export const p2pLobbyJoin = (
     }
   })
 
+  onName((payload: NamePayload, fromPeerId: string) => {
+    callbacks.onPeerName(fromPeerId, payload.name)
+  })
+
   return {
     session,
     getPeerIds: () => p2pGetPeerIds(session),
+    setName: (name: string): void => {
+      localName = name
+      sendName({ name })
+    },
     sendRequest: (targetPeerId: string): MatchRequest => {
       const requestId = `${session.peerId}-${Date.now()}`
       const gameRoomId = `${lobbyRoomId}-game-${requestId}`

--- a/packages/multiplayer-p2p/src/lobby.ts
+++ b/packages/multiplayer-p2p/src/lobby.ts
@@ -1,0 +1,102 @@
+import { p2pJoin, p2pLeave, p2pGetPeerIds, p2pOnPeerJoin, p2pOnPeerLeave } from './room'
+import type { P2PConfig, P2PSession } from './types'
+
+const REQUEST_CHANNEL = 'lobby-req'
+const RESPONSE_CHANNEL = 'lobby-res'
+
+export interface MatchRequest {
+  requestId: string
+  gameRoomId: string
+}
+
+type RequestPayload = { requestId: string; gameRoomId: string } & Record<string, string>
+type ResponsePayload = { requestId: string; accepted: string } & Record<string, string>
+
+export interface LobbyCallbacks {
+  /** A new peer appeared in the lobby */
+  onPeerJoin: (peerId: string) => void
+  /** A peer left the lobby */
+  onPeerLeave: (peerId: string) => void
+  /** Another peer sent us a match request */
+  onRequest: (request: MatchRequest, fromPeerId: string) => void
+  /** The peer we requested accepted the match */
+  onAccepted: (requestId: string) => void
+  /** The peer we requested ignored the match */
+  onIgnored: (requestId: string) => void
+}
+
+export interface LobbyHandle {
+  session: P2PSession
+  /** IDs of all peers currently in the lobby */
+  getPeerIds: () => string[]
+  /** Send a match request to a specific peer — returns the request for tracking */
+  sendRequest: (targetPeerId: string) => MatchRequest
+  /** Accept an incoming match request */
+  acceptRequest: (request: MatchRequest, fromPeerId: string) => void
+  /** Ignore an incoming match request */
+  ignoreRequest: (request: MatchRequest, fromPeerId: string) => void
+  /** Leave the lobby and clean up */
+  stop: () => void
+}
+
+/**
+ * Join a lobby room for peer discovery and match negotiation.
+ *
+ * Peers in the lobby can send targeted match requests to each other.
+ * The recipient can accept or ignore each request individually.
+ * On acceptance, both sides receive the shared `gameRoomId` to join.
+ *
+ * @param lobbyRoomId - Well-known room ID all players join to discover each other
+ * @param config - Optional P2P configuration
+ * @param callbacks - Event handlers for peer and request lifecycle events
+ * @returns A handle to send requests, respond, and leave the lobby
+ */
+export const p2pLobbyJoin = (
+  lobbyRoomId: string,
+  config: P2PConfig | undefined,
+  callbacks: LobbyCallbacks
+): LobbyHandle => {
+  const session = p2pJoin(lobbyRoomId, config)
+
+  const [sendRequest, onRequest] = session.room.makeAction<RequestPayload>(REQUEST_CHANNEL)
+  const [sendResponse, onResponse] = session.room.makeAction<ResponsePayload>(RESPONSE_CHANNEL)
+
+  p2pOnPeerJoin(session, callbacks.onPeerJoin)
+  p2pOnPeerLeave(session, callbacks.onPeerLeave)
+
+  onRequest((payload: RequestPayload, fromPeerId: string) => {
+    callbacks.onRequest(
+      { requestId: payload.requestId, gameRoomId: payload.gameRoomId },
+      fromPeerId
+    )
+  })
+
+  onResponse((payload: ResponsePayload) => {
+    if (payload.accepted === 'true') {
+      callbacks.onAccepted(payload.requestId)
+    } else {
+      callbacks.onIgnored(payload.requestId)
+    }
+  })
+
+  return {
+    session,
+    getPeerIds: () => p2pGetPeerIds(session),
+    sendRequest: (targetPeerId: string): MatchRequest => {
+      const requestId = `${session.peerId}-${Date.now()}`
+      const gameRoomId = `${lobbyRoomId}-game-${requestId}`
+      const payload: RequestPayload = { requestId, gameRoomId }
+      sendRequest(payload, targetPeerId)
+      return { requestId, gameRoomId }
+    },
+    acceptRequest: (request: MatchRequest, fromPeerId: string): void => {
+      const payload: ResponsePayload = { requestId: request.requestId, accepted: 'true' }
+      sendResponse(payload, fromPeerId)
+    },
+    ignoreRequest: (request: MatchRequest, fromPeerId: string): void => {
+      const payload: ResponsePayload = { requestId: request.requestId, accepted: 'false' }
+      sendResponse(payload, fromPeerId)
+    },
+    stop: () => p2pLeave(session)
+  }
+}

--- a/packages/multiplayer-p2p/src/matchmaker.ts
+++ b/packages/multiplayer-p2p/src/matchmaker.ts
@@ -1,0 +1,53 @@
+import { p2pJoin, p2pLeave, p2pGetPeerIds, p2pOnPeerJoin, p2pOnPeerLeave } from './room'
+import type { P2PConfig, P2PSession } from './types'
+
+export type MatchmakeStatus = 'searching' | 'matched'
+
+export interface MatchmakeHandle {
+  /** The underlying P2P session — use this to send/receive game data */
+  session: P2PSession
+  /** Leave the room and stop matchmaking */
+  stop: () => void
+}
+
+/**
+ * Join a shared room and report status changes as peers arrive or leave.
+ *
+ * - Calls `onStatusChange('searching', 0)` immediately if no peers are present.
+ * - Calls `onStatusChange('matched', n)` whenever peer count rises above zero.
+ * - Reverts to `'searching'` if all peers disconnect.
+ *
+ * @param roomId - Shared room to join (same value for all players in the session)
+ * @param config - Optional P2P configuration
+ * @param onStatusChange - Fired on initial join and on every peer join/leave
+ * @returns A handle with the active session and a `stop()` function to leave
+ */
+export const p2pMatchmake = (
+  roomId: string,
+  config: P2PConfig | undefined,
+  onStatusChange: (status: MatchmakeStatus, peerCount: number) => void
+): MatchmakeHandle => {
+  const session = p2pJoin(roomId, config)
+  const peers = new Set(p2pGetPeerIds(session))
+
+  const notifyStatus = (): void => {
+    onStatusChange(peers.size > 0 ? 'matched' : 'searching', peers.size)
+  }
+
+  p2pOnPeerJoin(session, (peerId) => {
+    peers.add(peerId)
+    notifyStatus()
+  })
+
+  p2pOnPeerLeave(session, (peerId) => {
+    peers.delete(peerId)
+    notifyStatus()
+  })
+
+  notifyStatus()
+
+  return {
+    session,
+    stop: () => p2pLeave(session)
+  }
+}

--- a/packages/threejs/src/defaults.ts
+++ b/packages/threejs/src/defaults.ts
@@ -3,7 +3,7 @@ import type { CoordinateTuple } from '@webgamekit/animation'
 export const GLOBAL_SCENE_DEFAULTS = {
   global: {
     frameRate: 60,
-    textSelection: false
+    textSelection: true
   },
   orbit: {
     disabled: false

--- a/src/assets/prevents.css
+++ b/src/assets/prevents.css
@@ -1,9 +1,5 @@
-/* iOS-specific zoom and selection prevention */
+/* iOS-specific zoom and touch prevention */
 * {
-  user-select: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   -webkit-touch-callout: none;
   -webkit-tap-highlight-color: transparent;
 }
@@ -23,7 +19,5 @@ canvas {
 html,
 body {
   touch-action: manipulation;
-  -webkit-user-select: none;
-  user-select: none;
   -webkit-touch-callout: none;
 }

--- a/src/config/viewsMeta.json
+++ b/src/config/viewsMeta.json
@@ -22,6 +22,9 @@
   },
   "Moon Two": { "description": "3D Moon surface rendering with displacement mapping." },
   "Moon View": { "description": "Detailed 3D Moon view with realistic surface shading." },
+  "Matchmaker": {
+    "description": "Browse online players and negotiate a P2P session — request, accept, or ignore individual matches."
+  },
   "Multiplayer P 2 P": {
     "description": "Peer-to-peer multiplayer demo using WebRTC data channels."
   },

--- a/src/views/Experiments/Matchmaker/Matchmaker.vue
+++ b/src/views/Experiments/Matchmaker/Matchmaker.vue
@@ -1,0 +1,358 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue'
+import {
+  p2pIsSupported,
+  p2pLobbyJoin,
+  type LobbyHandle,
+  type MatchRequest
+} from '@webgamekit/multiplayer-p2p'
+import Button from '@/components/ui/button/Button.vue'
+
+const LOBBY_ROOM_ID = 'webgamekit-lobby'
+const PEER_ID_LENGTH = 8
+
+const lobbyHandle = ref<LobbyHandle | null>(null)
+const localPeerId = ref<string>('')
+const lobbyPeers = ref<string[]>([])
+const incomingRequests = ref<Array<{ request: MatchRequest; fromPeerId: string }>>([])
+const sentRequests = ref<Map<string, { requestId: string; gameRoomId: string }>>(new Map())
+const matchedSession = ref<{ peerId: string; gameRoomId: string } | null>(null)
+const unsupported = ref(false)
+
+const abbrev = (peerId: string): string => peerId.slice(0, PEER_ID_LENGTH)
+
+const joinLobby = (): void => {
+  if (!p2pIsSupported()) {
+    unsupported.value = true
+    return
+  }
+
+  const handle = p2pLobbyJoin(LOBBY_ROOM_ID, undefined, {
+    onPeerJoin: (peerId) => {
+      if (!lobbyPeers.value.includes(peerId)) {
+        lobbyPeers.value = [...lobbyPeers.value, peerId]
+      }
+    },
+    onPeerLeave: (peerId) => {
+      lobbyPeers.value = lobbyPeers.value.filter((id) => id !== peerId)
+      incomingRequests.value = incomingRequests.value.filter((r) => r.fromPeerId !== peerId)
+      sentRequests.value.delete(peerId)
+    },
+    onRequest: (request, fromPeerId) => {
+      const alreadyPending = incomingRequests.value.some((r) => r.fromPeerId === fromPeerId)
+      if (!alreadyPending) {
+        incomingRequests.value = [...incomingRequests.value, { request, fromPeerId }]
+      }
+    },
+    onAccepted: (requestId) => {
+      const entry = [...sentRequests.value.entries()].find(([, v]) => v.requestId === requestId)
+      if (!entry) return
+      const [targetPeerId, { gameRoomId }] = entry
+      matchedSession.value = { peerId: targetPeerId, gameRoomId }
+      sentRequests.value.delete(targetPeerId)
+    },
+    onIgnored: (requestId) => {
+      const entry = [...sentRequests.value.entries()].find(([, v]) => v.requestId === requestId)
+      if (entry) sentRequests.value.delete(entry[0])
+    }
+  })
+
+  localPeerId.value = handle.session.peerId
+  lobbyPeers.value = handle.getPeerIds()
+  lobbyHandle.value = handle
+}
+
+const leaveLobby = (): void => {
+  lobbyHandle.value?.stop()
+  lobbyHandle.value = null
+  localPeerId.value = ''
+  lobbyPeers.value = []
+  incomingRequests.value = []
+  sentRequests.value = new Map()
+  matchedSession.value = null
+}
+
+const requestPlayer = (targetPeerId: string): void => {
+  if (!lobbyHandle.value || sentRequests.value.has(targetPeerId)) return
+  const request = lobbyHandle.value.sendRequest(targetPeerId)
+  sentRequests.value = new Map(sentRequests.value).set(targetPeerId, {
+    requestId: request.requestId,
+    gameRoomId: request.gameRoomId
+  })
+}
+
+const acceptRequest = (entry: { request: MatchRequest; fromPeerId: string }): void => {
+  if (!lobbyHandle.value) return
+  lobbyHandle.value.acceptRequest(entry.request, entry.fromPeerId)
+  incomingRequests.value = incomingRequests.value.filter(
+    (r) => r.request.requestId !== entry.request.requestId
+  )
+  matchedSession.value = { peerId: entry.fromPeerId, gameRoomId: entry.request.gameRoomId }
+}
+
+const ignoreRequest = (entry: { request: MatchRequest; fromPeerId: string }): void => {
+  if (!lobbyHandle.value) return
+  lobbyHandle.value.ignoreRequest(entry.request, entry.fromPeerId)
+  incomingRequests.value = incomingRequests.value.filter(
+    (r) => r.request.requestId !== entry.request.requestId
+  )
+}
+
+const dismissMatch = (): void => {
+  matchedSession.value = null
+}
+
+onMounted(() => {
+  joinLobby()
+})
+
+onUnmounted(() => {
+  leaveLobby()
+})
+</script>
+
+<template>
+  <div class="matchmaker">
+    <header class="matchmaker__header">
+      <h1 class="matchmaker__title">Matchmaker</h1>
+      <p v-if="unsupported" class="matchmaker__error">
+        P2P requires a secure context (HTTPS or localhost).
+      </p>
+      <p v-else-if="!lobbyHandle" class="matchmaker__subtitle">Connecting to lobby…</p>
+      <p v-else class="matchmaker__subtitle">
+        You are <strong>{{ abbrev(localPeerId) }}</strong> —
+        {{
+          lobbyPeers.length === 0
+            ? 'waiting for other players'
+            : `${lobbyPeers.length} player${lobbyPeers.length === 1 ? '' : 's'} online`
+        }}
+      </p>
+    </header>
+
+    <main v-if="lobbyHandle && !unsupported" class="matchmaker__main">
+      <!-- Incoming requests -->
+      <section v-if="incomingRequests.length" class="matchmaker__section">
+        <h2 class="matchmaker__section-title">Requests</h2>
+        <ul class="matchmaker__list">
+          <li
+            v-for="entry in incomingRequests"
+            :key="entry.request.requestId"
+            class="matchmaker__item matchmaker__item--request"
+          >
+            <span class="matchmaker__player-id">{{ abbrev(entry.fromPeerId) }}</span>
+            <span class="matchmaker__player-label">wants to play</span>
+            <div class="matchmaker__actions">
+              <Button size="sm" @click="acceptRequest(entry)">Accept</Button>
+              <Button size="sm" variant="outline" @click="ignoreRequest(entry)">Ignore</Button>
+            </div>
+          </li>
+        </ul>
+      </section>
+
+      <!-- Player list -->
+      <section class="matchmaker__section">
+        <h2 class="matchmaker__section-title">Online players</h2>
+        <p v-if="!lobbyPeers.length" class="matchmaker__empty">
+          No other players yet. Share this page to invite someone.
+        </p>
+        <ul v-else class="matchmaker__list">
+          <li v-for="peerId in lobbyPeers" :key="peerId" class="matchmaker__item">
+            <span class="matchmaker__player-id">{{ abbrev(peerId) }}</span>
+            <span v-if="sentRequests.has(peerId)" class="matchmaker__player-status">
+              Pending…
+            </span>
+            <Button v-else size="sm" variant="outline" @click="requestPlayer(peerId)">
+              Request
+            </Button>
+          </li>
+        </ul>
+      </section>
+
+      <Button class="matchmaker__leave-btn" variant="ghost" @click="leaveLobby">
+        Leave lobby
+      </Button>
+    </main>
+
+    <!-- Matched overlay -->
+    <div v-if="matchedSession" class="matchmaker__matched-overlay">
+      <div class="matchmaker__matched">
+        <p class="matchmaker__matched-title">Matched!</p>
+        <p class="matchmaker__matched-peer">
+          Session with <strong>{{ abbrev(matchedSession.peerId) }}</strong>
+        </p>
+        <p class="matchmaker__matched-room">Room: {{ matchedSession.gameRoomId }}</p>
+        <Button class="matchmaker__matched-close" variant="outline" @click="dismissMatch">
+          Close
+        </Button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.matchmaker {
+  position: relative;
+  min-height: 100vh;
+  padding-top: var(--nav-height);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+}
+
+.matchmaker__header {
+  width: 100%;
+  max-width: 36rem;
+  padding: var(--spacing-8) var(--spacing-4) var(--spacing-4);
+}
+
+.matchmaker__title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0 0 var(--spacing-1);
+}
+
+.matchmaker__subtitle {
+  font-size: 0.875rem;
+  color: var(--color-muted-foreground);
+  margin: 0;
+}
+
+.matchmaker__error {
+  font-size: 0.875rem;
+  color: var(--color-destructive);
+  margin: 0;
+}
+
+.matchmaker__main {
+  width: 100%;
+  max-width: 36rem;
+  padding: 0 var(--spacing-4) var(--spacing-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-6);
+}
+
+.matchmaker__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.matchmaker__section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-muted-foreground);
+  margin: 0;
+}
+
+.matchmaker__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.matchmaker__item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background-color: var(--color-card);
+}
+
+.matchmaker__item--request {
+  border-color: var(--color-primary);
+  background-color: var(--color-card);
+}
+
+.matchmaker__player-id {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.875rem;
+  font-weight: 600;
+  flex: 1;
+}
+
+.matchmaker__player-label {
+  font-size: 0.8125rem;
+  color: var(--color-muted-foreground);
+}
+
+.matchmaker__player-status {
+  font-size: 0.8125rem;
+  color: var(--color-muted-foreground);
+  font-style: italic;
+}
+
+.matchmaker__actions {
+  display: flex;
+  gap: var(--spacing-2);
+}
+
+.matchmaker__empty {
+  font-size: 0.875rem;
+  color: var(--color-muted-foreground);
+  margin: 0;
+  padding: var(--spacing-4);
+  text-align: center;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.matchmaker__leave-btn {
+  align-self: flex-start;
+}
+
+.matchmaker__matched-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, var(--overlay-opacity, 0.5));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-overlay);
+}
+
+.matchmaker__matched {
+  background-color: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-8);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-3);
+  min-width: 20rem;
+  text-align: center;
+}
+
+.matchmaker__matched-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0;
+  color: var(--color-primary);
+}
+
+.matchmaker__matched-peer {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.matchmaker__matched-room {
+  font-size: 0.75rem;
+  font-family: var(--font-mono, monospace);
+  color: var(--color-muted-foreground);
+  margin: 0;
+}
+
+.matchmaker__matched-close {
+  margin-top: var(--spacing-2);
+}
+</style>

--- a/src/views/Experiments/Matchmaker/Matchmaker.vue
+++ b/src/views/Experiments/Matchmaker/Matchmaker.vue
@@ -131,14 +131,23 @@ onUnmounted(() => {
       <p v-if="unsupported" class="matchmaker__error">
         P2P requires a secure context (HTTPS or localhost).
       </p>
-      <p v-else-if="!lobbyHandle" class="matchmaker__subtitle">Connecting to lobby…</p>
+      <p v-else-if="!lobbyHandle" class="matchmaker__subtitle matchmaker__subtitle--searching">
+        Connecting<span class="matchmaker__dots" aria-hidden="true"
+          ><span>.</span><span>.</span><span>.</span></span
+        >
+      </p>
+      <p
+        v-else-if="lobbyPeers.length === 0"
+        class="matchmaker__subtitle matchmaker__subtitle--searching"
+      >
+        You are <strong>{{ localName.trim() || localPeerId.slice(0, PEER_ID_LENGTH) }}</strong> —
+        searching<span class="matchmaker__dots" aria-hidden="true"
+          ><span>.</span><span>.</span><span>.</span></span
+        >
+      </p>
       <p v-else class="matchmaker__subtitle">
         You are <strong>{{ localName.trim() || localPeerId.slice(0, PEER_ID_LENGTH) }}</strong> —
-        {{
-          lobbyPeers.length === 0
-            ? 'waiting for other players'
-            : `${lobbyPeers.length} player${lobbyPeers.length === 1 ? '' : 's'} online`
-        }}
+        {{ lobbyPeers.length }} player{{ lobbyPeers.length === 1 ? '' : 's' }} online
       </p>
     </header>
 
@@ -244,6 +253,36 @@ onUnmounted(() => {
   font-size: 0.875rem;
   color: var(--color-muted-foreground);
   margin: 0;
+}
+
+@keyframes matchmaker-bounce {
+  0%,
+  60%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.4;
+  }
+  30% {
+    transform: translateY(-0.3em);
+    opacity: 1;
+  }
+}
+
+.matchmaker__dots {
+  display: inline-flex;
+  gap: 0.05em;
+}
+
+.matchmaker__dots span {
+  display: inline-block;
+  animation: matchmaker-bounce 1.2s ease-in-out infinite;
+}
+
+.matchmaker__dots span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.matchmaker__dots span:nth-child(3) {
+  animation-delay: 0.4s;
 }
 
 .matchmaker__error {

--- a/src/views/Experiments/Matchmaker/Matchmaker.vue
+++ b/src/views/Experiments/Matchmaker/Matchmaker.vue
@@ -7,19 +7,27 @@ import {
   type MatchRequest
 } from '@webgamekit/multiplayer-p2p'
 import Button from '@/components/ui/button/Button.vue'
+import { Input } from '@/components/ui/input'
 
 const LOBBY_ROOM_ID = 'webgamekit-lobby'
 const PEER_ID_LENGTH = 8
 
 const lobbyHandle = ref<LobbyHandle | null>(null)
 const localPeerId = ref<string>('')
+const localName = ref<string>('')
+const peerNames = ref<Map<string, string>>(new Map())
 const lobbyPeers = ref<string[]>([])
 const incomingRequests = ref<Array<{ request: MatchRequest; fromPeerId: string }>>([])
 const sentRequests = ref<Map<string, { requestId: string; gameRoomId: string }>>(new Map())
 const matchedSession = ref<{ peerId: string; gameRoomId: string } | null>(null)
 const unsupported = ref(false)
 
-const abbrev = (peerId: string): string => peerId.slice(0, PEER_ID_LENGTH)
+const displayName = (peerId: string): string =>
+  peerNames.value.get(peerId) || peerId.slice(0, PEER_ID_LENGTH)
+
+const commitName = (): void => {
+  lobbyHandle.value?.setName(localName.value.trim())
+}
 
 const joinLobby = (): void => {
   if (!p2pIsSupported()) {
@@ -54,12 +62,16 @@ const joinLobby = (): void => {
     onIgnored: (requestId) => {
       const entry = [...sentRequests.value.entries()].find(([, v]) => v.requestId === requestId)
       if (entry) sentRequests.value.delete(entry[0])
+    },
+    onPeerName: (peerId, name) => {
+      peerNames.value = new Map(peerNames.value).set(peerId, name)
     }
   })
 
   localPeerId.value = handle.session.peerId
   lobbyPeers.value = handle.getPeerIds()
   lobbyHandle.value = handle
+  if (localName.value.trim()) handle.setName(localName.value.trim())
 }
 
 const leaveLobby = (): void => {
@@ -69,6 +81,7 @@ const leaveLobby = (): void => {
   lobbyPeers.value = []
   incomingRequests.value = []
   sentRequests.value = new Map()
+  peerNames.value = new Map()
   matchedSession.value = null
 }
 
@@ -120,7 +133,7 @@ onUnmounted(() => {
       </p>
       <p v-else-if="!lobbyHandle" class="matchmaker__subtitle">Connecting to lobby…</p>
       <p v-else class="matchmaker__subtitle">
-        You are <strong>{{ abbrev(localPeerId) }}</strong> —
+        You are <strong>{{ localName.trim() || localPeerId.slice(0, PEER_ID_LENGTH) }}</strong> —
         {{
           lobbyPeers.length === 0
             ? 'waiting for other players'
@@ -130,6 +143,20 @@ onUnmounted(() => {
     </header>
 
     <main v-if="lobbyHandle && !unsupported" class="matchmaker__main">
+      <!-- Name setting -->
+      <section class="matchmaker__section">
+        <h2 class="matchmaker__section-title">Your name</h2>
+        <div class="matchmaker__name-row">
+          <Input
+            v-model="localName"
+            class="matchmaker__name-input"
+            placeholder="Enter your name…"
+            maxlength="24"
+            @keydown.enter="commitName"
+            @blur="commitName"
+          />
+        </div>
+      </section>
       <!-- Incoming requests -->
       <section v-if="incomingRequests.length" class="matchmaker__section">
         <h2 class="matchmaker__section-title">Requests</h2>
@@ -139,7 +166,7 @@ onUnmounted(() => {
             :key="entry.request.requestId"
             class="matchmaker__item matchmaker__item--request"
           >
-            <span class="matchmaker__player-id">{{ abbrev(entry.fromPeerId) }}</span>
+            <span class="matchmaker__player-id">{{ displayName(entry.fromPeerId) }}</span>
             <span class="matchmaker__player-label">wants to play</span>
             <div class="matchmaker__actions">
               <Button size="sm" @click="acceptRequest(entry)">Accept</Button>
@@ -157,7 +184,7 @@ onUnmounted(() => {
         </p>
         <ul v-else class="matchmaker__list">
           <li v-for="peerId in lobbyPeers" :key="peerId" class="matchmaker__item">
-            <span class="matchmaker__player-id">{{ abbrev(peerId) }}</span>
+            <span class="matchmaker__player-id">{{ displayName(peerId) }}</span>
             <span v-if="sentRequests.has(peerId)" class="matchmaker__player-status">
               Pending…
             </span>
@@ -178,7 +205,7 @@ onUnmounted(() => {
       <div class="matchmaker__matched">
         <p class="matchmaker__matched-title">Matched!</p>
         <p class="matchmaker__matched-peer">
-          Session with <strong>{{ abbrev(matchedSession.peerId) }}</strong>
+          Session with <strong>{{ displayName(matchedSession.peerId) }}</strong>
         </p>
         <p class="matchmaker__matched-room">Room: {{ matchedSession.gameRoomId }}</p>
         <Button class="matchmaker__matched-close" variant="outline" @click="dismissMatch">
@@ -304,6 +331,17 @@ onUnmounted(() => {
   text-align: center;
   border: 1px dashed var(--color-border);
   border-radius: var(--radius-md);
+}
+
+.matchmaker__name-row {
+  display: flex;
+  gap: var(--spacing-2);
+}
+
+.matchmaker__name-input {
+  flex: 1;
+  height: 2rem;
+  font-size: 0.875rem;
 }
 
 .matchmaker__leave-btn {

--- a/src/views/Experiments/MultiplayerP2P/MultiplayerP2P.vue
+++ b/src/views/Experiments/MultiplayerP2P/MultiplayerP2P.vue
@@ -14,27 +14,25 @@ import {
 } from '@webgamekit/animation'
 import { createControls, isMobile } from '@webgamekit/controls'
 import {
+  p2pJoin,
+  p2pLeave,
   p2pIsSupported,
-  p2pGetPeerIds,
   p2pOnPeerJoin,
   p2pOnPeerLeave,
+  p2pGetPeerIds,
   p2pSendPosition,
   p2pOnPlayers,
   p2pSendAction,
   p2pOnAction,
   p2pSendData,
   p2pOnData,
-  p2pMatchmake,
   type P2PSession,
-  type PlayerAction,
-  type MatchmakeHandle,
-  type MatchmakeStatus
+  type PlayerAction
 } from '@webgamekit/multiplayer-p2p'
 import { textureBuildCombined, textureToDataUrl } from '@webgamekit/canvas-editor'
 import TextureEditor from './TextureEditor.vue'
 import TouchControl from '@/components/TouchControl.vue'
 import ControlsLogger from '@/components/ControlsLogger.vue'
-import Button from '@/components/ui/button/Button.vue'
 import { registerViewConfig, unregisterViewConfig, createReactiveConfig } from '@/stores/viewConfig'
 import { usePanelsStore } from '@/stores/panels'
 import { useDebugSceneStore } from '@/stores/debugScene'
@@ -180,11 +178,11 @@ const refreshAllModels = (): void => {
 }
 
 const buildAndApplyTexture = async (front: string, back: string | null): Promise<void> => {
-  const textureCanvas = await textureBuildCombined(front, back)
-  combinedTextureMap.value = new THREE.CanvasTexture(textureCanvas)
+  const canvas = await textureBuildCombined(front, back)
+  combinedTextureMap.value = new THREE.CanvasTexture(canvas)
   refreshAllModels()
   if (p2pSession) {
-    p2pSendData(p2pSession, P2P_TEXTURE_CHANNEL, { dataUrl: textureToDataUrl(textureCanvas) })
+    p2pSendData(p2pSession, P2P_TEXTURE_CHANNEL, { dataUrl: textureToDataUrl(canvas) })
   }
 }
 
@@ -198,7 +196,7 @@ const setupConfig = {
   orbit: { target: new THREE.Vector3(0, 1, 0), disabled: true },
   camera: {
     position: [0, CAMERA_HEIGHT, CAMERA_DEPTH] as CoordinateTuple,
-    lookAt: [0, 0, 0] as CoordinateTuple,
+    lookAt: [0, 0, 0],
     fov: 70,
     up: new THREE.Vector3(0, 1, 0),
     near: 0.1,
@@ -284,122 +282,21 @@ const panelsStore = usePanelsStore()
 const canvas = ref<HTMLCanvasElement | null>(null)
 const isMobileDevice = isMobile()
 const peerCount = ref(0)
-const matchState = ref<'idle' | 'searching' | 'matched'>('idle')
 
-const hudLogs = computed(() => {
-  if (matchState.value === 'idle')
-    return ['', 'WASD — move', '1 wave  2 attack  3 jump', '4 talk  5 sit  6 pick  7 death']
-  if (matchState.value === 'searching')
-    return [
-      'Searching for players…',
-      '',
-      'WASD — move',
-      '1 wave  2 attack  3 jump',
-      '4 talk  5 sit  6 pick  7 death'
-    ]
-  return [
-    `Players: ${peerCount.value + 1}`,
-    '',
-    'WASD — move',
-    '1 wave  2 attack  3 jump',
-    '4 talk  5 sit  6 pick  7 death'
-  ]
-})
+const hudLogs = computed(() => [
+  `Players: ${peerCount.value + 1}`,
+  '',
+  'WASD — move',
+  '1 wave  2 attack  3 jump',
+  '4 talk  5 sit  6 pick  7 death'
+])
 
 let timelineManagerReference: ReturnType<typeof createTimelineManager> | null = null
 let localPlayerReference: ComplexModel | null = null
 let getDeltaReference: (() => number) | null = null
 let p2pSession: P2PSession | null = null
-let matchmakeHandle: MatchmakeHandle | null = null
-let addRemotePeer: ((peerId: string) => Promise<void>) | null = null
 const remoteModels = new Map<string, ComplexModel>()
 const movingPeers = new Set<string>()
-let sceneReference: THREE.Scene | null = null
-
-const cleanupRemoteModels = (): void => {
-  remoteModels.forEach((model) => sceneReference?.remove(model))
-  remoteModels.clear()
-  movingPeers.clear()
-  peerCount.value = 0
-}
-
-const startP2PSession = (session: P2PSession): void => {
-  p2pSession = session
-
-  p2pGetPeerIds(session).forEach((peerId) => addRemotePeer?.(peerId))
-
-  p2pOnPeerJoin(session, async (peerId) => {
-    await addRemotePeer?.(peerId)
-    if (combinedTextureMap.value) {
-      const textureCanvas = combinedTextureMap.value.image as HTMLCanvasElement
-      p2pSendData(session, P2P_TEXTURE_CHANNEL, { dataUrl: textureToDataUrl(textureCanvas) })
-    }
-  })
-
-  p2pOnPeerLeave(session, (peerId) => {
-    const model = remoteModels.get(peerId)
-    if (model) {
-      sceneReference?.remove(model)
-      remoteModels.delete(peerId)
-      movingPeers.delete(peerId)
-      peerCount.value = remoteModels.size
-    }
-  })
-
-  p2pOnPlayers(session, (playerState) => {
-    const model = remoteModels.get(playerState.id)
-    if (!model) return
-    const positionChanged =
-      model.position.x !== playerState.position.x || model.position.z !== playerState.position.z
-    model.position.set(playerState.position.x, playerState.position.y, playerState.position.z)
-    model.rotation.set(playerState.rotation.x, playerState.rotation.y, playerState.rotation.z)
-    if (positionChanged) {
-      movingPeers.add(playerState.id)
-    }
-  })
-
-  p2pOnAction(session, (peerId, action) => {
-    const model = remoteModels.get(peerId)
-    if (!model) return
-    playRemoteAction(model, action)
-  })
-
-  p2pOnData<{ dataUrl: string }>(session, P2P_TEXTURE_CHANNEL, (payload, peerId) => {
-    const model = remoteModels.get(peerId)
-    if (!model) return
-    const texture = new THREE.TextureLoader().load(payload.dataUrl)
-    model.traverse((child: THREE.Object3D) => {
-      const mesh = child as THREE.Mesh
-      if (!mesh.isMesh) return
-      const material = mesh.material as THREE.MeshLambertMaterial
-      material.map = texture
-      material.needsUpdate = true
-    })
-  })
-}
-
-const startSearching = (): void => {
-  if (!p2pIsSupported() || matchmakeHandle) return
-  let sessionStarted = false
-
-  matchmakeHandle = p2pMatchmake(ROOM_ID, undefined, (status: MatchmakeStatus, count: number) => {
-    matchState.value = status
-    peerCount.value = count
-    if (status === 'matched' && !sessionStarted && matchmakeHandle) {
-      sessionStarted = true
-      startP2PSession(matchmakeHandle.session)
-    }
-  })
-}
-
-const stopSearching = (): void => {
-  const handle = matchmakeHandle
-  matchmakeHandle = null
-  p2pSession = null
-  cleanupRemoteModels()
-  matchState.value = 'idle'
-  handle?.stop()
-}
 
 const handleBlockingAction = (actionName: string): void => {
   if (!timelineManagerReference || !localPlayerReference || !getDeltaReference) return
@@ -435,11 +332,9 @@ const init = async (): Promise<void> => {
     canvas: canvas.value
   })
 
-  sceneReference = scene
-
   const { orbit } = await setup({
     config: setupConfig,
-    defineSetup: async () => {
+    defineSetup: async ({ ground }) => {
       getDeltaReference = getDelta
       const movementDirection = new THREE.Vector3()
       const broadcastPosition = { x: 0, y: 0, z: 0 }
@@ -457,15 +352,6 @@ const init = async (): Promise<void> => {
 
       const timelineManager = createTimelineManager()
       timelineManagerReference = timelineManager
-
-      addRemotePeer = async (peerId: string): Promise<void> => {
-        if (remoteModels.has(peerId)) return
-        const remoteModel = await getModel(scene, world, 'stickboy.glb', remoteSettings)
-        remapUVsToWorldProjection(remoteModel)
-        applyTextureToModel(remoteModel)
-        remoteModels.set(peerId, remoteModel)
-        peerCount.value = remoteModels.size
-      }
 
       timelineManager.addAction({
         frequency: 2,
@@ -543,6 +429,72 @@ const init = async (): Promise<void> => {
       })
 
       animate({ beforeTimeline: () => {}, timeline: timelineManager })
+
+      if (!p2pIsSupported()) return
+
+      const session = p2pJoin(ROOM_ID)
+      p2pSession = session
+
+      const addRemotePeer = async (peerId: string): Promise<void> => {
+        if (remoteModels.has(peerId)) return
+        const remoteModel = await getModel(scene, world, 'stickboy.glb', remoteSettings)
+        remapUVsToWorldProjection(remoteModel)
+        applyTextureToModel(remoteModel)
+        remoteModels.set(peerId, remoteModel)
+        peerCount.value = remoteModels.size
+      }
+
+      p2pGetPeerIds(session).forEach((peerId) => {
+        addRemotePeer(peerId)
+      })
+
+      p2pOnPeerJoin(session, (peerId) => {
+        addRemotePeer(peerId)
+        if (combinedTextureMap.value) {
+          const canvas = combinedTextureMap.value.image as HTMLCanvasElement
+          p2pSendData(session, P2P_TEXTURE_CHANNEL, { dataUrl: textureToDataUrl(canvas) })
+        }
+      })
+
+      p2pOnPeerLeave(session, (peerId) => {
+        const model = remoteModels.get(peerId)
+        if (model) {
+          scene.remove(model)
+          remoteModels.delete(peerId)
+          peerCount.value = remoteModels.size
+        }
+      })
+
+      p2pOnPlayers(session, (playerState) => {
+        const model = remoteModels.get(playerState.id)
+        if (!model) return
+        const positionChanged =
+          model.position.x !== playerState.position.x || model.position.z !== playerState.position.z
+        model.position.set(playerState.position.x, playerState.position.y, playerState.position.z)
+        model.rotation.set(playerState.rotation.x, playerState.rotation.y, playerState.rotation.z)
+        if (positionChanged) {
+          movingPeers.add(playerState.id)
+        }
+      })
+
+      p2pOnAction(session, (peerId, action) => {
+        const model = remoteModels.get(peerId)
+        if (!model) return
+        playRemoteAction(model, action)
+      })
+
+      p2pOnData<{ dataUrl: string }>(session, P2P_TEXTURE_CHANNEL, (payload, peerId) => {
+        const model = remoteModels.get(peerId)
+        if (!model) return
+        const texture = new THREE.TextureLoader().load(payload.dataUrl)
+        model.traverse((child: THREE.Object3D) => {
+          const mesh = child as THREE.Mesh
+          if (!mesh.isMesh) return
+          const material = mesh.material as THREE.MeshLambertMaterial
+          material.map = texture
+          material.needsUpdate = true
+        })
+      })
     }
   })
 }
@@ -570,33 +522,16 @@ onUnmounted(() => {
   clearAllElementProperties()
   unregisterViewConfig(route.name as string)
   destroyControls()
-  stopSearching()
+  if (p2pSession) {
+    p2pLeave(p2pSession)
+    p2pSession = null
+  }
 })
 </script>
 
 <template>
   <canvas ref="canvas"></canvas>
   <ControlsLogger :logs="hudLogs" />
-
-  <div class="multiplayer-p2p__matchmaker">
-    <template v-if="matchState === 'idle'">
-      <p class="multiplayer-p2p__matchmaker-hint">Find other players to join a session</p>
-      <Button class="multiplayer-p2p__matchmaker-btn" @click="startSearching">Find Match</Button>
-    </template>
-
-    <template v-else-if="matchState === 'searching'">
-      <p class="multiplayer-p2p__matchmaker-status">Searching for players…</p>
-      <Button class="multiplayer-p2p__matchmaker-btn" variant="outline" @click="stopSearching">
-        Cancel
-      </Button>
-    </template>
-
-    <template v-else>
-      <Button class="multiplayer-p2p__matchmaker-btn" variant="outline" @click="stopSearching">
-        Leave
-      </Button>
-    </template>
-  </div>
 
   <Teleport defer to="#config-panel-extra">
     <TextureEditor
@@ -645,30 +580,5 @@ canvas {
   display: block;
   width: 100%;
   height: 100vh;
-}
-
-.multiplayer-p2p__matchmaker {
-  position: fixed;
-  bottom: var(--spacing-6, 1.5rem);
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--spacing-2, 0.5rem);
-  z-index: var(--z-overlay);
-  pointer-events: auto;
-}
-
-.multiplayer-p2p__matchmaker-hint,
-.multiplayer-p2p__matchmaker-status {
-  color: var(--color-foreground);
-  font-size: 0.875rem;
-  text-shadow: 0 1px 3px rgba(0, 0, 0, var(--shadow-opacity, 0.6));
-  margin: 0;
-}
-
-.multiplayer-p2p__matchmaker-btn {
-  min-width: 9rem;
 }
 </style>

--- a/src/views/Experiments/MultiplayerP2P/MultiplayerP2P.vue
+++ b/src/views/Experiments/MultiplayerP2P/MultiplayerP2P.vue
@@ -14,25 +14,27 @@ import {
 } from '@webgamekit/animation'
 import { createControls, isMobile } from '@webgamekit/controls'
 import {
-  p2pJoin,
-  p2pLeave,
   p2pIsSupported,
+  p2pGetPeerIds,
   p2pOnPeerJoin,
   p2pOnPeerLeave,
-  p2pGetPeerIds,
   p2pSendPosition,
   p2pOnPlayers,
   p2pSendAction,
   p2pOnAction,
   p2pSendData,
   p2pOnData,
+  p2pMatchmake,
   type P2PSession,
-  type PlayerAction
+  type PlayerAction,
+  type MatchmakeHandle,
+  type MatchmakeStatus
 } from '@webgamekit/multiplayer-p2p'
 import { textureBuildCombined, textureToDataUrl } from '@webgamekit/canvas-editor'
 import TextureEditor from './TextureEditor.vue'
 import TouchControl from '@/components/TouchControl.vue'
 import ControlsLogger from '@/components/ControlsLogger.vue'
+import Button from '@/components/ui/button/Button.vue'
 import { registerViewConfig, unregisterViewConfig, createReactiveConfig } from '@/stores/viewConfig'
 import { usePanelsStore } from '@/stores/panels'
 import { useDebugSceneStore } from '@/stores/debugScene'
@@ -178,11 +180,11 @@ const refreshAllModels = (): void => {
 }
 
 const buildAndApplyTexture = async (front: string, back: string | null): Promise<void> => {
-  const canvas = await textureBuildCombined(front, back)
-  combinedTextureMap.value = new THREE.CanvasTexture(canvas)
+  const textureCanvas = await textureBuildCombined(front, back)
+  combinedTextureMap.value = new THREE.CanvasTexture(textureCanvas)
   refreshAllModels()
   if (p2pSession) {
-    p2pSendData(p2pSession, P2P_TEXTURE_CHANNEL, { dataUrl: textureToDataUrl(canvas) })
+    p2pSendData(p2pSession, P2P_TEXTURE_CHANNEL, { dataUrl: textureToDataUrl(textureCanvas) })
   }
 }
 
@@ -196,7 +198,7 @@ const setupConfig = {
   orbit: { target: new THREE.Vector3(0, 1, 0), disabled: true },
   camera: {
     position: [0, CAMERA_HEIGHT, CAMERA_DEPTH] as CoordinateTuple,
-    lookAt: [0, 0, 0],
+    lookAt: [0, 0, 0] as CoordinateTuple,
     fov: 70,
     up: new THREE.Vector3(0, 1, 0),
     near: 0.1,
@@ -282,21 +284,122 @@ const panelsStore = usePanelsStore()
 const canvas = ref<HTMLCanvasElement | null>(null)
 const isMobileDevice = isMobile()
 const peerCount = ref(0)
+const matchState = ref<'idle' | 'searching' | 'matched'>('idle')
 
-const hudLogs = computed(() => [
-  `Players: ${peerCount.value + 1}`,
-  '',
-  'WASD — move',
-  '1 wave  2 attack  3 jump',
-  '4 talk  5 sit  6 pick  7 death'
-])
+const hudLogs = computed(() => {
+  if (matchState.value === 'idle')
+    return ['', 'WASD — move', '1 wave  2 attack  3 jump', '4 talk  5 sit  6 pick  7 death']
+  if (matchState.value === 'searching')
+    return [
+      'Searching for players…',
+      '',
+      'WASD — move',
+      '1 wave  2 attack  3 jump',
+      '4 talk  5 sit  6 pick  7 death'
+    ]
+  return [
+    `Players: ${peerCount.value + 1}`,
+    '',
+    'WASD — move',
+    '1 wave  2 attack  3 jump',
+    '4 talk  5 sit  6 pick  7 death'
+  ]
+})
 
 let timelineManagerReference: ReturnType<typeof createTimelineManager> | null = null
 let localPlayerReference: ComplexModel | null = null
 let getDeltaReference: (() => number) | null = null
 let p2pSession: P2PSession | null = null
+let matchmakeHandle: MatchmakeHandle | null = null
+let addRemotePeer: ((peerId: string) => Promise<void>) | null = null
 const remoteModels = new Map<string, ComplexModel>()
 const movingPeers = new Set<string>()
+let sceneReference: THREE.Scene | null = null
+
+const cleanupRemoteModels = (): void => {
+  remoteModels.forEach((model) => sceneReference?.remove(model))
+  remoteModels.clear()
+  movingPeers.clear()
+  peerCount.value = 0
+}
+
+const startP2PSession = (session: P2PSession): void => {
+  p2pSession = session
+
+  p2pGetPeerIds(session).forEach((peerId) => addRemotePeer?.(peerId))
+
+  p2pOnPeerJoin(session, async (peerId) => {
+    await addRemotePeer?.(peerId)
+    if (combinedTextureMap.value) {
+      const textureCanvas = combinedTextureMap.value.image as HTMLCanvasElement
+      p2pSendData(session, P2P_TEXTURE_CHANNEL, { dataUrl: textureToDataUrl(textureCanvas) })
+    }
+  })
+
+  p2pOnPeerLeave(session, (peerId) => {
+    const model = remoteModels.get(peerId)
+    if (model) {
+      sceneReference?.remove(model)
+      remoteModels.delete(peerId)
+      movingPeers.delete(peerId)
+      peerCount.value = remoteModels.size
+    }
+  })
+
+  p2pOnPlayers(session, (playerState) => {
+    const model = remoteModels.get(playerState.id)
+    if (!model) return
+    const positionChanged =
+      model.position.x !== playerState.position.x || model.position.z !== playerState.position.z
+    model.position.set(playerState.position.x, playerState.position.y, playerState.position.z)
+    model.rotation.set(playerState.rotation.x, playerState.rotation.y, playerState.rotation.z)
+    if (positionChanged) {
+      movingPeers.add(playerState.id)
+    }
+  })
+
+  p2pOnAction(session, (peerId, action) => {
+    const model = remoteModels.get(peerId)
+    if (!model) return
+    playRemoteAction(model, action)
+  })
+
+  p2pOnData<{ dataUrl: string }>(session, P2P_TEXTURE_CHANNEL, (payload, peerId) => {
+    const model = remoteModels.get(peerId)
+    if (!model) return
+    const texture = new THREE.TextureLoader().load(payload.dataUrl)
+    model.traverse((child: THREE.Object3D) => {
+      const mesh = child as THREE.Mesh
+      if (!mesh.isMesh) return
+      const material = mesh.material as THREE.MeshLambertMaterial
+      material.map = texture
+      material.needsUpdate = true
+    })
+  })
+}
+
+const startSearching = (): void => {
+  if (!p2pIsSupported() || matchmakeHandle) return
+  let sessionStarted = false
+
+  matchmakeHandle = p2pMatchmake(ROOM_ID, undefined, (status: MatchmakeStatus, count: number) => {
+    matchState.value = status
+    peerCount.value = count
+    if (status === 'matched' && !sessionStarted && matchmakeHandle) {
+      sessionStarted = true
+      startP2PSession(matchmakeHandle.session)
+    }
+  })
+}
+
+const stopSearching = (): void => {
+  const handle = matchmakeHandle
+  matchmakeHandle = null
+  p2pSession = null
+  cleanupRemoteModels()
+  matchState.value = 'idle'
+  handle?.stop()
+}
 
 const handleBlockingAction = (actionName: string): void => {
   if (!timelineManagerReference || !localPlayerReference || !getDeltaReference) return
@@ -332,9 +435,11 @@ const init = async (): Promise<void> => {
     canvas: canvas.value
   })
 
+  sceneReference = scene
+
   const { orbit } = await setup({
     config: setupConfig,
-    defineSetup: async ({ ground }) => {
+    defineSetup: async () => {
       getDeltaReference = getDelta
       const movementDirection = new THREE.Vector3()
       const broadcastPosition = { x: 0, y: 0, z: 0 }
@@ -352,6 +457,15 @@ const init = async (): Promise<void> => {
 
       const timelineManager = createTimelineManager()
       timelineManagerReference = timelineManager
+
+      addRemotePeer = async (peerId: string): Promise<void> => {
+        if (remoteModels.has(peerId)) return
+        const remoteModel = await getModel(scene, world, 'stickboy.glb', remoteSettings)
+        remapUVsToWorldProjection(remoteModel)
+        applyTextureToModel(remoteModel)
+        remoteModels.set(peerId, remoteModel)
+        peerCount.value = remoteModels.size
+      }
 
       timelineManager.addAction({
         frequency: 2,
@@ -429,72 +543,6 @@ const init = async (): Promise<void> => {
       })
 
       animate({ beforeTimeline: () => {}, timeline: timelineManager })
-
-      if (!p2pIsSupported()) return
-
-      const session = p2pJoin(ROOM_ID)
-      p2pSession = session
-
-      const addRemotePeer = async (peerId: string): Promise<void> => {
-        if (remoteModels.has(peerId)) return
-        const remoteModel = await getModel(scene, world, 'stickboy.glb', remoteSettings)
-        remapUVsToWorldProjection(remoteModel)
-        applyTextureToModel(remoteModel)
-        remoteModels.set(peerId, remoteModel)
-        peerCount.value = remoteModels.size
-      }
-
-      p2pGetPeerIds(session).forEach((peerId) => {
-        addRemotePeer(peerId)
-      })
-
-      p2pOnPeerJoin(session, (peerId) => {
-        addRemotePeer(peerId)
-        if (combinedTextureMap.value) {
-          const canvas = combinedTextureMap.value.image as HTMLCanvasElement
-          p2pSendData(session, P2P_TEXTURE_CHANNEL, { dataUrl: textureToDataUrl(canvas) })
-        }
-      })
-
-      p2pOnPeerLeave(session, (peerId) => {
-        const model = remoteModels.get(peerId)
-        if (model) {
-          scene.remove(model)
-          remoteModels.delete(peerId)
-          peerCount.value = remoteModels.size
-        }
-      })
-
-      p2pOnPlayers(session, (playerState) => {
-        const model = remoteModels.get(playerState.id)
-        if (!model) return
-        const positionChanged =
-          model.position.x !== playerState.position.x || model.position.z !== playerState.position.z
-        model.position.set(playerState.position.x, playerState.position.y, playerState.position.z)
-        model.rotation.set(playerState.rotation.x, playerState.rotation.y, playerState.rotation.z)
-        if (positionChanged) {
-          movingPeers.add(playerState.id)
-        }
-      })
-
-      p2pOnAction(session, (peerId, action) => {
-        const model = remoteModels.get(peerId)
-        if (!model) return
-        playRemoteAction(model, action)
-      })
-
-      p2pOnData<{ dataUrl: string }>(session, P2P_TEXTURE_CHANNEL, (payload, peerId) => {
-        const model = remoteModels.get(peerId)
-        if (!model) return
-        const texture = new THREE.TextureLoader().load(payload.dataUrl)
-        model.traverse((child: THREE.Object3D) => {
-          const mesh = child as THREE.Mesh
-          if (!mesh.isMesh) return
-          const material = mesh.material as THREE.MeshLambertMaterial
-          material.map = texture
-          material.needsUpdate = true
-        })
-      })
     }
   })
 }
@@ -522,16 +570,33 @@ onUnmounted(() => {
   clearAllElementProperties()
   unregisterViewConfig(route.name as string)
   destroyControls()
-  if (p2pSession) {
-    p2pLeave(p2pSession)
-    p2pSession = null
-  }
+  stopSearching()
 })
 </script>
 
 <template>
   <canvas ref="canvas"></canvas>
   <ControlsLogger :logs="hudLogs" />
+
+  <div class="multiplayer-p2p__matchmaker">
+    <template v-if="matchState === 'idle'">
+      <p class="multiplayer-p2p__matchmaker-hint">Find other players to join a session</p>
+      <Button class="multiplayer-p2p__matchmaker-btn" @click="startSearching">Find Match</Button>
+    </template>
+
+    <template v-else-if="matchState === 'searching'">
+      <p class="multiplayer-p2p__matchmaker-status">Searching for players…</p>
+      <Button class="multiplayer-p2p__matchmaker-btn" variant="outline" @click="stopSearching">
+        Cancel
+      </Button>
+    </template>
+
+    <template v-else>
+      <Button class="multiplayer-p2p__matchmaker-btn" variant="outline" @click="stopSearching">
+        Leave
+      </Button>
+    </template>
+  </div>
 
   <Teleport defer to="#config-panel-extra">
     <TextureEditor
@@ -580,5 +645,30 @@ canvas {
   display: block;
   width: 100%;
   height: 100vh;
+}
+
+.multiplayer-p2p__matchmaker {
+  position: fixed;
+  bottom: var(--spacing-6, 1.5rem);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-2, 0.5rem);
+  z-index: var(--z-overlay);
+  pointer-events: auto;
+}
+
+.multiplayer-p2p__matchmaker-hint,
+.multiplayer-p2p__matchmaker-status {
+  color: var(--color-foreground);
+  font-size: 0.875rem;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, var(--shadow-opacity, 0.6));
+  margin: 0;
+}
+
+.multiplayer-p2p__matchmaker-btn {
+  min-width: 9rem;
 }
 </style>

--- a/src/views/Games/Pictionary/Pictionary.vue
+++ b/src/views/Games/Pictionary/Pictionary.vue
@@ -100,6 +100,12 @@ const copyLink = async (): Promise<void> => {
   await navigator.clipboard.writeText(shareableLink.value)
 }
 
+const handleMatchFound = (gameRoomId: string): void => {
+  roomId.value = gameRoomId
+  router.replace({ query: { room: gameRoomId } })
+  session.reconnect(gameRoomId)
+}
+
 const handleNameChange = (): void => {
   const trimmed = playerName.value.trim()
   if (!trimmed) return
@@ -147,6 +153,7 @@ onMounted(() => {
       @update:hint-count="hintCount = $event"
       @name-change="handleNameChange"
       @start-game="session.startRound()"
+      @match-found="handleMatchFound"
     />
 
     <PictionaryChoosing

--- a/src/views/Games/Pictionary/Pictionary.vue
+++ b/src/views/Games/Pictionary/Pictionary.vue
@@ -145,6 +145,7 @@ onMounted(() => {
       :player-color="playerColor"
       :is-host="isHost"
       :player-list="playerList"
+      :room-id="roomId"
       :round="round"
       :difficulty="difficulty"
       :total-rounds="totalRounds"

--- a/src/views/Games/Pictionary/Pictionary.vue
+++ b/src/views/Games/Pictionary/Pictionary.vue
@@ -106,6 +106,13 @@ const handleMatchFound = (gameRoomId: string): void => {
   session.reconnect(gameRoomId)
 }
 
+const handleLeaveRoom = (): void => {
+  const freshId = crypto.randomUUID()
+  roomId.value = freshId
+  router.replace({ query: { room: freshId } })
+  session.reconnect(freshId)
+}
+
 const handleNameChange = (): void => {
   const trimmed = playerName.value.trim()
   if (!trimmed) return
@@ -154,6 +161,7 @@ onMounted(() => {
       @name-change="handleNameChange"
       @start-game="session.startRound()"
       @match-found="handleMatchFound"
+      @leave-room="handleLeaveRoom"
     />
 
     <PictionaryChoosing

--- a/src/views/Games/Pictionary/PictionaryCard.vue
+++ b/src/views/Games/Pictionary/PictionaryCard.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    tag?: string
+  }>(),
+  { tag: 'div' }
+)
+</script>
+
+<template>
+  <component :is="tag" class="pictionary-card">
+    <slot />
+  </component>
+</template>
+
+<style scoped>
+.pictionary-card {
+  background: #fff;
+  border: 3px solid #111;
+  border-radius: 1.25rem;
+  box-shadow: 4px 4px 0 #111;
+  box-sizing: border-box;
+  color: #111;
+}
+</style>

--- a/src/views/Games/Pictionary/PictionaryDrawing.vue
+++ b/src/views/Games/Pictionary/PictionaryDrawing.vue
@@ -63,12 +63,15 @@ defineExpose({
   justify-content: space-between;
   align-items: stretch;
   min-width: 0;
+  min-height: 0;
   max-width: 100%;
   overflow: hidden;
 }
 
 .pictionary-drawing :deep(.canvas-editor) {
-  max-height: 100%;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .pictionary-drawing :deep(.canvas-editor-canvas) {

--- a/src/views/Games/Pictionary/PictionaryHeader.vue
+++ b/src/views/Games/Pictionary/PictionaryHeader.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { POINTS_BASE, POINTS_FIRST_BONUS, POINTS_DRAWER_PER_GUESS } from './constants'
+
 defineProps<{
   roomId: string
 }>()
@@ -16,6 +18,24 @@ const emit = defineEmits<{
       <button class="pictionary-header__copy-btn" type="button" @click="emit('copyLink')">
         Copy link
       </button>
+      <details class="pictionary-header__rules">
+        <summary class="pictionary-header__rules-btn" title="How points work">?</summary>
+        <ul class="pictionary-header__rules-list">
+          <li>
+            Guessers earn up to <strong>{{ POINTS_BASE }} pts</strong> based on speed — faster
+            guesses score more
+          </li>
+          <li>
+            First correct guess gets a <strong>+{{ POINTS_FIRST_BONUS }} pts</strong> bonus
+          </li>
+          <li>
+            Drawer earns up to <strong>{{ POINTS_DRAWER_PER_GUESS }} pts</strong> per correct guess,
+            scaled by time remaining
+          </li>
+          <li>Round continues until time runs out or all players guess</li>
+          <li>Hints reveal extra letters (configurable)</li>
+        </ul>
+      </details>
     </div>
   </header>
 </template>
@@ -64,6 +84,59 @@ const emit = defineEmits<{
 .pictionary-header__copy-btn:hover {
   transform: translate(-1px, -1px);
   box-shadow: 4px 4px 0 #111;
+}
+
+.pictionary-header__rules {
+  position: relative;
+}
+
+.pictionary-header__rules-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 2px solid #111;
+  border-radius: 50%;
+  background: #fff;
+  font-size: 0.875rem;
+  font-weight: 900;
+  cursor: pointer;
+  list-style: none;
+  box-shadow: 2px 2px 0 #111;
+  transition: transform 0.1s ease;
+  user-select: none;
+  font-family: inherit;
+}
+
+.pictionary-header__rules-btn::-webkit-details-marker {
+  display: none;
+}
+
+.pictionary-header__rules-btn:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 3px 3px 0 #111;
+}
+
+.pictionary-header__rules-list {
+  position: absolute;
+  top: calc(100% + var(--spacing-2));
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  margin: 0;
+  padding: var(--spacing-3) var(--spacing-3) var(--spacing-3) var(--spacing-5);
+  background: #fff;
+  border: 2px solid #111;
+  border-radius: 0.75rem;
+  box-shadow: 3px 3px 0 #111;
+  width: 18rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  font-size: var(--font-size-sm);
+  line-height: 1.4;
+  color: #111;
 }
 
 @media (max-width: 720px) {

--- a/src/views/Games/Pictionary/PictionaryHeader.vue
+++ b/src/views/Games/Pictionary/PictionaryHeader.vue
@@ -47,6 +47,9 @@ const emit = defineEmits<{
   justify-content: space-between;
   align-items: center;
   gap: var(--spacing-2);
+  overflow: visible;
+  position: relative;
+  z-index: 10;
 }
 
 .pictionary-header__room {
@@ -123,7 +126,7 @@ const emit = defineEmits<{
   top: calc(100% + var(--spacing-2));
   left: 50%;
   transform: translateX(-50%);
-  z-index: 10;
+  z-index: 100;
   margin: 0;
   padding: var(--spacing-3) var(--spacing-3) var(--spacing-3) var(--spacing-5);
   background: #fff;

--- a/src/views/Games/Pictionary/PictionaryHeader.vue
+++ b/src/views/Games/Pictionary/PictionaryHeader.vue
@@ -102,6 +102,7 @@ const emit = defineEmits<{
   border: 2px solid #111;
   border-radius: 50%;
   background: #fff;
+  color: #111;
   font-size: 0.875rem;
   font-weight: 900;
   cursor: pointer;

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -174,9 +174,7 @@ onUnmounted(stopSearching)
         </div>
       </div>
     </div>
-    <p class="pictionary-lobby__hint">
-      Share the room link with friends. Game starts when the host clicks Start.
-    </p>
+    <p class="pictionary-lobby__hint">Game starts when the host clicks Start.</p>
 
     <div v-if="playerList.length <= 1" class="pictionary-lobby__matchmaker">
       <template v-if="!lobbyHandle">

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -4,12 +4,10 @@ import { onUnmounted, ref } from 'vue'
 import type { DictionaryDifficulty } from '@webgamekit/dictionary'
 import type { PictionaryPlayer, PictionaryRound } from '@/stores/pictionary'
 import {
-  p2pJoin,
-  p2pLeave,
-  p2pGetPeerIds,
-  p2pOnPeerJoin,
   p2pIsSupported,
-  type P2PSession
+  p2pLobbyJoin,
+  type LobbyHandle,
+  type MatchRequest
 } from '@webgamekit/multiplayer-p2p'
 import {
   PLAYER_COLORS,
@@ -22,8 +20,9 @@ import {
 } from './constants'
 
 const MATCHMAKER_ROOM = 'pictionary-matchmaker'
+const PEER_ID_LENGTH = 8
 
-defineProps<{
+const props = defineProps<{
   playerName: string
   playerColor: string
   isHost: boolean
@@ -47,45 +46,92 @@ const emit = defineEmits<{
   nameChange: []
   startGame: []
   matchFound: [roomId: string]
+  leaveRoom: []
 }>()
 
-const matchState = ref<'idle' | 'searching'>('idle')
-let matchSession: P2PSession | null = null
+const lobbyHandle = ref<LobbyHandle | null>(null)
+const pendingRequests = ref<Array<{ request: MatchRequest; fromPeerId: string }>>([])
+const peerNames = ref<Record<string, string>>({})
+// Non-reactive: requestId → targetPeerId (only needed for onAccepted lookup)
+const sentRequestPeerIds: Record<string, string> = {}
+let matchComplete = false
 
-const deriveGameRoomId = (peerA: string, peerB: string): string => [peerA, peerB].sort().join('--')
+const displayName = (peerId: string): string =>
+  peerNames.value[peerId] || peerId.slice(0, PEER_ID_LENGTH)
 
-const handlePeerFound = (session: P2PSession, remotePeerId: string): void => {
-  const gameRoomId = deriveGameRoomId(session.peerId, remotePeerId)
-  p2pLeave(session)
-  matchSession = null
-  matchState.value = 'idle'
+const gameRoomFor = (remotePeerId: string): string =>
+  [lobbyHandle.value?.session.peerId ?? '', remotePeerId].sort().join('--')
+
+const doMatch = (remotePeerId: string): void => {
+  if (matchComplete) return
+  matchComplete = true
+  const gameRoomId = gameRoomFor(remotePeerId)
+  lobbyHandle.value?.stop()
+  lobbyHandle.value = null
+  pendingRequests.value = []
   emit('matchFound', gameRoomId)
 }
 
-const startSearching = (): void => {
-  if (!p2pIsSupported()) return
-  const session = p2pJoin(MATCHMAKER_ROOM)
-  matchSession = session
-  matchState.value = 'searching'
-
-  const existing = p2pGetPeerIds(session)
-  if (existing.length > 0) {
-    handlePeerFound(session, existing[0])
-    return
-  }
-
-  p2pOnPeerJoin(session, (remotePeerId) => {
-    if (!matchSession) return
-    handlePeerFound(session, remotePeerId)
-  })
+const stopSearching = (): void => {
+  lobbyHandle.value?.stop()
+  lobbyHandle.value = null
+  pendingRequests.value = []
+  peerNames.value = {}
+  matchComplete = false
 }
 
-const stopSearching = (): void => {
-  if (matchSession) {
-    p2pLeave(matchSession)
-    matchSession = null
-  }
-  matchState.value = 'idle'
+const startSearching = (): void => {
+  if (!p2pIsSupported() || lobbyHandle.value) return
+  matchComplete = false
+
+  const handle = p2pLobbyJoin(MATCHMAKER_ROOM, undefined, {
+    onPeerJoin: (peerId) => {
+      if (matchComplete) return
+      const req = handle.sendRequest(peerId)
+      sentRequestPeerIds[req.requestId] = peerId
+    },
+    onPeerLeave: (peerId) => {
+      pendingRequests.value = pendingRequests.value.filter((r) => r.fromPeerId !== peerId)
+    },
+    onRequest: (request, fromPeerId) => {
+      if (matchComplete) return
+      if (!pendingRequests.value.some((r) => r.fromPeerId === fromPeerId)) {
+        pendingRequests.value = [...pendingRequests.value, { request, fromPeerId }]
+      }
+    },
+    onAccepted: (requestId) => {
+      const targetPeerId = sentRequestPeerIds[requestId]
+      if (targetPeerId) doMatch(targetPeerId)
+    },
+    onIgnored: (requestId) => {
+      delete sentRequestPeerIds[requestId]
+    },
+    onPeerName: (peerId, name) => {
+      peerNames.value = { ...peerNames.value, [peerId]: name }
+    }
+  })
+
+  handle.getPeerIds().forEach((peerId) => {
+    const req = handle.sendRequest(peerId)
+    sentRequestPeerIds[req.requestId] = peerId
+  })
+
+  handle.setName(props.playerName)
+  lobbyHandle.value = handle
+}
+
+const acceptRequest = (entry: { request: MatchRequest; fromPeerId: string }): void => {
+  if (!lobbyHandle.value) return
+  lobbyHandle.value.acceptRequest(entry.request, entry.fromPeerId)
+  doMatch(entry.fromPeerId)
+}
+
+const ignoreRequest = (entry: { request: MatchRequest; fromPeerId: string }): void => {
+  if (!lobbyHandle.value) return
+  lobbyHandle.value.ignoreRequest(entry.request, entry.fromPeerId)
+  pendingRequests.value = pendingRequests.value.filter(
+    (r) => r.request.requestId !== entry.request.requestId
+  )
 }
 
 const handleNameInput = (event: Event): void => {
@@ -98,7 +144,7 @@ onUnmounted(stopSearching)
 <template>
   <section class="pictionary-lobby">
     <div class="pictionary-lobby__profile">
-      <h2 class="pictionary-lobby__profile-title">👋 Your name</h2>
+      <h2 class="pictionary-lobby__profile-title">Your name</h2>
       <div class="pictionary-lobby__profile-row">
         <label class="pictionary-lobby__field">
           Name
@@ -133,22 +179,76 @@ onUnmounted(stopSearching)
     </p>
 
     <div v-if="playerList.length <= 1" class="pictionary-lobby__matchmaker">
-      <p class="pictionary-lobby__matchmaker-label">No one else here yet.</p>
-      <template v-if="matchState === 'idle'">
-        <button class="pictionary-lobby__matchmaker-btn" type="button" @click="startSearching">
-          🔍 Find players
-        </button>
+      <template v-if="!lobbyHandle">
+        <p class="pictionary-lobby__matchmaker-label">No one else here yet.</p>
+        <div class="pictionary-lobby__matchmaker-actions">
+          <button class="pictionary-lobby__matchmaker-btn" type="button" @click="startSearching">
+            Find players
+          </button>
+          <button
+            class="pictionary-lobby__matchmaker-btn pictionary-lobby__matchmaker-btn--ghost"
+            type="button"
+            @click="emit('leaveRoom')"
+          >
+            Leave room
+          </button>
+        </div>
       </template>
+
       <template v-else>
-        <span class="pictionary-lobby__matchmaker-searching">Searching…</span>
+        <div class="pictionary-lobby__matchmaker-searching">
+          <span>Searching</span>
+          <span class="pictionary-lobby__dots" aria-hidden="true">
+            <span>.</span><span>.</span><span>.</span>
+          </span>
+        </div>
+
+        <ul v-if="pendingRequests.length" class="pictionary-lobby__requests">
+          <li
+            v-for="entry in pendingRequests"
+            :key="entry.request.requestId"
+            class="pictionary-lobby__request"
+          >
+            <span class="pictionary-lobby__request-name">
+              {{ displayName(entry.fromPeerId) }} wants to play
+            </span>
+            <div class="pictionary-lobby__request-actions">
+              <button
+                class="pictionary-lobby__matchmaker-btn"
+                type="button"
+                @click="acceptRequest(entry)"
+              >
+                Join
+              </button>
+              <button
+                class="pictionary-lobby__matchmaker-btn pictionary-lobby__matchmaker-btn--ghost"
+                type="button"
+                @click="ignoreRequest(entry)"
+              >
+                Ignore
+              </button>
+            </div>
+          </li>
+        </ul>
+
         <button
-          class="pictionary-lobby__matchmaker-btn pictionary-lobby__matchmaker-btn--cancel"
+          class="pictionary-lobby__matchmaker-btn pictionary-lobby__matchmaker-btn--ghost"
           type="button"
           @click="stopSearching"
         >
           Cancel
         </button>
       </template>
+    </div>
+
+    <div v-else-if="isHost" class="pictionary-lobby__leave-row">
+      <button
+        class="pictionary-lobby__matchmaker-btn pictionary-lobby__matchmaker-btn--ghost"
+        type="button"
+        @click="emit('leaveRoom')"
+      >
+        Leave room
+      </button>
     </div>
     <details class="pictionary-lobby__rules">
       <summary class="pictionary-lobby__rules-title">
@@ -357,8 +457,8 @@ onUnmounted(stopSearching)
 
 .pictionary-lobby__matchmaker {
   display: flex;
-  align-items: center;
-  gap: var(--spacing-3);
+  flex-direction: column;
+  gap: var(--spacing-2);
   padding: var(--spacing-3) var(--spacing-4);
   background: #fff;
   border: 3px solid #111;
@@ -369,17 +469,80 @@ onUnmounted(stopSearching)
 }
 
 .pictionary-lobby__matchmaker-label {
-  flex: 1;
   margin: 0;
   font-size: var(--font-size-sm);
   font-weight: 700;
   color: #111;
 }
 
+.pictionary-lobby__matchmaker-actions {
+  display: flex;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
 .pictionary-lobby__matchmaker-searching {
+  display: flex;
+  align-items: baseline;
+  gap: 0.1em;
   font-size: var(--font-size-sm);
   font-weight: 700;
-  color: var(--color-muted-foreground);
+  color: #111;
+}
+
+@keyframes pic-bounce {
+  0%,
+  60%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.4;
+  }
+  30% {
+    transform: translateY(-0.35em);
+    opacity: 1;
+  }
+}
+
+.pictionary-lobby__dots span {
+  display: inline-block;
+  animation: pic-bounce 1.2s ease-in-out infinite;
+}
+.pictionary-lobby__dots span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.pictionary-lobby__dots span:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+.pictionary-lobby__requests {
+  list-style: none;
+  margin: var(--spacing-1) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.pictionary-lobby__request {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 2px solid #111;
+  border-radius: 999px;
+  background: #f0f9ff;
+}
+
+.pictionary-lobby__request-name {
+  flex: 1;
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  color: #111;
+}
+
+.pictionary-lobby__request-actions {
+  display: flex;
+  gap: var(--spacing-1);
 }
 
 .pictionary-lobby__matchmaker-btn {
@@ -401,9 +564,15 @@ onUnmounted(stopSearching)
   box-shadow: 3px 3px 0 #111;
 }
 
-.pictionary-lobby__matchmaker-btn--cancel {
+.pictionary-lobby__matchmaker-btn--ghost {
   background: #fff;
   color: #111;
+}
+
+.pictionary-lobby__leave-row {
+  max-width: 28rem;
+  width: 100%;
+  display: flex;
 }
 
 .pictionary-lobby__host-controls {

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -30,6 +30,7 @@ const props = defineProps<{
   roundDuration: number
   wordCount: number
   hintCount: number
+  roomId: string
 }>()
 
 const emit = defineEmits<{
@@ -49,70 +50,42 @@ const emit = defineEmits<{
 const lobbyHandle = ref<LobbyHandle | null>(null)
 const pendingRequests = ref<Array<{ request: MatchRequest; fromPeerId: string }>>([])
 const peerNames = ref<Record<string, string>>({})
-// Non-reactive: requestId → targetPeerId (only needed for onAccepted lookup)
-const sentRequestPeerIds: Record<string, string> = {}
-let matchComplete = false
 
 const displayName = (peerId: string): string =>
   peerNames.value[peerId] || peerId.slice(0, PEER_ID_LENGTH)
-
-const gameRoomFor = (remotePeerId: string): string =>
-  [lobbyHandle.value?.session.peerId ?? '', remotePeerId].sort().join('--')
-
-const doMatch = (remotePeerId: string): void => {
-  if (matchComplete) return
-  matchComplete = true
-  const gameRoomId = gameRoomFor(remotePeerId)
-  lobbyHandle.value?.stop()
-  lobbyHandle.value = null
-  pendingRequests.value = []
-  emit('matchFound', gameRoomId)
-}
 
 const stopSearching = (): void => {
   lobbyHandle.value?.stop()
   lobbyHandle.value = null
   pendingRequests.value = []
   peerNames.value = {}
-  matchComplete = false
 }
 
 const startSearching = (): void => {
   if (!p2pIsSupported() || lobbyHandle.value) return
-  matchComplete = false
 
   const handle = p2pLobbyJoin(MATCHMAKER_ROOM, undefined, {
     onPeerJoin: (peerId) => {
-      if (matchComplete) return
-      const req = handle.sendRequest(peerId)
-      sentRequestPeerIds[req.requestId] = peerId
+      handle.sendRequest(peerId, props.roomId)
     },
     onPeerLeave: (peerId) => {
       pendingRequests.value = pendingRequests.value.filter((r) => r.fromPeerId !== peerId)
     },
     onRequest: (request, fromPeerId) => {
-      if (matchComplete) return
       if (!pendingRequests.value.some((r) => r.fromPeerId === fromPeerId)) {
         pendingRequests.value = [...pendingRequests.value, { request, fromPeerId }]
       }
     },
-    onAccepted: (requestId) => {
-      const targetPeerId = sentRequestPeerIds[requestId]
-      if (targetPeerId) doMatch(targetPeerId)
+    onAccepted: () => {
+      // Our request was accepted — the peer is coming to our room. Stay and keep searching.
     },
-    onIgnored: (requestId) => {
-      delete sentRequestPeerIds[requestId]
-    },
+    onIgnored: () => {},
     onPeerName: (peerId, name) => {
       peerNames.value = { ...peerNames.value, [peerId]: name }
     }
   })
 
-  handle.getPeerIds().forEach((peerId) => {
-    const req = handle.sendRequest(peerId)
-    sentRequestPeerIds[req.requestId] = peerId
-  })
-
+  handle.getPeerIds().forEach((peerId) => handle.sendRequest(peerId, props.roomId))
   handle.setName(props.playerName)
   lobbyHandle.value = handle
 }
@@ -120,7 +93,8 @@ const startSearching = (): void => {
 const acceptRequest = (entry: { request: MatchRequest; fromPeerId: string }): void => {
   if (!lobbyHandle.value) return
   lobbyHandle.value.acceptRequest(entry.request, entry.fromPeerId)
-  doMatch(entry.fromPeerId)
+  stopSearching()
+  emit('matchFound', entry.request.gameRoomId)
 }
 
 const ignoreRequest = (entry: { request: MatchRequest; fromPeerId: string }): void => {
@@ -141,20 +115,17 @@ onUnmounted(stopSearching)
 <template>
   <section class="pictionary-lobby">
     <div class="pictionary-lobby__profile">
-      <h2 class="pictionary-lobby__profile-title">Your name</h2>
       <div class="pictionary-lobby__profile-row">
-        <label class="pictionary-lobby__field">
-          Name
-          <input
-            :value="playerName"
-            type="text"
-            maxlength="20"
-            class="pictionary-lobby__name-input"
-            @input="handleNameInput"
-            @change="emit('nameChange')"
-            @blur="emit('nameChange')"
-          />
-        </label>
+        <h2 class="pictionary-lobby__profile-title">Your name is</h2>
+        <input
+          :value="playerName"
+          type="text"
+          maxlength="20"
+          class="pictionary-lobby__name-input"
+          @input="handleNameInput"
+          @change="emit('nameChange')"
+          @blur="emit('nameChange')"
+        />
         <div class="pictionary-lobby__swatches">
           <button
             v-for="color in PLAYER_COLORS"
@@ -375,17 +346,18 @@ onUnmounted(stopSearching)
   font-size: var(--font-size-md, 1.125rem);
   font-weight: 800;
   color: #111;
+  white-space: nowrap;
 }
 
 .pictionary-lobby__profile-row {
   display: flex;
   gap: var(--spacing-3);
-  align-items: flex-end;
+  align-items: center;
   flex-wrap: wrap;
 }
 
-.pictionary-lobby__field .pictionary-lobby__name-input,
-.pictionary-lobby__field .pictionary-lobby__name-input:focus {
+.pictionary-lobby__name-input,
+.pictionary-lobby__name-input:focus {
   padding: var(--spacing-2) var(--spacing-3);
   border: 3px solid #111;
   border-radius: 999px;
@@ -393,8 +365,9 @@ onUnmounted(stopSearching)
   color: #111;
   font-size: var(--font-size-md, 1rem);
   font-weight: 700;
-  min-width: 12rem;
+  min-width: 10rem;
   outline: none;
+  flex: 1;
 }
 
 .pictionary-lobby__swatches {

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -481,7 +481,6 @@ onUnmounted(stopSearching)
   box-shadow: 4px 4px 0 #111;
   max-width: 28rem;
   width: 100%;
-  box-sizing: border-box;
 }
 
 .pictionary-lobby__matchmaker-label {

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Check } from 'lucide-vue-next'
-import { onUnmounted, ref } from 'vue'
+import { onUnmounted, ref, watch } from 'vue'
 import type { DictionaryDifficulty } from '@webgamekit/dictionary'
 import type { PictionaryPlayer, PictionaryRound } from '@/stores/pictionary'
 import {
@@ -109,6 +109,13 @@ const handleNameInput = (event: Event): void => {
   emit('update:playerName', (event.target as HTMLInputElement).value)
 }
 
+watch(
+  () => props.isHost,
+  (isHost) => {
+    if (!isHost) stopSearching()
+  }
+)
+
 onUnmounted(stopSearching)
 </script>
 
@@ -155,7 +162,10 @@ onUnmounted(stopSearching)
       />
     </div>
 
-    <div v-if="lobbyHandle !== null || playerList.length <= 1" class="pictionary-lobby__matchmaker">
+    <div
+      v-if="isHost && (lobbyHandle !== null || playerList.length <= 1)"
+      class="pictionary-lobby__matchmaker"
+    >
       <template v-if="!lobbyHandle">
         <p class="pictionary-lobby__matchmaker-label">No one else here yet.</p>
         <button class="pictionary-lobby__matchmaker-btn" type="button" @click="startSearching">

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -162,15 +162,24 @@ onUnmounted(stopSearching)
       />
     </div>
 
-    <div
-      v-if="isHost && (lobbyHandle !== null || playerList.length <= 1)"
-      class="pictionary-lobby__matchmaker"
-    >
+    <div v-if="isHost" class="pictionary-lobby__matchmaker">
       <template v-if="!lobbyHandle">
-        <p class="pictionary-lobby__matchmaker-label">No one else here yet.</p>
-        <button class="pictionary-lobby__matchmaker-btn" type="button" @click="startSearching">
-          Find players
-        </button>
+        <p v-if="playerList.length <= 1" class="pictionary-lobby__matchmaker-label">
+          No one else here yet.
+        </p>
+        <div class="pictionary-lobby__matchmaker-actions">
+          <button class="pictionary-lobby__matchmaker-btn" type="button" @click="startSearching">
+            Find players
+          </button>
+          <button
+            v-if="playerList.length > 1"
+            class="pictionary-lobby__matchmaker-btn pictionary-lobby__matchmaker-btn--ghost"
+            type="button"
+            @click="emit('leaveRoom')"
+          >
+            Leave room
+          </button>
+        </div>
       </template>
 
       <template v-else>
@@ -227,16 +236,6 @@ onUnmounted(stopSearching)
           </button>
         </div>
       </template>
-    </div>
-
-    <div v-else-if="isHost" class="pictionary-lobby__leave-row">
-      <button
-        class="pictionary-lobby__matchmaker-btn pictionary-lobby__matchmaker-btn--ghost"
-        type="button"
-        @click="emit('leaveRoom')"
-      >
-        Leave room
-      </button>
     </div>
     <div v-if="isHost" class="pictionary-lobby__host-controls">
       <label class="pictionary-lobby__field">

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -116,7 +116,7 @@ onUnmounted(stopSearching)
   <section class="pictionary-lobby">
     <div class="pictionary-lobby__profile">
       <div class="pictionary-lobby__profile-row">
-        <h2 class="pictionary-lobby__profile-title">Your name is</h2>
+        <h2 class="pictionary-lobby__profile-title">Your name</h2>
         <input
           :value="playerName"
           type="text"

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -116,7 +116,7 @@ onUnmounted(stopSearching)
   <section class="pictionary-lobby">
     <div class="pictionary-lobby__profile">
       <div class="pictionary-lobby__profile-row">
-        <h2 class="pictionary-lobby__profile-title">Your name</h2>
+        <h2 class="pictionary-lobby__profile-title">Your name is</h2>
         <input
           :value="playerName"
           type="text"

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -481,6 +481,7 @@ onUnmounted(stopSearching)
   box-shadow: 4px 4px 0 #111;
   max-width: 28rem;
   width: 100%;
+  box-sizing: border-box;
 }
 
 .pictionary-lobby__matchmaker-label {

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -174,9 +174,20 @@ onUnmounted(stopSearching)
         </div>
       </div>
     </div>
-    <p class="pictionary-lobby__hint">Game starts when the host clicks Start.</p>
+    <div class="pictionary-lobby__players">
+      <span class="pictionary-lobby__player-count">
+        {{ playerList.length }} / {{ playerList.length < 2 ? '2+' : playerList.length }} players
+      </span>
+      <span
+        v-for="player in playerList"
+        :key="player.id"
+        class="pictionary-lobby__player-dot"
+        :style="{ background: player.color }"
+        :title="player.name"
+      />
+    </div>
 
-    <div v-if="playerList.length <= 1" class="pictionary-lobby__matchmaker">
+    <div v-if="lobbyHandle !== null || playerList.length <= 1" class="pictionary-lobby__matchmaker">
       <template v-if="!lobbyHandle">
         <p class="pictionary-lobby__matchmaker-label">No one else here yet.</p>
         <div class="pictionary-lobby__matchmaker-actions">
@@ -229,13 +240,22 @@ onUnmounted(stopSearching)
           </li>
         </ul>
 
-        <button
-          class="pictionary-lobby__matchmaker-btn pictionary-lobby__matchmaker-btn--ghost"
-          type="button"
-          @click="stopSearching"
-        >
-          Cancel
-        </button>
+        <div class="pictionary-lobby__matchmaker-actions">
+          <button
+            class="pictionary-lobby__matchmaker-btn pictionary-lobby__matchmaker-btn--ghost"
+            type="button"
+            @click="stopSearching"
+          >
+            Stop searching
+          </button>
+          <button
+            class="pictionary-lobby__matchmaker-btn pictionary-lobby__matchmaker-btn--ghost"
+            type="button"
+            @click="emit('leaveRoom')"
+          >
+            Leave room
+          </button>
+        </div>
       </template>
     </div>
 
@@ -336,10 +356,24 @@ onUnmounted(stopSearching)
         :disabled="playerList.length < 2"
         @click="emit('startGame')"
       >
-        Start round {{ round.number + 1 }}
+        Start
       </button>
     </div>
-    <p v-else class="pictionary-lobby__hint">Waiting for the host to start the round…</p>
+    <div v-else class="pictionary-lobby__guest-waiting">
+      <span class="pictionary-lobby__matchmaker-searching">
+        Waiting for host
+        <span class="pictionary-lobby__dots" aria-hidden="true">
+          <span>.</span><span>.</span><span>.</span>
+        </span>
+      </span>
+      <button
+        class="pictionary-lobby__matchmaker-btn pictionary-lobby__matchmaker-btn--ghost"
+        type="button"
+        @click="emit('leaveRoom')"
+      >
+        Leave room
+      </button>
+    </div>
   </section>
 </template>
 
@@ -451,6 +485,40 @@ onUnmounted(stopSearching)
 .pictionary-lobby__hint {
   color: var(--color-muted-foreground);
   font-size: var(--font-size-sm);
+}
+
+.pictionary-lobby__players {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  color: #111;
+}
+
+.pictionary-lobby__player-count {
+  font-size: var(--font-size-sm);
+}
+
+.pictionary-lobby__player-dot {
+  width: 0.875rem;
+  height: 0.875rem;
+  border-radius: 50%;
+  border: 2px solid #111;
+  display: inline-block;
+}
+
+.pictionary-lobby__guest-waiting {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-4);
+  background: #fff;
+  border: 3px solid #111;
+  border-radius: 1.25rem;
+  box-shadow: 4px 4px 0 #111;
+  max-width: 28rem;
+  width: 100%;
 }
 
 .pictionary-lobby__matchmaker {

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -13,10 +13,7 @@ import {
   PLAYER_COLORS,
   ROUND_DURATION_OPTIONS,
   WORD_COUNT_OPTIONS,
-  HINT_COUNT_OPTIONS,
-  POINTS_BASE,
-  POINTS_FIRST_BONUS,
-  POINTS_DRAWER_PER_GUESS
+  HINT_COUNT_OPTIONS
 } from './constants'
 
 const MATCHMAKER_ROOM = 'pictionary-matchmaker'
@@ -190,18 +187,9 @@ onUnmounted(stopSearching)
     <div v-if="lobbyHandle !== null || playerList.length <= 1" class="pictionary-lobby__matchmaker">
       <template v-if="!lobbyHandle">
         <p class="pictionary-lobby__matchmaker-label">No one else here yet.</p>
-        <div class="pictionary-lobby__matchmaker-actions">
-          <button class="pictionary-lobby__matchmaker-btn" type="button" @click="startSearching">
-            Find players
-          </button>
-          <button
-            class="pictionary-lobby__matchmaker-btn pictionary-lobby__matchmaker-btn--ghost"
-            type="button"
-            @click="emit('leaveRoom')"
-          >
-            Leave room
-          </button>
-        </div>
+        <button class="pictionary-lobby__matchmaker-btn" type="button" @click="startSearching">
+          Find players
+        </button>
       </template>
 
       <template v-else>
@@ -249,6 +237,7 @@ onUnmounted(stopSearching)
             Stop searching
           </button>
           <button
+            v-if="playerList.length > 1"
             class="pictionary-lobby__matchmaker-btn pictionary-lobby__matchmaker-btn--ghost"
             type="button"
             @click="emit('leaveRoom')"
@@ -268,24 +257,6 @@ onUnmounted(stopSearching)
         Leave room
       </button>
     </div>
-    <details class="pictionary-lobby__rules">
-      <summary class="pictionary-lobby__rules-title" title="How points work">?</summary>
-      <ul class="pictionary-lobby__rules-list">
-        <li>
-          Guessers earn up to <strong>{{ POINTS_BASE }} pts</strong> based on speed — faster guesses
-          score more
-        </li>
-        <li>
-          First correct guess gets a <strong>+{{ POINTS_FIRST_BONUS }} pts</strong> bonus
-        </li>
-        <li>
-          Drawer earns up to <strong>{{ POINTS_DRAWER_PER_GUESS }} pts</strong> per correct guess,
-          scaled by time remaining
-        </li>
-        <li>Everyone can guess — the round continues until time runs out or all players guess</li>
-        <li>Hints reveal extra letters during the round (configurable above)</li>
-      </ul>
-    </details>
     <div v-if="isHost" class="pictionary-lobby__host-controls">
       <label class="pictionary-lobby__field">
         Difficulty
@@ -670,66 +641,13 @@ onUnmounted(stopSearching)
   box-shadow: 2px 2px 0 #111;
 }
 
-.pictionary-lobby__rules {
-  position: relative;
-  align-self: flex-start;
-  color: #111;
-}
-
-.pictionary-lobby__rules-title {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.5rem;
-  height: 1.5rem;
-  border: 2px solid #111;
-  border-radius: 50%;
-  background: #fff;
-  font-size: 0.875rem;
-  font-weight: 900;
-  cursor: pointer;
-  list-style: none;
-  box-shadow: 2px 2px 0 #111;
-  transition: transform 0.1s ease;
-  user-select: none;
-}
-
-.pictionary-lobby__rules-title::-webkit-details-marker {
-  display: none;
-}
-
-.pictionary-lobby__rules-title:hover {
-  transform: translate(-1px, -1px);
-  box-shadow: 3px 3px 0 #111;
-}
-
-.pictionary-lobby__rules-list {
-  position: absolute;
-  bottom: calc(100% + var(--spacing-2));
-  left: 0;
-  z-index: 10;
-  margin: 0;
-  padding: var(--spacing-3) var(--spacing-3) var(--spacing-3) var(--spacing-5);
-  background: #fff;
-  border: 2px solid #111;
-  border-radius: 0.75rem;
-  box-shadow: 3px 3px 0 #111;
-  width: 16rem;
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-1);
-  font-size: var(--font-size-sm);
-  line-height: 1.4;
-}
-
 @media (max-width: 720px) {
   .pictionary-lobby {
     padding-left: 0;
     padding-right: 0;
   }
 
-  .pictionary-lobby__profile,
-  .pictionary-lobby__rules {
+  .pictionary-lobby__profile {
     max-width: 100%;
     box-sizing: border-box;
     box-shadow: none;

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Check } from 'lucide-vue-next'
+import PictionaryCard from './PictionaryCard.vue'
 import { onUnmounted, ref, watch } from 'vue'
 import type { DictionaryDifficulty } from '@webgamekit/dictionary'
 import type { PictionaryPlayer, PictionaryRound } from '@/stores/pictionary'
@@ -121,7 +122,7 @@ onUnmounted(stopSearching)
 
 <template>
   <section class="pictionary-lobby">
-    <div class="pictionary-lobby__profile">
+    <PictionaryCard class="pictionary-lobby__profile">
       <div class="pictionary-lobby__profile-row">
         <h2 class="pictionary-lobby__profile-title">Your name is</h2>
         <input
@@ -148,7 +149,7 @@ onUnmounted(stopSearching)
           </button>
         </div>
       </div>
-    </div>
+    </PictionaryCard>
     <div class="pictionary-lobby__players">
       <span class="pictionary-lobby__player-count">
         {{ playerList.length }} / {{ playerList.length < 2 ? '2+' : playerList.length }} players
@@ -162,7 +163,7 @@ onUnmounted(stopSearching)
       />
     </div>
 
-    <div v-if="isHost" class="pictionary-lobby__matchmaker">
+    <PictionaryCard v-if="isHost" class="pictionary-lobby__matchmaker">
       <template v-if="!lobbyHandle">
         <p v-if="playerList.length <= 1" class="pictionary-lobby__matchmaker-label">
           No one else here yet.
@@ -236,7 +237,7 @@ onUnmounted(stopSearching)
           </button>
         </div>
       </template>
-    </div>
+    </PictionaryCard>
     <div v-if="isHost" class="pictionary-lobby__host-controls">
       <label class="pictionary-lobby__field">
         Difficulty
@@ -306,7 +307,7 @@ onUnmounted(stopSearching)
         Start
       </button>
     </div>
-    <div v-else class="pictionary-lobby__guest-waiting">
+    <PictionaryCard v-else class="pictionary-lobby__guest-waiting">
       <span class="pictionary-lobby__matchmaker-searching">
         Waiting for host
         <span class="pictionary-lobby__dots" aria-hidden="true">
@@ -320,7 +321,7 @@ onUnmounted(stopSearching)
       >
         Leave room
       </button>
-    </div>
+    </PictionaryCard>
   </section>
 </template>
 
@@ -342,10 +343,6 @@ onUnmounted(stopSearching)
   flex-direction: column;
   gap: var(--spacing-2);
   padding: var(--spacing-3);
-  background: #fff;
-  border: 3px solid #111;
-  border-radius: 1.25rem;
-  box-shadow: 4px 4px 0 #111;
   max-width: 28rem;
   width: 100%;
 }
@@ -462,10 +459,6 @@ onUnmounted(stopSearching)
   align-items: center;
   gap: var(--spacing-3);
   padding: var(--spacing-3) var(--spacing-4);
-  background: #fff;
-  border: 3px solid #111;
-  border-radius: 1.25rem;
-  box-shadow: 4px 4px 0 #111;
   max-width: 28rem;
   width: 100%;
 }
@@ -475,10 +468,6 @@ onUnmounted(stopSearching)
   flex-direction: column;
   gap: var(--spacing-2);
   padding: var(--spacing-3) var(--spacing-4);
-  background: #fff;
-  border: 3px solid #111;
-  border-radius: 1.25rem;
-  box-shadow: 4px 4px 0 #111;
   max-width: 28rem;
   width: 100%;
 }

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -618,10 +618,11 @@ onUnmounted(stopSearching)
     padding-right: 0;
   }
 
-  .pictionary-lobby__profile {
+  .pictionary-lobby__profile,
+  .pictionary-lobby__matchmaker,
+  .pictionary-lobby__guest-waiting {
     max-width: 100%;
     box-sizing: border-box;
-    box-shadow: none;
     padding: var(--spacing-2);
   }
 

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Check, Plus, Minus } from 'lucide-vue-next'
+import { Check } from 'lucide-vue-next'
 import { onUnmounted, ref } from 'vue'
 import type { DictionaryDifficulty } from '@webgamekit/dictionary'
 import type { PictionaryPlayer, PictionaryRound } from '@/stores/pictionary'
@@ -269,11 +269,7 @@ onUnmounted(stopSearching)
       </button>
     </div>
     <details class="pictionary-lobby__rules">
-      <summary class="pictionary-lobby__rules-title">
-        <Plus class="pictionary-lobby__rules-icon pictionary-lobby__rules-icon--closed" />
-        <Minus class="pictionary-lobby__rules-icon pictionary-lobby__rules-icon--open" />
-        How points work
-      </summary>
+      <summary class="pictionary-lobby__rules-title" title="How points work">?</summary>
       <ul class="pictionary-lobby__rules-list">
         <li>
           Guessers earn up to <strong>{{ POINTS_BASE }} pts</strong> based on speed — faster guesses
@@ -675,55 +671,50 @@ onUnmounted(stopSearching)
 }
 
 .pictionary-lobby__rules {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-2);
-  padding: var(--spacing-3);
-  background: #fff;
-  border: 3px solid #111;
-  border-radius: 1.25rem;
-  box-shadow: 4px 4px 0 #111;
-  max-width: 28rem;
-  width: 100%;
+  position: relative;
+  align-self: flex-start;
   color: #111;
 }
 
 .pictionary-lobby__rules-title {
-  margin: 0;
-  font-size: var(--font-size-md, 1.125rem);
-  font-weight: 800;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 2px solid #111;
+  border-radius: 50%;
+  background: #fff;
+  font-size: 0.875rem;
+  font-weight: 900;
   cursor: pointer;
   list-style: none;
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-1);
+  box-shadow: 2px 2px 0 #111;
+  transition: transform 0.1s ease;
+  user-select: none;
 }
 
 .pictionary-lobby__rules-title::-webkit-details-marker {
   display: none;
 }
 
-.pictionary-lobby__rules-icon {
-  width: 1rem;
-  height: 1rem;
-  flex-shrink: 0;
-}
-
-.pictionary-lobby__rules-icon--open {
-  display: none;
-}
-
-.pictionary-lobby__rules[open] .pictionary-lobby__rules-icon--closed {
-  display: none;
-}
-
-.pictionary-lobby__rules[open] .pictionary-lobby__rules-icon--open {
-  display: block;
+.pictionary-lobby__rules-title:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 3px 3px 0 #111;
 }
 
 .pictionary-lobby__rules-list {
+  position: absolute;
+  bottom: calc(100% + var(--spacing-2));
+  left: 0;
+  z-index: 10;
   margin: 0;
-  padding-left: 1.25rem;
+  padding: var(--spacing-3) var(--spacing-3) var(--spacing-3) var(--spacing-5);
+  background: #fff;
+  border: 2px solid #111;
+  border-radius: 0.75rem;
+  box-shadow: 3px 3px 0 #111;
+  width: 16rem;
   display: flex;
   flex-direction: column;
   gap: var(--spacing-1);

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -1,7 +1,16 @@
 <script setup lang="ts">
 import { Check, Plus, Minus } from 'lucide-vue-next'
+import { onUnmounted, ref } from 'vue'
 import type { DictionaryDifficulty } from '@webgamekit/dictionary'
 import type { PictionaryPlayer, PictionaryRound } from '@/stores/pictionary'
+import {
+  p2pJoin,
+  p2pLeave,
+  p2pGetPeerIds,
+  p2pOnPeerJoin,
+  p2pIsSupported,
+  type P2PSession
+} from '@webgamekit/multiplayer-p2p'
 import {
   PLAYER_COLORS,
   ROUND_DURATION_OPTIONS,
@@ -11,6 +20,8 @@ import {
   POINTS_FIRST_BONUS,
   POINTS_DRAWER_PER_GUESS
 } from './constants'
+
+const MATCHMAKER_ROOM = 'pictionary-matchmaker'
 
 defineProps<{
   playerName: string
@@ -35,11 +46,53 @@ const emit = defineEmits<{
   'update:hintCount': [value: number]
   nameChange: []
   startGame: []
+  matchFound: [roomId: string]
 }>()
+
+const matchState = ref<'idle' | 'searching'>('idle')
+let matchSession: P2PSession | null = null
+
+const deriveGameRoomId = (peerA: string, peerB: string): string => [peerA, peerB].sort().join('--')
+
+const handlePeerFound = (session: P2PSession, remotePeerId: string): void => {
+  const gameRoomId = deriveGameRoomId(session.peerId, remotePeerId)
+  p2pLeave(session)
+  matchSession = null
+  matchState.value = 'idle'
+  emit('matchFound', gameRoomId)
+}
+
+const startSearching = (): void => {
+  if (!p2pIsSupported()) return
+  const session = p2pJoin(MATCHMAKER_ROOM)
+  matchSession = session
+  matchState.value = 'searching'
+
+  const existing = p2pGetPeerIds(session)
+  if (existing.length > 0) {
+    handlePeerFound(session, existing[0])
+    return
+  }
+
+  p2pOnPeerJoin(session, (remotePeerId) => {
+    if (!matchSession) return
+    handlePeerFound(session, remotePeerId)
+  })
+}
+
+const stopSearching = (): void => {
+  if (matchSession) {
+    p2pLeave(matchSession)
+    matchSession = null
+  }
+  matchState.value = 'idle'
+}
 
 const handleNameInput = (event: Event): void => {
   emit('update:playerName', (event.target as HTMLInputElement).value)
 }
+
+onUnmounted(stopSearching)
 </script>
 
 <template>
@@ -78,6 +131,25 @@ const handleNameInput = (event: Event): void => {
     <p class="pictionary-lobby__hint">
       Share the room link with friends. Game starts when the host clicks Start.
     </p>
+
+    <div v-if="playerList.length <= 1" class="pictionary-lobby__matchmaker">
+      <p class="pictionary-lobby__matchmaker-label">No one else here yet.</p>
+      <template v-if="matchState === 'idle'">
+        <button class="pictionary-lobby__matchmaker-btn" type="button" @click="startSearching">
+          🔍 Find players
+        </button>
+      </template>
+      <template v-else>
+        <span class="pictionary-lobby__matchmaker-searching">Searching…</span>
+        <button
+          class="pictionary-lobby__matchmaker-btn pictionary-lobby__matchmaker-btn--cancel"
+          type="button"
+          @click="stopSearching"
+        >
+          Cancel
+        </button>
+      </template>
+    </div>
     <details class="pictionary-lobby__rules">
       <summary class="pictionary-lobby__rules-title">
         <Plus class="pictionary-lobby__rules-icon pictionary-lobby__rules-icon--closed" />
@@ -281,6 +353,57 @@ const handleNameInput = (event: Event): void => {
 .pictionary-lobby__hint {
   color: var(--color-muted-foreground);
   font-size: var(--font-size-sm);
+}
+
+.pictionary-lobby__matchmaker {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-4);
+  background: #fff;
+  border: 3px solid #111;
+  border-radius: 1.25rem;
+  box-shadow: 4px 4px 0 #111;
+  max-width: 28rem;
+  width: 100%;
+}
+
+.pictionary-lobby__matchmaker-label {
+  flex: 1;
+  margin: 0;
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  color: #111;
+}
+
+.pictionary-lobby__matchmaker-searching {
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  color: var(--color-muted-foreground);
+}
+
+.pictionary-lobby__matchmaker-btn {
+  padding: var(--spacing-1) var(--spacing-3);
+  border: 2px solid #111;
+  border-radius: 999px;
+  background: var(--pic-blue);
+  color: #fff;
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 2px 2px 0 #111;
+  white-space: nowrap;
+  transition: transform 0.1s ease;
+}
+
+.pictionary-lobby__matchmaker-btn:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 3px 3px 0 #111;
+}
+
+.pictionary-lobby__matchmaker-btn--cancel {
+  background: #fff;
+  color: #111;
 }
 
 .pictionary-lobby__host-controls {

--- a/src/views/Games/Pictionary/usePictionarySession.ts
+++ b/src/views/Games/Pictionary/usePictionarySession.ts
@@ -499,6 +499,11 @@ export const usePictionarySession = (options: UsePictionarySessionOptions) => {
 
   const init = (): void => initSessionForContext(ctx, options.roomId)
 
+  const reconnect = (newRoomId: string): void => {
+    destroy()
+    initSessionForContext(ctx, newRoomId)
+  }
+
   const destroy = (): void => {
     clearHintTimers(ctx)
     if (session.value) {
@@ -524,6 +529,7 @@ export const usePictionarySession = (options: UsePictionarySessionOptions) => {
     updateProfile,
     restartGame,
     init,
+    reconnect,
     destroy
   }
 }


### PR DESCRIPTION
Closes #91

## Summary

- New `p2pLobbyJoin()` in `@webgamekit/multiplayer-p2p`: joins a shared discovery room and provides a targeted two-way match negotiation protocol (send request → accept / ignore)
- New `Matchmaker` view at `/experiments/Matchmaker`: lists online lobby players; user can request specific players, accept or ignore incoming requests; shows a matched overlay with the shared game room ID on agreement
- `MultiplayerP2P` is unchanged — it remains a separate, auto-connecting game demo

## Key Changes

- `packages/multiplayer-p2p/src/lobby.ts` — `p2pLobbyJoin(roomId, config, callbacks)` tracks peers in the lobby and drives `sendRequest(targetPeer)` / `acceptRequest` / `ignoreRequest` via dedicated data channels; requests are targeted at specific peers via Trystero's per-peer send
- `packages/multiplayer-p2p/src/index.ts` — exports `p2pLobbyJoin`, `p2pMatchmake`, `MatchRequest`, `LobbyCallbacks`, `LobbyHandle`, `MatchmakeStatus`, `MatchmakeHandle`
- `packages/multiplayer-p2p/src/index.test.ts` — 19 new tests (9 matchmaker + 10 lobby) covering all state and message flows
- `src/views/Experiments/Matchmaker/Matchmaker.vue` — joins lobby on mount; shows online player list with Request/Pending per player; Requests section with Accept/Ignore per incoming request; matched overlay on agreement
- `src/config/viewsMeta.json` — adds Matchmaker entry

## Matchmaking approach

**Why lobby room + targeted requests:** Trystero provides peer discovery in a named room with no server. A well-known lobby room makes all searching players visible to each other. Targeted data channels (Trystero supports per-peer sends) allow each player to selectively negotiate with a specific match rather than auto-joining with everyone. This gives users meaningful agency without requiring a signaling server.

**Why not skill-based / ELO ranking:** No persistent state storage exists in the stack; overkill for an experimental demo.

## Test Plan

- [ ] Navigate to `/experiments/Matchmaker` — lobby joins automatically; "No other players yet" shown
- [ ] Open second tab — both tabs show each other in the list
- [ ] Click **Request** on a player — that player sees "wants to play" with Accept / Ignore
- [ ] Click **Accept** — both tabs show the matched overlay with the game room ID
- [ ] Click **Ignore** — request disappears on both sides; Request button restores
- [ ] Close a tab — it disappears from the other tab's list; pending requests for it are cleared
- [ ] Navigate to `/experiments/MultiplayerP2P` — unchanged, still auto-connects
- [ ] 834 unit tests pass; 0 type errors; 0 lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)