### PR TITLE
fix: Pictionary overflow, canvas P2P fill/undo/redo, collapsible lobby sections

### DIFF
--- a/packages/canvas-editor/src/drawing.ts
+++ b/packages/canvas-editor/src/drawing.ts
@@ -17,6 +17,11 @@ export interface StrokeEvent {
   options: DrawingOptions
 }
 
+export interface FillEvent {
+  point: DrawingPoint
+  color: string
+}
+
 /**
  * Draw a stroke segment between two points on the canvas.
  * @param ctx - 2D rendering context

--- a/packages/canvas-editor/src/index.ts
+++ b/packages/canvas-editor/src/index.ts
@@ -1,5 +1,5 @@
 export { drawingStroke, drawingDot, drawingFill, drawingClear, drawingRestore } from './drawing'
-export type { DrawingTool, DrawingOptions, DrawingPoint, StrokeEvent } from './drawing'
+export type { DrawingTool, DrawingOptions, DrawingPoint, StrokeEvent, FillEvent } from './drawing'
 
 export {
   historyCreate,

--- a/src/components/CanvasEditor/CanvasEditor.vue
+++ b/src/components/CanvasEditor/CanvasEditor.vue
@@ -3,7 +3,7 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import CanvasEditorCanvas from './CanvasEditorCanvas.vue'
 import CanvasEditorTools from './CanvasEditorTools.vue'
 import { storageLoad } from '@webgamekit/canvas-editor'
-import type { DrawingTool, DrawingOptions, StrokeEvent } from '@webgamekit/canvas-editor'
+import type { DrawingTool, DrawingOptions, StrokeEvent, FillEvent } from '@webgamekit/canvas-editor'
 import type { CanvasEditorToolButton } from './types'
 
 const props = withDefaults(
@@ -40,6 +40,9 @@ const emit = defineEmits<{
   'update:size': [value: number]
   change: [dataUrl: string]
   stroke: [event: StrokeEvent]
+  fill: [event: FillEvent]
+  undo: [dataUrl: string]
+  redo: [dataUrl: string]
   clear: []
 }>()
 
@@ -91,6 +94,18 @@ const handleStroke = (event: StrokeEvent): void => {
   emit('stroke', event)
 }
 
+const handleFill = (event: FillEvent): void => {
+  emit('fill', event)
+}
+
+const handleUndo = (dataUrl: string): void => {
+  emit('undo', dataUrl)
+}
+
+const handleRedo = (dataUrl: string): void => {
+  emit('redo', dataUrl)
+}
+
 const handleHistoryChange = (state: { canUndo: boolean; canRedo: boolean }): void => {
   canUndo.value = state.canUndo
   canRedo.value = state.canRedo
@@ -113,6 +128,7 @@ const handleSizeUpdate = (value: number): void => {
 
 const undo = (): Promise<void> | undefined => canvasEditorCanvasReference.value?.undo()
 const redo = (): Promise<void> | undefined => canvasEditorCanvasReference.value?.redo()
+
 const clear = (): void => {
   canvasEditorCanvasReference.value?.clear()
   emit('clear')
@@ -122,8 +138,11 @@ defineExpose({
   snapshot: (): string => canvasEditorCanvasReference.value?.snapshot() ?? '',
   restore: (dataUrl: string, options?: { silent?: boolean }): Promise<void> =>
     canvasEditorCanvasReference.value?.restore(dataUrl, options) ?? Promise.resolve(),
+  silentRestore: (dataUrl: string): Promise<void> =>
+    canvasEditorCanvasReference.value?.silentRestore(dataUrl) ?? Promise.resolve(),
   renderSegment: (event: StrokeEvent): void =>
     canvasEditorCanvasReference.value?.renderSegment(event),
+  renderFill: (event: FillEvent): void => canvasEditorCanvasReference.value?.renderFill(event),
   silentClear: (): void => canvasEditorCanvasReference.value?.silentClear()
 })
 
@@ -168,6 +187,9 @@ onUnmounted(() => {
       @change="handleChange"
       @history-change="handleHistoryChange"
       @stroke="handleStroke"
+      @fill="handleFill"
+      @undo="handleUndo"
+      @redo="handleRedo"
     />
     <CanvasEditorTools
       v-if="showTools"

--- a/src/components/CanvasEditor/CanvasEditorCanvas.vue
+++ b/src/components/CanvasEditor/CanvasEditorCanvas.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { useCanvasEditor } from './useCanvasEditor'
-import type { DrawingOptions, StrokeEvent } from '@webgamekit/canvas-editor'
+import type { DrawingOptions, StrokeEvent, FillEvent } from '@webgamekit/canvas-editor'
 
 const props = withDefaults(
   defineProps<{
@@ -18,6 +18,9 @@ const emit = defineEmits<{
   change: [dataUrl: string]
   historyChange: [{ canUndo: boolean; canRedo: boolean }]
   stroke: [event: StrokeEvent]
+  fill: [event: FillEvent]
+  undo: [dataUrl: string]
+  redo: [dataUrl: string]
 }>()
 
 const canvasReference = ref<HTMLCanvasElement | null>(null)
@@ -47,7 +50,17 @@ const handleStroke = (event: StrokeEvent): void => {
   emit('stroke', event)
 }
 
-const editor = useCanvasEditor(canvasReference, optionsReference, emitChange, handleStroke)
+const handleFill = (event: FillEvent): void => {
+  emit('fill', event)
+}
+
+const editor = useCanvasEditor(
+  canvasReference,
+  optionsReference,
+  emitChange,
+  handleStroke,
+  handleFill
+)
 
 const updateCursor = (event: MouseEvent): void => {
   if (!canvasReference.value) return
@@ -90,14 +103,26 @@ const onTouchMove = (event: TouchEvent): void => {
 
 const snapshot = (): string => canvasReference.value?.toDataURL() ?? ''
 
+const undo = async (): Promise<void> => {
+  await editor.undo()
+  emit('undo', snapshot())
+}
+
+const redo = async (): Promise<void> => {
+  await editor.redo()
+  emit('redo', snapshot())
+}
+
 defineExpose({
-  undo: editor.undo,
-  redo: editor.redo,
+  undo,
+  redo,
   clear: editor.clear,
   silentClear: editor.silentClear,
   restore: editor.restore,
+  silentRestore: editor.silentRestore,
   snapshot,
-  renderSegment: editor.renderSegment
+  renderSegment: editor.renderSegment,
+  renderFill: editor.renderFill
 })
 </script>
 

--- a/src/components/CanvasEditor/useCanvasEditor.ts
+++ b/src/components/CanvasEditor/useCanvasEditor.ts
@@ -17,6 +17,7 @@ import type {
   DrawingOptions,
   DrawingPoint,
   StrokeEvent,
+  FillEvent,
   HistoryStack
 } from '@webgamekit/canvas-editor'
 
@@ -78,6 +79,7 @@ type EditorContext = {
   history: ReturnType<typeof useHistory>
   onUpdate: () => void
   onStrokeCallback?: (event: StrokeEvent) => void
+  onFillCallback?: (event: FillEvent) => void
 }
 
 const getContext = (ctx: EditorContext): CanvasRenderingContext2D | null =>
@@ -91,6 +93,7 @@ const startDrawing = (ctx: EditorContext, point: DrawingPoint): void => {
   if (ctx.options.value.tool === 'fill') {
     ctx.history.push()
     drawingFill(renderContext, point, ctx.options.value.color)
+    ctx.onFillCallback?.({ point, color: ctx.options.value.color })
     ctx.onUpdate()
     ctx.isDrawing.value = false
     return
@@ -121,12 +124,14 @@ const finishDrawing = (ctx: EditorContext): void => {
  * @param options - Reactive drawing options (tool, color, size)
  * @param onUpdate - Callback fired after any operation that changes the canvas
  * @param onStrokeCallback - Optional callback fired per stroke segment
+ * @param onFillCallback - Optional callback fired when a fill is applied
  */
 export const useCanvasEditor = (
   canvasReference: Ref<HTMLCanvasElement | null>,
   options: Ref<DrawingOptions>,
   onUpdate: () => void,
-  onStrokeCallback?: (event: StrokeEvent) => void
+  onStrokeCallback?: (event: StrokeEvent) => void,
+  onFillCallback?: (event: FillEvent) => void
 ) => {
   const snapshot = (): string => canvasReference.value?.toDataURL() ?? ''
   const history = useHistory(snapshot)
@@ -137,13 +142,26 @@ export const useCanvasEditor = (
     lastPoint: ref({ x: 0, y: 0 }),
     history,
     onUpdate,
-    onStrokeCallback
+    onStrokeCallback,
+    onFillCallback
   }
 
   const renderSegment = (event: StrokeEvent): void => {
     const renderContext = getContext(ctx)
     if (!renderContext) return
     drawingStroke(renderContext, event.from, event.to, event.options)
+  }
+
+  const renderFill = (event: FillEvent): void => {
+    const renderContext = getContext(ctx)
+    if (!renderContext) return
+    drawingFill(renderContext, event.point, event.color)
+  }
+
+  const silentRestore = async (dataUrl: string): Promise<void> => {
+    const renderContext = getContext(ctx)
+    if (!renderContext) return
+    await drawingRestore(renderContext, dataUrl)
   }
 
   const undo = async (): Promise<void> => {
@@ -185,6 +203,8 @@ export const useCanvasEditor = (
     canRedo: history.canRedo,
     snapshot,
     renderSegment,
+    renderFill,
+    silentRestore,
     onPointerDown: (event: MouseEvent): void =>
       startDrawing(ctx, getCanvasPoint(event, canvasReference)),
     onPointerMove: (event: MouseEvent): void =>

--- a/src/views/Games/Lobby/Lobby.vue
+++ b/src/views/Games/Lobby/Lobby.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, watch, defineAsyncComponent } from 'vue'
+import { ref, computed, onMounted, watch, defineAsyncComponent, storeToRefs } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Check } from 'lucide-vue-next'
 import {
@@ -17,6 +17,7 @@ import { useWordleMultiplayerStore } from '@/stores/wordleMultiplayer'
 import LobbyChat from './LobbyChat.vue'
 import LobbyPresence from './LobbyPresence.vue'
 import LobbyRoomList from './LobbyRoomList.vue'
+import { useLobbyStore } from '@/stores/lobby'
 import type { GameType, LobbyRoom } from '@/types/lobby'
 import { GAME_LABELS, GAME_TYPES } from './constants'
 
@@ -123,6 +124,15 @@ const handleJoin = (room: LobbyRoom): void => {
   if (ownRoom.value) closeRoom()
   router.replace({ query: { game: room.game, room: room.id } })
 }
+
+const lobbyStore = useLobbyStore()
+const { players: lobbyPlayers, rooms: lobbyRooms } = storeToRefs(lobbyStore)
+const onlineCount = computed(() => Object.keys(lobbyPlayers.value).length)
+const roomCount = computed(() => Object.keys(lobbyRooms.value).length)
+
+const profileOpen = ref(true)
+const presenceOpen = ref(true)
+const roomsOpen = ref(true)
 </script>
 
 <template>
@@ -152,41 +162,75 @@ const handleJoin = (room: LobbyRoom): void => {
     <!-- Sidebar — hidden when a game is active -->
     <aside v-if="!activeComponent" class="lobby__sidebar">
       <!-- Profile -->
-      <div class="lobby__profile">
-        <input
-          v-model="playerName"
-          class="lobby__name-input"
-          type="text"
-          maxlength="20"
-          placeholder="Your name"
-          @change="handleNameCommit"
-          @blur="handleNameCommit"
-        />
-        <div class="lobby__swatches">
-          <button
-            v-for="color in PLAYER_COLORS"
-            :key="color"
-            class="lobby__swatch"
-            :class="{ 'lobby__swatch--active': playerColor === color }"
-            :style="{ background: color }"
-            type="button"
-            @click="handleColorPick(color)"
+      <div class="lobby__section" :class="{ 'lobby__section--collapsed': !profileOpen }">
+        <button class="lobby__section-toggle" type="button" @click="profileOpen = !profileOpen">
+          <span class="lobby__section-label">Profile</span>
+          <span
+            class="lobby__section-chevron"
+            :class="{ 'lobby__section-chevron--open': profileOpen }"
+            >›</span
           >
-            <Check v-if="playerColor === color" class="lobby__swatch-check" />
-          </button>
+        </button>
+        <div v-show="profileOpen" class="lobby__profile">
+          <input
+            v-model="playerName"
+            class="lobby__name-input"
+            type="text"
+            maxlength="20"
+            placeholder="Your name"
+            @change="handleNameCommit"
+            @blur="handleNameCommit"
+          />
+          <div class="lobby__swatches">
+            <button
+              v-for="color in PLAYER_COLORS"
+              :key="color"
+              class="lobby__swatch"
+              :class="{ 'lobby__swatch--active': playerColor === color }"
+              :style="{ background: color }"
+              type="button"
+              @click="handleColorPick(color)"
+            >
+              <Check v-if="playerColor === color" class="lobby__swatch-check" />
+            </button>
+          </div>
         </div>
       </div>
 
       <!-- Presence -->
-      <LobbyPresence :local-peer-id="localPeerId" />
+      <div class="lobby__section" :class="{ 'lobby__section--collapsed': !presenceOpen }">
+        <button class="lobby__section-toggle" type="button" @click="presenceOpen = !presenceOpen">
+          <span class="lobby__section-label">Online ({{ onlineCount }})</span>
+          <span
+            class="lobby__section-chevron"
+            :class="{ 'lobby__section-chevron--open': presenceOpen }"
+            >›</span
+          >
+        </button>
+        <div v-show="presenceOpen">
+          <LobbyPresence :local-peer-id="localPeerId" />
+        </div>
+      </div>
 
       <!-- Rooms -->
-      <LobbyRoomList
-        :local-peer-id="localPeerId"
-        :own-room-id="ownRoomId"
-        @join="handleJoin"
-        @toggle="toggleRoomVisibility"
-      />
+      <div class="lobby__section" :class="{ 'lobby__section--collapsed': !roomsOpen }">
+        <button class="lobby__section-toggle" type="button" @click="roomsOpen = !roomsOpen">
+          <span class="lobby__section-label">Rooms ({{ roomCount }})</span>
+          <span
+            class="lobby__section-chevron"
+            :class="{ 'lobby__section-chevron--open': roomsOpen }"
+            >›</span
+          >
+        </button>
+        <div v-show="roomsOpen">
+          <LobbyRoomList
+            :local-peer-id="localPeerId"
+            :own-room-id="ownRoomId"
+            @join="handleJoin"
+            @toggle="toggleRoomVisibility"
+          />
+        </div>
+      </div>
 
       <!-- Chat -->
       <div class="lobby__chat">
@@ -316,9 +360,45 @@ const handleJoin = (room: LobbyRoom): void => {
   padding-top: var(--nav-height);
 }
 
-.lobby__profile {
-  padding: var(--spacing-2) var(--spacing-3);
+.lobby__section {
   border-bottom: 3px solid #111;
+}
+
+.lobby__section-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-2) var(--spacing-3);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  gap: var(--spacing-2);
+}
+
+.lobby__section-label {
+  font-size: var(--font-size-xs);
+  font-weight: 800;
+  color: var(--color-muted-foreground);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.lobby__section-chevron {
+  font-size: var(--font-size-sm);
+  color: var(--color-muted-foreground);
+  transition: transform 0.15s ease;
+  transform: rotate(90deg);
+  display: inline-block;
+}
+
+.lobby__section-chevron--open {
+  transform: rotate(270deg);
+}
+
+.lobby__profile {
+  padding: 0 var(--spacing-3) var(--spacing-2);
   display: flex;
   flex-direction: column;
   gap: var(--spacing-1);

--- a/src/views/Games/Lobby/Lobby.vue
+++ b/src/views/Games/Lobby/Lobby.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, watch, defineAsyncComponent, storeToRefs } from 'vue'
+import { ref, computed, onMounted, watch, defineAsyncComponent } from 'vue'
+import { storeToRefs } from 'pinia'
 import { useRoute, useRouter } from 'vue-router'
 import { Check } from 'lucide-vue-next'
 import {

--- a/src/views/Games/Lobby/LobbyPresence.vue
+++ b/src/views/Games/Lobby/LobbyPresence.vue
@@ -9,7 +9,6 @@ const playerList = computed(() => Object.values(store.players))
 
 <template>
   <div class="lb-presence">
-    <h3 class="lb-presence__title">Online ({{ playerList.length }})</h3>
     <ul class="lb-presence__list">
       <li v-for="player in playerList" :key="player.id" class="lb-presence__player">
         <span class="lb-presence__dot" :style="{ background: player.color }" />
@@ -24,8 +23,7 @@ const playerList = computed(() => Object.values(store.players))
 
 <style scoped>
 .lb-presence {
-  padding: var(--spacing-3);
-  border-bottom: 3px solid #111;
+  padding: 0 var(--spacing-3) var(--spacing-2);
 }
 
 .lb-presence__title {

--- a/src/views/Games/Lobby/LobbyRoomList.vue
+++ b/src/views/Games/Lobby/LobbyRoomList.vue
@@ -13,7 +13,6 @@ const rooms = computed(() => Object.values(store.rooms))
 
 <template>
   <div class="lb-rooms">
-    <p class="lb-rooms__label">Rooms</p>
     <ul v-if="rooms.length" class="lb-rooms__list">
       <li v-for="room in rooms" :key="room.id">
         <LobbyRoomCard
@@ -30,19 +29,10 @@ const rooms = computed(() => Object.values(store.rooms))
 
 <style scoped>
 .lb-rooms {
-  padding: var(--spacing-2) var(--spacing-3);
+  padding: 0 var(--spacing-3) var(--spacing-2);
   display: flex;
   flex-direction: column;
   gap: var(--spacing-1);
-}
-
-.lb-rooms__label {
-  margin: 0;
-  font-size: var(--font-size-xs);
-  font-weight: 800;
-  color: var(--color-muted-foreground);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
 }
 
 .lb-rooms__list {

--- a/src/views/Games/Pictionary/Pictionary.vue
+++ b/src/views/Games/Pictionary/Pictionary.vue
@@ -3,7 +3,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { usePictionaryStore } from '@/stores/pictionary'
-import type { StrokeEvent } from '@webgamekit/canvas-editor'
+import type { StrokeEvent, FillEvent } from '@webgamekit/canvas-editor'
 import { usePictionarySession } from './usePictionarySession'
 import { usePictionaryTimer } from './usePictionaryTimer'
 import {
@@ -71,6 +71,8 @@ const session = usePictionarySession({
   color: playerColor.value,
   roomId: resolvedRoomId,
   onRemoteStroke: (payload) => drawingReference.value?.renderSegment(payload),
+  onRemoteFill: (payload) => drawingReference.value?.renderFill(payload),
+  onRemoteRestore: (dataUrl) => drawingReference.value?.silentRestore(dataUrl),
   onRemoteClear: () => drawingReference.value?.silentClear()
 })
 
@@ -130,6 +132,14 @@ const handleStroke = (event: StrokeEvent): void => {
   session.broadcastStroke(event)
 }
 
+const handleFill = (event: FillEvent): void => {
+  session.broadcastFill(event)
+}
+
+const handleUndoRedo = (dataUrl: string): void => {
+  session.broadcastCanvasRestore(dataUrl)
+}
+
 onMounted(() => {
   session.init()
 })
@@ -184,6 +194,9 @@ onMounted(() => {
       :total-rounds="totalRounds"
       :time-left="timeLeft"
       @stroke="handleStroke"
+      @fill="handleFill"
+      @undo="handleUndoRedo"
+      @redo="handleUndoRedo"
       @clear="session.broadcastClear()"
     />
 
@@ -229,14 +242,21 @@ onMounted(() => {
   display: grid;
   grid-template-columns: 1fr 320px;
   grid-template-areas: 'header header' 'main sidebar';
-  grid-template-rows: auto 1fr;
+  grid-template-rows: auto minmax(0, 1fr);
   gap: var(--spacing-3);
   padding: var(--spacing-3);
   padding-top: calc(var(--nav-height) + var(--spacing-3));
-  min-height: 100vh;
+  height: 100dvh;
   box-sizing: border-box;
+  overflow: hidden;
   background: #fff7e6;
   font-family: 'Comic Sans MS', 'Chalkboard SE', 'Marker Felt', cursive, system-ui;
+}
+
+.pictionary--lobby {
+  height: auto;
+  min-height: 100dvh;
+  overflow: auto;
 }
 
 @media (max-width: 720px) {

--- a/src/views/Games/Pictionary/PictionaryDrawing.vue
+++ b/src/views/Games/Pictionary/PictionaryDrawing.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import type { StrokeEvent } from '@webgamekit/canvas-editor'
+import type { StrokeEvent, FillEvent } from '@webgamekit/canvas-editor'
 import { dictionaryGetDefinition } from '@webgamekit/dictionary'
 import { CanvasEditor } from '@/components/CanvasEditor'
 
@@ -15,6 +15,9 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   stroke: [event: StrokeEvent]
+  fill: [event: FillEvent]
+  undo: [dataUrl: string]
+  redo: [dataUrl: string]
   clear: []
 }>()
 
@@ -26,7 +29,9 @@ const wordDefinition = computed(() =>
 
 defineExpose({
   renderSegment: (payload: StrokeEvent) => canvasEditorReference.value?.renderSegment(payload),
-  silentClear: () => canvasEditorReference.value?.silentClear()
+  renderFill: (payload: FillEvent) => canvasEditorReference.value?.renderFill(payload),
+  silentClear: () => canvasEditorReference.value?.silentClear(),
+  silentRestore: (dataUrl: string) => canvasEditorReference.value?.silentRestore(dataUrl)
 })
 </script>
 
@@ -57,6 +62,9 @@ defineExpose({
       :canvas-height="400"
       disable-storage
       @stroke="emit('stroke', $event)"
+      @fill="emit('fill', $event)"
+      @undo="emit('undo', $event)"
+      @redo="emit('redo', $event)"
       @clear="emit('clear')"
     />
   </section>

--- a/src/views/Games/Pictionary/usePictionarySession.ts
+++ b/src/views/Games/Pictionary/usePictionarySession.ts
@@ -16,7 +16,7 @@ import {
   type ChatMessage
 } from '@webgamekit/chat'
 import { dictionaryPickRandom, type DictionaryDifficulty } from '@webgamekit/dictionary'
-import type { StrokeEvent } from '@webgamekit/canvas-editor'
+import type { StrokeEvent, FillEvent } from '@webgamekit/canvas-editor'
 import { usePictionaryStore, type PictionaryPlayer } from '@/stores/pictionary'
 
 const INTERMISSION_MS = 10_000
@@ -28,6 +28,8 @@ const POINTS_DRAWER_PER_GUESS = 25
 const POINTS_MINIMUM = 10
 const CHAT_CHANNEL = 'chat'
 const STROKE_CHANNEL = 'stroke'
+const FILL_CHANNEL = 'fill'
+const CANVAS_RESTORE_CHANNEL = 'canvas-restore'
 const CLEAR_CHANNEL = 'clear'
 const ROUND_CHOICES_CHANNEL = 'round-choices'
 const ROUND_CHANNEL = 'round'
@@ -80,6 +82,8 @@ type UsePictionarySessionOptions = {
   color: string
   roomId: string
   onRemoteStroke: (payload: PictionaryStrokePayload) => void
+  onRemoteFill: (payload: FillEvent) => void
+  onRemoteRestore: (dataUrl: string) => void
   onRemoteClear: () => void
 }
 
@@ -332,6 +336,14 @@ const bindDrawingEvents = (ctx: PictionaryContext, joined: P2PSession): void => 
     if (peerId !== ctx.store.round.drawerId) return
     ctx.options.onRemoteStroke(payload)
   })
+  p2pOnData<FillEvent>(joined, FILL_CHANNEL, (payload, peerId) => {
+    if (peerId !== ctx.store.round.drawerId) return
+    ctx.options.onRemoteFill(payload)
+  })
+  p2pOnData<{ dataUrl: string }>(joined, CANVAS_RESTORE_CHANNEL, (payload, peerId) => {
+    if (peerId !== ctx.store.round.drawerId) return
+    ctx.options.onRemoteRestore(payload.dataUrl)
+  })
   p2pOnData<{ ts: number }>(joined, CLEAR_CHANNEL, (_payload, peerId) => {
     if (peerId !== ctx.store.round.drawerId) return
     ctx.options.onRemoteClear()
@@ -387,6 +399,16 @@ const bindRoundEvents = (ctx: PictionaryContext, joined: P2PSession): void => {
     }
   })
   p2pOnData<{ ts: number }>(joined, RESTART_CHANNEL, () => ctx.applyRestart())
+}
+
+const broadcastFillForContext = (ctx: PictionaryContext, payload: FillEvent): void => {
+  if (!ctx.session.value || !ctx.isDrawer.value) return
+  p2pSendData(ctx.session.value, FILL_CHANNEL, payload)
+}
+
+const broadcastCanvasRestoreForContext = (ctx: PictionaryContext, dataUrl: string): void => {
+  if (!ctx.session.value || !ctx.isDrawer.value) return
+  p2pSendData(ctx.session.value, CANVAS_RESTORE_CHANNEL, { dataUrl })
 }
 
 /**
@@ -483,6 +505,11 @@ export const usePictionarySession = (options: UsePictionarySessionOptions) => {
     p2pSendData(session.value, STROKE_CHANNEL, payload)
   }
 
+  const broadcastFill = (payload: FillEvent): void => broadcastFillForContext(ctx, payload)
+
+  const broadcastCanvasRestore = (dataUrl: string): void =>
+    broadcastCanvasRestoreForContext(ctx, dataUrl)
+
   const broadcastClear = (): void => {
     if (!session.value || !isDrawer.value) return
     p2pSendData(session.value, CLEAR_CHANNEL, { ts: Date.now() })
@@ -526,6 +553,8 @@ export const usePictionarySession = (options: UsePictionarySessionOptions) => {
     isDrawer,
     broadcastChat,
     broadcastStroke,
+    broadcastFill,
+    broadcastCanvasRestore,
     broadcastClear,
     startRound,
     pickWord,


### PR DESCRIPTION
Closes #108
Closes #109
Closes #110

## Summary

- **#108** — Pictionary standalone no longer overflows the bottom: root uses `height: 100dvh; overflow: hidden` with `minmax(0, 1fr)` grid row; `.pictionary--lobby` reverts to `height: auto; overflow: auto` for the scrollable lobby phase
- **#109** — Canvas editor fill, undo, and redo are now broadcast over P2P in Pictionary: `FillEvent` type added to `@webgamekit/canvas-editor`; fill sends point+color via `fill` channel; undo/redo send the resulting canvas snapshot via `canvas-restore` channel; receivers apply via `renderFill` / `silentRestore` (no history push on remote)
- **#110** — Lobby sidebar Profile, Online, and Rooms sections are now collapsible: each has a chevron toggle button that shows/hides the content with `v-show`; Online and Rooms labels include live counts

## Key Changes

- `packages/canvas-editor/src/drawing.ts` — added `FillEvent` interface
- `src/components/CanvasEditor/useCanvasEditor.ts` — `onFillCallback`, `renderFill`, `silentRestore`
- `src/components/CanvasEditor/CanvasEditorCanvas.vue` — emits `fill`, `undo`, `redo`; exposes `renderFill`, `silentRestore`
- `src/components/CanvasEditor/CanvasEditor.vue` — passes through new events and exposes new methods
- `src/views/Games/Pictionary/PictionaryDrawing.vue` — emits and exposes fill/undo/redo/silentRestore
- `src/views/Games/Pictionary/usePictionarySession.ts` — `fill` and `canvas-restore` P2P channels
- `src/views/Games/Lobby/Lobby.vue` — collapsible sections with toggle buttons and counts

## Test Plan

- [ ] Pictionary standalone: verify no bottom overflow on desktop across all phases
- [ ] Pictionary P2P: as drawer, use fill → verify other player's canvas updates
- [ ] Pictionary P2P: as drawer, undo/redo → verify other player's canvas matches
- [ ] Lobby sidebar: collapse and expand each of the three sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)