### PR TITLE
fix: remove double border between rooms section and chat in Lobby

### DIFF
--- a/src/views/Games/Lobby/Lobby.vue
+++ b/src/views/Games/Lobby/Lobby.vue
@@ -453,7 +453,6 @@ const roomsOpen = ref(true)
 .lobby__chat {
   flex: 1;
   min-height: 0;
-  border-top: 3px solid #111;
   display: flex;
   flex-direction: column;
   overflow: hidden;


### PR DESCRIPTION
## Summary

`.lobby__section` has `border-bottom: 3px solid #111` and `.lobby__chat` had a redundant `border-top: 3px solid #111` — the two borders stacked into a visible 6px double line between the Rooms section and the Chat.

Removed `border-top` from `.lobby__chat` since the section above already provides the separator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)