### PR TITLE
fix: remove build block from docker-compose so server uses pulled GHCR image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
   website:
     image: ghcr.io/cnotv/generative-art:latest
-    build:
-      context: .
     environment:
       NODE_ENV: production
     ports:


### PR DESCRIPTION
Closes #97

## Summary

- Remove `build: { context: . }` from `docker-compose.yml`

## Key Changes

When both `image:` and `build:` are present in a Compose service, Docker Compose treats the service as buildable and may use a locally cached image (or attempt a local build with no source) instead of the GHCR image that `docker compose pull` just fetched. Removing `build:` ensures `docker compose up -d --force-recreate` always starts from the registry image.

## Test Plan

- [ ] Trigger a push to `main` and verify GitHub Actions deploy job completes without errors
- [ ] SSH to the Hetzner server and confirm the running container image digest matches the latest GHCR tag