### PR TITLE
fix: go to summary when last opponent leaves an active game

### DIFF
--- a/src/views/Games/Pictionary/usePictionarySession.ts
+++ b/src/views/Games/Pictionary/usePictionarySession.ts
@@ -307,6 +307,14 @@ const bindPeerEvents = (ctx: PictionaryContext, joined: P2PSession): void => {
       ctx.store.appendMessage(leaveMessage)
     }
     ctx.store.removePlayer(peerId)
+    const activePhase =
+      ctx.store.phase === 'choosing' ||
+      ctx.store.phase === 'drawing' ||
+      ctx.store.phase === 'intermission'
+    if (activePhase && Object.keys(ctx.store.players).length <= 1) {
+      ctx.store.winnerId = ctx.store.playerList[0]?.id ?? null
+      ctx.store.phase = 'summary'
+    }
   })
   p2pOnData<{ id: string }>(joined, HELLO_CHANNEL, () => {
     p2pSendData(joined, AVATAR_CHANNEL, { name: ctx.options.name, color: ctx.options.color })

--- a/src/views/Games/SquaresMultiplayer/useSquaresMultiplayerSession.ts
+++ b/src/views/Games/SquaresMultiplayer/useSquaresMultiplayerSession.ts
@@ -157,6 +157,11 @@ const bindPeerEvents = (ctx: WmContext, joined: P2PSession): void => {
       ctx.store.appendMessage(leaveMessage)
     }
     ctx.store.removePlayer(peerId)
+    const activePhase = ctx.store.phase === 'playing' || ctx.store.phase === 'intermission'
+    if (activePhase && Object.keys(ctx.store.players).length <= 1) {
+      ctx.store.winnerId = ctx.store.playerList[0]?.id ?? null
+      ctx.store.phase = 'summary'
+    }
   })
 
   p2pOnData<{ id: string }>(joined, HELLO_CHANNEL, () => {

--- a/src/views/Games/WordleMultiplayer/useWordleMultiplayerSession.ts
+++ b/src/views/Games/WordleMultiplayer/useWordleMultiplayerSession.ts
@@ -198,6 +198,11 @@ const bindPeerEvents = (ctx: WlContext, joined: P2PSession): void => {
       ctx.store.appendMessage(leaveMessage)
     }
     ctx.store.removePlayer(peerId)
+    const activePhase = ctx.store.phase === 'playing' || ctx.store.phase === 'intermission'
+    if (activePhase && Object.keys(ctx.store.players).length <= 1) {
+      ctx.store.winnerId = ctx.store.playerList[0]?.id ?? null
+      ctx.store.phase = 'summary'
+    }
   })
 
   p2pOnData<{ id: string }>(joined, HELLO_CHANNEL, () => {


### PR DESCRIPTION
## Summary

All three multiplayer games (Pictionary, Squares, Wordle) called `removePlayer` on peer leave but never checked whether the local player was now alone. If every remote player quit during an active phase, the game froze with no way to proceed.

After each `removePlayer`, the sessions now check:
- Is the phase active? (`playing` / `drawing` / `choosing` / `intermission`)
- Is only one player (the local user) left in `store.players`?

If both are true, the game immediately transitions to `summary` with the current scores so the remaining player can see the results and optionally restart.

## Test Plan

- [ ] Start a game with 2 players; have one close the tab during play — the other should see the summary screen
- [ ] Verify that the summary shows the correct scores for all players who participated
- [ ] Verify the Restart button works after landing on summary via this path

🤖 Generated with [Claude Code](https://claude.com/claude-code)