### PR TITLE
docs: Games Lobby guide and journey notes

### DIFF
--- a/documentation/docs/guides/adding-game-to-lobby.md
+++ b/documentation/docs/guides/adding-game-to-lobby.md
@@ -1,0 +1,146 @@
+---
+sidebar_position: 2
+---
+
+# Adding a Game to the Lobby
+
+The Games Lobby (`/games/Lobby`) is a shared room-discovery and matchmaking hub. It embeds existing games via `defineAsyncComponent` and tracks their player lists via Pinia stores. This guide covers the four integration points you need to wire up when adding a new game.
+
+## Prerequisites
+
+Your game must already follow the P2P multiplayer pattern described in [Building a P2P Multiplayer Word Game](./p2p-multiplayer-word-game.md):
+
+- A Pinia store with a `playerList` computed ref (array of `{ id, name, color }`)
+- A root Vue component (e.g. `MyGame.vue`) that reads `route.query.room` to join a P2P room
+- A header component that can detect lobby mode via `route.query.game`
+
+---
+
+## 1. Register the game type
+
+Open `src/views/Games/Lobby/constants.ts` and add your game to `GAME_TYPES` and `GAME_LABELS`:
+
+```ts
+export const GAME_TYPES = [
+  'Pictionary',
+  'SquaresMultiplayer',
+  'WordleMultiplayer',
+  'MyGame'
+] as const
+export type GameType = (typeof GAME_TYPES)[number]
+
+export const GAME_LABELS: Record<GameType, string> = {
+  Pictionary: 'Pictionary',
+  SquaresMultiplayer: 'Squares',
+  WordleMultiplayer: 'Wordle',
+  MyGame: 'My Game' // display name on the lobby card
+}
+```
+
+---
+
+## 2. Register the async component
+
+In `src/views/Games/Lobby/Lobby.vue`, add your game to the `GAME_COMPONENTS` map:
+
+```ts
+const GAME_COMPONENTS: Record<GameType, ReturnType<typeof defineAsyncComponent>> = {
+  Pictionary: defineAsyncComponent(() => import('@/views/Games/Pictionary/Pictionary.vue')),
+  SquaresMultiplayer: defineAsyncComponent(
+    () => import('@/views/Games/SquaresMultiplayer/SquaresMultiplayer.vue')
+  ),
+  WordleMultiplayer: defineAsyncComponent(
+    () => import('@/views/Games/WordleMultiplayer/WordleMultiplayer.vue')
+  ),
+  MyGame: defineAsyncComponent(() => import('@/views/Games/MyGame/MyGame.vue'))
+}
+```
+
+The lobby will render the active game's component when `route.query.game === 'MyGame'`.
+
+---
+
+## 3. Wire the player list
+
+The lobby needs to sync its room's player count with whoever is currently in the game. Add your store to the `gamePlayerList` computed in `Lobby.vue`:
+
+```ts
+import { useMyGameStore } from '@/stores/myGame'
+const myGameStore = useMyGameStore()
+
+const gamePlayerList = computed(() => {
+  if (activeGame.value === 'Pictionary') return pictionaryStore.playerList
+  if (activeGame.value === 'SquaresMultiplayer') return squaresStore.playerList
+  if (activeGame.value === 'WordleMultiplayer') return wordleStore.playerList
+  if (activeGame.value === 'MyGame') return myGameStore.playerList
+  return []
+})
+```
+
+The existing `watch(gamePlayerList, ...)` will call `updateRoomPlayers` automatically — no further changes needed.
+
+---
+
+## 4. Add the ← Lobby button to your game's header
+
+When a game is launched from the Lobby, `route.query.game` is set. Your header should detect this and replace the room-ID row with a back button:
+
+```vue
+<!-- MyGameHeader.vue -->
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+defineProps<{ roomId: string }>()
+const emit = defineEmits<{ copyLink: [] }>()
+
+const route = useRoute()
+const router = useRouter()
+const fromLobby = computed(() => !!route.query.game)
+</script>
+
+<template>
+  <header class="my-game-header">
+    <template v-if="fromLobby">
+      <button type="button" @click="router.replace({ query: {} })">← Lobby</button>
+    </template>
+    <template v-else>
+      <code>{{ roomId.slice(0, 8) }}</code>
+      <button type="button" @click="emit('copyLink')">Copy link</button>
+    </template>
+  </header>
+</template>
+```
+
+`router.replace({ query: {} })` clears all query params, which triggers the lobby's `watch(activeGame)` to auto-close the room and return to the picker.
+
+---
+
+## 5. (Optional) Add a CSS deep override for embedded padding
+
+The lobby embeds your game inside `.lobby__game-embed`. Each game root normally has `padding-top: calc(var(--nav-height) + var(--spacing-3))`. When embedded, this must be reduced to just `var(--nav-height)` so the ← Lobby button sits flush below the fixed nav bar.
+
+Add a deep selector in `Lobby.vue`'s `<style scoped>`:
+
+```css
+.lobby__game-embed :deep(.my-game),
+.lobby__game-embed :deep(.wm),
+.lobby__game-embed :deep(.wl),
+.lobby__game-embed :deep(.pictionary) {
+  padding-top: var(--nav-height);
+}
+```
+
+Replace `.my-game` with your root element's BEM class name.
+
+---
+
+## How the URL routing works
+
+When the user picks a game or joins a room, the lobby calls:
+
+```ts
+router.replace({ query: { game: 'MyGame', room: '<uuid>' } })
+```
+
+The embedded game's composable reads `route.query.room` on mount and joins the corresponding P2P room. The lobby itself reads `route.query.game` to decide which component to render. Clearing both params (`router.replace({ query: {} })`) brings the user back to the picker screen.

