### PR TITLE
fix: canvas stretching in Pictionary drawing phase

### DIFF
--- a/src/views/Games/Pictionary/PictionaryDrawing.vue
+++ b/src/views/Games/Pictionary/PictionaryDrawing.vue
@@ -91,6 +91,8 @@ defineExpose({
 }
 
 .pictionary-drawing :deep(.canvas-editor-canvas) {
+  flex-grow: 0;
+  height: auto;
   border: 3px solid #111;
   border-radius: 1.25rem;
   box-shadow: 3px 3px 0 #111;


### PR DESCRIPTION
## Summary

After #111 changed `.pictionary` from `min-height:100vh` to `height:100dvh`, the grid has a fixed height. The `.canvas-editor-canvas` had `flex-grow:1` which in an unconstrained layout was fine, but in the fixed-height context it overrides `aspect-ratio` — the canvas container grows to fill all available vertical space and the 600×400 canvas stretches vertically.

Fix: add `flex-grow:0; height:auto` to the Pictionary deep selector for `.canvas-editor-canvas` so it sizes from `width:100%` + `aspect-ratio` instead of flex-grow.

## Test Plan

- [ ] Open Pictionary drawing phase — canvas should appear at correct 600:400 ratio, not stretched
- [ ] Verify the canvas still fills horizontal space correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)