### PR TITLE
feat: skip matchmaking step in wizard when launched from Lobby

### DIFF
--- a/src/components/GameLobbyWizard.vue
+++ b/src/components/GameLobbyWizard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, useSlots } from 'vue'
+import { useRoute } from 'vue-router'
 import { Check } from 'lucide-vue-next'
 import GameCard from '@/components/GameCard.vue'
 import { useGameLobby } from '@/composables/useGameLobby'
@@ -28,8 +29,17 @@ const emit = defineEmits<{
   leaveRoom: []
 }>()
 
+const route = useRoute()
+const fromLobby = computed(() => !!route.query.game)
+
 const step = ref(1)
-const totalSteps = computed(() => (props.isHost ? 3 : 2))
+// From lobby: matchmaking step is skipped. Host: profile + settings (2). Guest: profile only (1).
+const totalSteps = computed(() => {
+  if (fromLobby.value) return props.isHost ? 2 : 1
+  return props.isHost ? 3 : 2
+})
+// Maps visual step to content slot: when fromLobby, step 2 shows settings (slot 3).
+const contentStep = computed(() => (fromLobby.value && step.value === 2 ? 3 : step.value))
 const required = computed(() => props.minPlayers ?? 2)
 
 const {
@@ -52,7 +62,10 @@ const handleAccept = (entry: Parameters<typeof acceptRequest>[0]): void => {
 }
 
 const canGoNext = computed(() => {
-  if (step.value === 2 && props.isHost) return props.playerList.length >= required.value
+  // Require minimum players only on the matchmaking step (step 2 when NOT from lobby)
+  if (step.value === 2 && props.isHost && !fromLobby.value) {
+    return props.playerList.length >= required.value
+  }
   return step.value < totalSteps.value
 })
 
@@ -97,7 +110,7 @@ watch(
       </div>
 
       <!-- Step 1: Profile -->
-      <div v-if="step === 1" class="glw__body">
+      <div v-if="contentStep === 1" class="glw__body">
         <h3 class="glw__step-title">Your profile</h3>
         <input
           :value="playerName"
@@ -126,8 +139,8 @@ watch(
         </div>
       </div>
 
-      <!-- Step 2: Matchmaker (host) / Waiting (guest) -->
-      <div v-else-if="step === 2" class="glw__body">
+      <!-- Step 2: Matchmaker (host) / Waiting (guest) — skipped when fromLobby -->
+      <div v-else-if="contentStep === 2" class="glw__body">
         <template v-if="isHost">
           <h3 class="glw__step-title">Find players</h3>
           <div class="glw__players">
@@ -242,8 +255,8 @@ watch(
         </template>
       </div>
 
-      <!-- Step 3: Settings (host only) -->
-      <div v-else-if="step === 3" class="glw__body">
+      <!-- Step 3: Settings (host only) — also shown as step 2 when fromLobby -->
+      <div v-else-if="contentStep === 3" class="glw__body">
         <h3 class="glw__step-title">Game settings</h3>
         <div class="glw__players">
           <span class="glw__player-count">{{ playerList.length }} players ready</span>


### PR DESCRIPTION
## Summary

When a game is opened from the Games Lobby (`route.query.game` is set), the P2P room already exists and players are already connected. The "Find Players" / "Waiting for host" wizard step serves no purpose in this context.

**Before:** Profile → Find Players/Waiting (step 2) → Settings (step 3, host only)
**After (from Lobby):** Profile → Settings (step 2, host only) — guest sees profile only

## How it works

- `fromLobby` computed detects `route.query.game` inside the wizard (no new props needed)
- `totalSteps`: host gets 2, guest gets 1 when from Lobby
- `contentStep`: maps visual step 2 → settings content (was slot 3) when from Lobby
- `canGoNext`: player-count gate is skipped when from Lobby (players are already in the room)
- Applies to all three games (Pictionary, Squares, Wordle) via the shared `GameLobbyWizard`

## Test Plan

- [ ] Open a game from the Lobby as host — should see Profile → Settings (no matchmaking step)
- [ ] Open a game from the Lobby as guest — should see Profile only, host starts the game
- [ ] Open a game standalone (not from Lobby) — original 3-step/2-step flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)