### PR TITLE
fix: add missing @webgamekit packages to Vite source aliases

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -319,6 +319,29 @@ scene.add(new THREE.Mesh(groundGeo, new THREE.MeshLambertMaterial({ color: 0x2c3
 - Vite aliases resolve to `packages/{pkg}/src/index.ts` for HMR
 - Changes to packages hot-reload without rebuilding
 
+**CRITICAL — register every new package in `vite.config.ts`**:
+
+When a new `@webgamekit/*` package is added to `packages/`, it **must** be added to the `packages` array in `vite.config.ts`:
+
+```ts
+const packages = [
+  'animation',
+  'threejs',
+  'audio',
+  'game',
+  'controls',
+  'recording',
+  'logic',
+  'multiplayer-p2p',
+  'dictionary',
+  'chat',
+  'canvas-editor',
+  'your-new-package' // ← add here
+]
+```
+
+Omitting a package causes Vite to resolve it via `node_modules` to its `dist/` file. If that dist is stale or missing a new export, the app will throw a runtime `SyntaxError` in both dev and Docker.
+
 ### Configuration Separation
 
 Keep scene configs in separate `config.ts` files:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,10 @@ const packages = [
   'controls',
   'recording',
   'logic',
-  'multiplayer-p2p'
+  'multiplayer-p2p',
+  'dictionary',
+  'chat',
+  'canvas-editor'
 ]
 const packageAliases = Object.fromEntries(
   packages.map((package_) => [


### PR DESCRIPTION
Closes #103

## Summary
- Add `dictionary`, `chat`, and `canvas-editor` to the `packages` array in `vite.config.ts` so all `@webgamekit/*` packages are resolved from TypeScript source instead of their `dist/`
- Document the requirement in `copilot-instructions.md` with a CRITICAL note and example so new packages are never left out

## Key Changes
- `vite.config.ts` — three missing packages added to alias list
- `.github/copilot-instructions.md` — CRITICAL rule: every new package must be registered here

## Test Plan
- [ ] `docker compose up -d` no longer throws `SyntaxError` for dictionary exports
- [ ] Hot-reload works for `@webgamekit/dictionary`, `@webgamekit/chat`, `@webgamekit/canvas-editor` changes in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)