--- a/documentation/docs/journey/word-multiplayer-games.md
+++ b/documentation/docs/journey/word-multiplayer-games.md
@@ -238,3 +238,69 @@ Cards used `background: #fff` but no explicit `color`. On a dark OS theme the bo
 ## Intermission layout with many words
 
 A full dictionary scan can produce 20–30 valid words. With `align-items: center` on the flex container, overflow split equally above and below — words above the viewport were unreachable. Switching to `align-items: flex-start; overflow-y: auto` kept all content scrollable from the top.
+
+---
+
+## Games Lobby
+
+### Overview
+
+The Lobby (`src/views/Games/Lobby/`) is a shared room-discovery hub that embeds any of the three games via `defineAsyncComponent`. The URL carries the game and room as query params (`?game=Pictionary&room=<uuid>`), so the embedded game's own composable can join the correct P2P room without modification.
+
+The Lobby runs its own P2P session (`useLobbySession`) on a separate well-known room key. Each peer broadcasts an `lb-hello` (profile) and `lb-room` (room announcement) on join. Room state is ephemeral — only the host's peer keeps it alive; if that peer disconnects before the room is cleaned up, the room simply disappears from all other clients' lists.
+
+### Player list sync
+
+The lobby needs to know how many players are in the embedded game so it can update its own room advertisement. Rather than adding a new P2P channel, the lobby watches each game's Pinia `playerList` computed ref directly:
+
+```ts
+const gamePlayerList = computed(() => {
+  if (activeGame.value === 'Pictionary') return pictionaryStore.playerList
+  ...
+})
+watch(gamePlayerList, (players) => {
+  if (!ownRoom.value) return
+  updateRoomPlayers(players.map(p => ({ id: p.id, name: p.name, color: p.color })))
+}, { deep: true })
+```
+
+This avoids any new networking layer — the Pinia store is the source of truth.
+
+### Host-stealing bug
+
+`hostId` was originally computed as `[...Object.keys(players)].sort()[0]`. Any peer whose UUID sorts lexicographically before the current host's UUID would silently become the new host on join, triggering duplicate `startRound` calls. The fix is simple:
+
+```ts
+// Before: sort()[0]  — alphabetical, anyone can steal host
+// After: ids[0]      — insertion order, first joiner stays host
+const hostId = computed(() => {
+  const ids = Object.keys(players.value)
+  return ids.length ? ids[0] : ''
+})
+```
+
+JavaScript objects preserve insertion order for string keys that are not array indices, so `Object.keys()[0]` reliably returns the first player to call `upsertPlayer`.
+
+### Embedded game top padding
+
+Each game root had `padding-top: calc(var(--nav-height) + var(--spacing-3))`. The lobby wrapper previously added its own `padding-top: var(--nav-height)`, then zeroed the CSS variable inside the embed container (`--nav-height: 0px`) to prevent double-padding — leaving only the `var(--spacing-3)` gap, which appeared as a white strip at the top of every embedded game.
+
+The fix restructures clearance per section instead of on the wrapper:
+
+- Removed `padding-top` from `.lobby` root entirely
+- Added `padding-top: var(--nav-height)` to `.lobby__sidebar` and `.lobby__picker` individually
+- Used CSS deep selectors to override each embedded game root's padding-top to just `var(--nav-height)` (no extra `spacing-3`):
+
+```css
+.lobby__game-embed :deep(.wm),
+.lobby__game-embed :deep(.wl),
+.lobby__game-embed :deep(.pictionary) {
+  padding-top: var(--nav-height);
+}
+```
+
+Each section now owns its own nav clearance; the wrapper is transparent.
+
+### ← Lobby button
+
+Each game header detects `route.query.game` and replaces the room-ID row with a back button when set. Clicking it calls `router.replace({ query: {} })`, which clears `activeGame` in the lobby, triggers `watch(activeGame)` to auto-close the room, and returns the user to the picker screen — no extra event bus needed.


### PR DESCRIPTION
## Summary

- New guide: `documentation/docs/guides/adding-game-to-lobby.md` — step-by-step for wiring a new game into the shared Lobby (register type, async component, player list, ← Lobby button, CSS padding override)
- Journey: appended a **Games Lobby** section to `documentation/docs/journey/word-multiplayer-games.md` covering the overview, player-list sync approach, host-stealing bug fix, embedded-game top-padding fix, and ← Lobby routing pattern

## Test Plan

- [ ] Run `cd documentation && pnpm start` and verify both pages render without errors
- [ ] Check the Guides sidebar shows "Adding a Game to the Lobby" under the correct category
- [ ] Check the Journey page for Word Multiplayer Games includes the new Games Lobby section

🤖 Generated with [Claude Code](https://claude.com/claude-code)