### PR TITLE
feat: dark mode, directional transitions, and UX polish for multiplayer lobby

### DIFF
--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -1,6 +1,52 @@
 // Design System Variables
 // CSS custom properties for theming support
 
+// ── Game UI tokens ───────────────────────────────────────────────────────────
+// Light mode defaults; overridden in the dark-mode block below.
+:root {
+  --game-ink: #111;
+  --game-ink-medium: #555;
+  --game-ink-muted: #888;
+  --game-border: rgba(0, 0, 0, 0.28);
+  --game-surface: #fff;
+  --game-surface-subtle: #f5f5f5;
+  --game-surface-dim: #f0f0f0;
+  --game-border-secondary: #ccc;
+  --game-border-light: #ddd;
+
+  --lb-bg: #fff7e6;
+  --lb-sidebar-bg: #fffbf0;
+  --lb-card-hover: #ffefc0;
+  --pic-bg: #fff7e6;
+  --wm-bg: #f0fff4;
+  --wl-bg: #f9f9f9;
+
+  --game-msg-system-bg: #fff4c2;
+  --game-msg-error-bg: #ffeaea;
+}
+
+@keyframes slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-from-right {
+  from {
+    opacity: 0;
+    transform: translateX(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
 :root {
   // Light theme (default)
   --color-background: hsl(0 0% 100%);
@@ -101,6 +147,26 @@
 // Dark theme - manual toggle
 .dark,
 [data-theme='dark'] {
+  --game-ink: #e0d5c0;
+  --game-ink-medium: #b0a590;
+  --game-ink-muted: #7a6e60;
+  --game-border: rgba(255, 240, 220, 0.22);
+  --game-surface: #262218;
+  --game-surface-subtle: #2e2820;
+  --game-surface-dim: #222016;
+  --game-border-secondary: #4a4035;
+  --game-border-light: #3a3028;
+
+  --lb-bg: #1c1812;
+  --lb-sidebar-bg: #161210;
+  --lb-card-hover: #252015;
+  --pic-bg: #1c1812;
+  --wm-bg: #0d1a10;
+  --wl-bg: #181818;
+
+  --game-msg-system-bg: #2a2208;
+  --game-msg-error-bg: #2a0d0d;
+
   --panel-item-bg: hsl(0 0% 12%);
   --panel-item-bg-hover: hsl(0 0% 18%);
   --panel-item-bg-selected: hsl(0 0% 22%);
@@ -133,6 +199,25 @@
 // Dark theme - system preference auto-detection
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme='light']) {
+    --game-ink: #e0d5c0;
+    --game-ink-medium: #b0a590;
+    --game-ink-muted: #7a6e60;
+    --game-border: rgba(255, 240, 220, 0.22);
+    --game-surface: #262218;
+    --game-surface-subtle: #2e2820;
+    --game-surface-dim: #222016;
+    --game-border-secondary: #4a4035;
+    --game-border-light: #3a3028;
+
+    --lb-bg: #1c1812;
+    --lb-sidebar-bg: #161210;
+    --lb-card-hover: #252015;
+    --pic-bg: #1c1812;
+    --wm-bg: #0d1a10;
+    --wl-bg: #181818;
+
+    --game-msg-system-bg: #2a2208;
+    --game-msg-error-bg: #2a0d0d;
     --panel-item-bg: hsl(0 0% 12%);
     --panel-item-bg-hover: hsl(0 0% 18%);
     --panel-item-bg-selected: hsl(0 0% 22%);

--- a/src/components/GameCard.vue
+++ b/src/components/GameCard.vue
@@ -4,11 +4,11 @@
 
 <style scoped>
 .game-card {
-  background: #fff;
-  border: 3px solid #111;
+  background: var(--game-surface-subtle);
+  border: 3px solid var(--game-border);
   border-radius: 1.25rem;
-  box-shadow: 4px 4px 0 #111;
+  box-shadow: 4px 4px 0 var(--game-border);
   box-sizing: border-box;
-  color: #111;
+  color: var(--game-ink);
 }
 </style>

--- a/src/components/GameLobbyWizard.vue
+++ b/src/components/GameLobbyWizard.vue
@@ -357,16 +357,16 @@ watch(
   width: 0.5rem;
   height: 0.5rem;
   border-radius: 50%;
-  background: #ddd;
-  border: 2px solid #ccc;
+  background: var(--game-border-light);
+  border: 2px solid var(--game-border-secondary);
   transition:
     background 0.15s ease,
     border-color 0.15s ease;
 }
 
 .glw__step-dot--active {
-  background: #111;
-  border-color: #111;
+  background: var(--game-ink);
+  border-color: var(--game-border);
 }
 
 .glw__step-dot--done {
@@ -384,16 +384,16 @@ watch(
   margin: 0;
   font-size: var(--font-size-md, 1rem);
   font-weight: 800;
-  color: #111;
+  color: var(--game-ink);
 }
 
 .glw__name-input,
 .glw__name-input:focus {
   padding: var(--spacing-2) var(--spacing-3);
-  border: 3px solid #111;
+  border: 3px solid var(--game-border);
   border-radius: 999px;
-  background: #fff;
-  color: #111;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
   font-size: var(--font-size-md, 1rem);
   font-weight: 700;
   outline: none;
@@ -410,11 +410,11 @@ watch(
 .glw__swatch-btn {
   width: 2rem;
   height: 2rem;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 50%;
   cursor: pointer;
   padding: 0;
-  box-shadow: 2px 2px 0 #111;
+  box-shadow: 2px 2px 0 var(--game-border);
   transition: transform 0.1s ease;
   display: inline-flex;
   align-items: center;
@@ -425,7 +425,7 @@ watch(
 
 .glw__swatch-btn:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
 }
 
 .glw__swatch-check {
@@ -441,7 +441,7 @@ watch(
   gap: var(--spacing-2);
   font-size: var(--font-size-sm);
   font-weight: 700;
-  color: #111;
+  color: var(--game-ink);
 }
 
 .glw__player-count {
@@ -453,7 +453,7 @@ watch(
   width: 0.875rem;
   height: 0.875rem;
   border-radius: 50%;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   flex-shrink: 0;
 }
 
@@ -461,7 +461,7 @@ watch(
   margin: 0;
   font-size: var(--font-size-sm);
   font-weight: 700;
-  color: #555;
+  color: var(--game-ink-medium);
 }
 
 .glw__actions {
@@ -476,7 +476,7 @@ watch(
   gap: 0.1em;
   font-size: var(--font-size-sm);
   font-weight: 700;
-  color: #111;
+  color: var(--game-ink);
 }
 
 @keyframes glw-bounce {
@@ -517,16 +517,16 @@ watch(
   align-items: center;
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-3);
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 999px;
-  background: #f0fff4;
+  background: var(--game-surface-subtle);
 }
 
 .glw__request-name {
   flex: 1;
   font-size: var(--font-size-sm);
   font-weight: 700;
-  color: #111;
+  color: var(--game-ink);
 }
 
 .glw__request-actions {
@@ -551,7 +551,7 @@ watch(
 .glw__settings-label {
   font-size: var(--font-size-xs);
   font-weight: 700;
-  color: #555;
+  color: var(--game-ink-medium);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -560,7 +560,7 @@ watch(
   margin: 0;
   font-size: var(--font-size-sm);
   font-weight: 700;
-  color: #111;
+  color: var(--game-ink);
 }
 
 .glw__fields {
@@ -575,40 +575,41 @@ watch(
   flex-direction: column;
   gap: var(--spacing-1);
   font-size: var(--font-size-xs);
-  color: #111;
+  color: var(--game-ink);
   font-weight: 700;
 }
 
 .glw__field select,
 .glw__field input {
   padding: var(--spacing-1) var(--spacing-2);
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: var(--radius-sm);
-  background: #fff;
-  color: #111;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
   font-size: var(--font-size-sm);
   font-weight: 600;
 }
 
 .glw__btn {
   padding: var(--spacing-1) var(--spacing-3);
-  border: 2px solid #111;
+  border: 1px solid var(--game-border-secondary);
   border-radius: 999px;
   background: var(--glw-accent);
   color: #fff;
   font-size: var(--font-size-sm);
   font-weight: 700;
   cursor: pointer;
-  box-shadow: 2px 2px 0 #111;
+  box-shadow: none;
   white-space: nowrap;
-  transition: transform 0.1s ease;
+  transition:
+    transform 0.1s ease,
+    opacity 0.1s ease;
   touch-action: manipulation;
   font-family: inherit;
 }
 
 .glw__btn:hover:not(:disabled) {
-  transform: translate(-1px, -1px);
-  box-shadow: 3px 3px 0 #111;
+  opacity: 0.88;
 }
 
 .glw__btn:disabled {
@@ -617,8 +618,16 @@ watch(
 }
 
 .glw__btn--ghost {
-  background: #fff;
-  color: #111;
+  background: transparent;
+  color: var(--game-ink-medium);
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.glw__btn--ghost:hover:not(:disabled) {
+  opacity: 1;
+  color: var(--game-ink);
+  background: var(--game-surface-subtle);
 }
 
 .glw__nav {
@@ -626,7 +635,7 @@ watch(
   align-items: center;
   gap: var(--spacing-2);
   padding-top: var(--spacing-2);
-  border-top: 2px solid #f0f0f0;
+  border-top: 1px solid var(--game-surface-dim);
 }
 
 .glw__nav-spacer {
@@ -643,21 +652,21 @@ watch(
   justify-content: center;
   width: 1.5rem;
   height: 1.5rem;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 50%;
-  background: #fff;
-  color: #111;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
   font-size: 0.875rem;
   font-weight: 900;
   cursor: pointer;
-  box-shadow: 2px 2px 0 #111;
+  box-shadow: 2px 2px 0 var(--game-border);
   transition: transform 0.1s ease;
   font-family: inherit;
 }
 
 .glw__rules-btn:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
 }
 
 .glw__rules-panel {
@@ -666,27 +675,27 @@ watch(
   left: 50%;
   transform: translateX(-50%);
   z-index: 100;
-  background: #fff;
-  border: 2px solid #111;
+  background: var(--game-surface-subtle);
+  border: 2px solid var(--game-border);
   border-radius: 0.75rem;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
   width: 18rem;
   padding: var(--spacing-3) var(--spacing-3) var(--spacing-3) var(--spacing-5);
   font-size: var(--font-size-sm);
   line-height: 1.4;
-  color: #111;
+  color: var(--game-ink);
 }
 
 .glw__start-btn {
   padding: var(--spacing-2) var(--spacing-5, 1.5rem);
-  border: 3px solid #111;
+  border: 3px solid var(--game-border);
   border-radius: 999px;
   background: var(--glw-accent);
   color: #fff;
   font-size: var(--font-size-md, 1rem);
   font-weight: 700;
   cursor: pointer;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
   transition: transform 0.1s ease;
   touch-action: manipulation;
   font-family: inherit;
@@ -694,13 +703,13 @@ watch(
 
 .glw__start-btn:hover:not(:disabled) {
   transform: translate(-1px, -1px);
-  box-shadow: 4px 4px 0 #111;
+  box-shadow: 4px 4px 0 var(--game-border);
 }
 
 .glw__start-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
-  box-shadow: 2px 2px 0 #111;
+  box-shadow: 2px 2px 0 var(--game-border);
 }
 
 @media (max-width: 720px) {

--- a/src/utils/playerProfile.ts
+++ b/src/utils/playerProfile.ts
@@ -37,7 +37,7 @@ export const buildRandomGradient = (): string => {
     const color = GRADIENT_COLORS[Math.floor(Math.random() * GRADIENT_COLORS.length)]
     return `radial-gradient(circle at ${x}% ${y}%, ${color}, transparent ${GRADIENT_STOP_PERCENT}%)`
   })
-  return [...layers, '#fff7e6'].join(', ')
+  return layers.join(', ')
 }
 
 /**

--- a/src/views/Games/Lobby/Lobby.vue
+++ b/src/views/Games/Lobby/Lobby.vue
@@ -254,7 +254,7 @@ const roomsOpen = ref(true)
   height: 100dvh;
   box-sizing: border-box;
   overflow: hidden;
-  background: #fff7e6;
+  background: var(--lb-bg);
   font-family: 'Comic Sans MS', 'Chalkboard SE', 'Marker Felt', cursive, system-ui;
 }
 
@@ -265,15 +265,10 @@ const roomsOpen = ref(true)
 
 .lobby__main {
   grid-area: main;
-  border-right: 3px solid #111;
   min-height: 0;
   overflow: hidden;
   display: flex;
   flex-direction: column;
-}
-
-.lobby--in-game .lobby__main {
-  border-right: none;
 }
 
 /* Game picker */
@@ -308,10 +303,10 @@ const roomsOpen = ref(true)
   align-items: center;
   gap: var(--spacing-2);
   padding: var(--spacing-5, 1.5rem) var(--spacing-6, 2rem);
-  border: 3px solid #111;
+  border: 3px solid var(--game-border);
   border-radius: 1.25rem;
   background: var(--lb-yellow);
-  box-shadow: 5px 5px 0 #111;
+  box-shadow: 5px 5px 0 var(--game-border);
   cursor: pointer;
   transition: transform 0.1s ease;
   min-width: 9rem;
@@ -328,7 +323,7 @@ const roomsOpen = ref(true)
 
 .lobby__game-card:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 7px 7px 0 #111;
+  box-shadow: 7px 7px 0 var(--game-border);
 }
 
 .lobby__game-name {
@@ -336,6 +331,12 @@ const roomsOpen = ref(true)
   font-weight: 900;
   color: #111;
   letter-spacing: 0.02em;
+}
+
+/* Picker and embedded game slide up on mount */
+.lobby__picker,
+.lobby__game-embed {
+  animation: slide-up 0.28s ease both;
 }
 
 /* Embedded game */
@@ -357,12 +358,14 @@ const roomsOpen = ref(true)
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  background: #fffbf0;
+  background: var(--lb-sidebar-bg);
   padding-top: var(--nav-height);
+  border-left: 3px solid var(--game-border);
+  animation: slide-from-right 0.32s ease both;
 }
 
 .lobby__section {
-  border-bottom: 3px solid #111;
+  border-bottom: 3px solid var(--game-border);
 }
 
 .lobby__section-toggle {
@@ -407,10 +410,10 @@ const roomsOpen = ref(true)
 
 .lobby__name-input {
   padding: var(--spacing-1) var(--spacing-2);
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 999px;
-  background: #fff;
-  color: #111;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
   font-size: var(--font-size-sm);
   font-weight: 700;
   outline: none;
@@ -428,11 +431,11 @@ const roomsOpen = ref(true)
 .lobby__swatch {
   width: 1.5rem;
   height: 1.5rem;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 50%;
   cursor: pointer;
   padding: 0;
-  box-shadow: 1px 1px 0 #111;
+  box-shadow: 1px 1px 0 var(--game-border);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -469,14 +472,11 @@ const roomsOpen = ref(true)
     grid-template-rows: auto 1fr;
   }
 
-  .lobby__main {
-    border-right: none;
-    border-bottom: 2px solid #111;
-  }
-
   .lobby__sidebar {
     max-height: 50dvh;
     padding-top: 0;
+    border-left: none;
+    border-top: 3px solid var(--game-border);
   }
 
   .lobby__picker-games {

--- a/src/views/Games/Lobby/LobbyChat.vue
+++ b/src/views/Games/Lobby/LobbyChat.vue
@@ -110,7 +110,7 @@ const handleSend = (): void => {
 }
 
 .lb-chat__message--own .lb-chat__text {
-  background: #111;
+  background: var(--game-ink);
   color: #fff;
 }
 
@@ -126,16 +126,16 @@ const handleSend = (): void => {
   display: flex;
   gap: var(--spacing-2);
   padding: var(--spacing-3);
-  border-top: 3px solid #111;
+  border-top: 3px solid var(--game-border);
 }
 
 .lb-chat__input {
   flex: 1;
   padding: var(--spacing-2) var(--spacing-3);
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 999px;
-  background: #fff;
-  color: #111;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
   font-size: var(--font-size-sm);
   font-weight: 600;
   outline: none;
@@ -143,19 +143,19 @@ const handleSend = (): void => {
 
 .lb-chat__send {
   padding: var(--spacing-2) var(--spacing-3);
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 999px;
-  background: #111;
-  color: #fff;
+  background: var(--game-ink);
+  color: var(--game-surface);
   font-size: var(--font-size-sm);
   font-weight: 700;
   cursor: pointer;
-  box-shadow: 2px 2px 0 #444;
+  box-shadow: 2px 2px 0 var(--game-ink-medium);
   transition: transform 0.1s ease;
 }
 
 .lb-chat__send:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 3px 3px 0 #444;
+  box-shadow: 3px 3px 0 var(--game-ink-medium);
 }
 </style>

--- a/src/views/Games/Lobby/LobbyPresence.vue
+++ b/src/views/Games/Lobby/LobbyPresence.vue
@@ -54,14 +54,14 @@ const playerList = computed(() => Object.values(store.players))
   width: 0.625rem;
   height: 0.625rem;
   border-radius: 50%;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   flex-shrink: 0;
 }
 
 .lb-presence__name {
   font-size: var(--font-size-sm);
   font-weight: 700;
-  color: #111;
+  color: var(--game-ink);
 }
 
 .lb-presence__you {

--- a/src/views/Games/Lobby/LobbyRoomCard.vue
+++ b/src/views/Games/Lobby/LobbyRoomCard.vue
@@ -49,11 +49,11 @@ const emit = defineEmits<{
 }
 
 .lb-room-card:hover {
-  background: #ffefc0;
+  background: var(--lb-card-hover);
 }
 
 .lb-room-card--own {
-  border-color: #ccc;
+  border-color: var(--game-border-secondary);
 }
 
 .lb-room-card__info {
@@ -66,7 +66,7 @@ const emit = defineEmits<{
 .lb-room-card__game {
   font-size: var(--font-size-xs);
   font-weight: 800;
-  color: #111;
+  color: var(--game-ink);
   white-space: nowrap;
 }
 
@@ -76,14 +76,14 @@ const emit = defineEmits<{
   gap: var(--spacing-1);
   font-size: var(--font-size-xs);
   font-weight: 600;
-  color: #555;
+  color: var(--game-ink-medium);
 }
 
 .lb-room-card__dot {
   width: 0.5rem;
   height: 0.5rem;
   border-radius: 50%;
-  border: 1.5px solid #111;
+  border: 1.5px solid var(--game-border);
   flex-shrink: 0;
 }
 
@@ -97,9 +97,9 @@ const emit = defineEmits<{
 
 .lb-room-card__join {
   padding: 2px var(--spacing-2);
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 999px;
-  background: #111;
+  background: var(--game-ink);
   color: #fff;
   font-size: var(--font-size-xs);
   font-weight: 700;

--- a/src/views/Games/Pictionary/Pictionary.vue
+++ b/src/views/Games/Pictionary/Pictionary.vue
@@ -46,7 +46,7 @@ const playerName = ref(
   storedProfile?.name ?? `${randomPick(NAME_ADJECTIVES)}${randomPick(NAME_ANIMALS)}`
 )
 const playerColor = ref(storedProfile?.color ?? randomPick(PLAYER_COLORS))
-const backgroundStyle = { background: buildRandomGradient() }
+const backgroundStyle = { backgroundImage: buildRandomGradient() }
 const drawingReference = ref<InstanceType<typeof PictionaryDrawing> | null>(null)
 
 const resolvedRoomId = ((): string => {
@@ -249,7 +249,7 @@ onMounted(() => {
   height: 100dvh;
   box-sizing: border-box;
   overflow: hidden;
-  background: #fff7e6;
+  background: var(--pic-bg);
   font-family: 'Comic Sans MS', 'Chalkboard SE', 'Marker Felt', cursive, system-ui;
 }
 
@@ -257,6 +257,18 @@ onMounted(() => {
   height: auto;
   min-height: 100dvh;
   overflow: auto;
+}
+
+.pictionary :deep(.glw),
+.pictionary :deep(.pictionary-choosing),
+.pictionary :deep(.pictionary-drawing),
+.pictionary :deep(.pictionary-intermission),
+.pictionary :deep(.pictionary-summary) {
+  animation: slide-up 0.28s ease both;
+}
+
+.pictionary :deep(.pictionary-sidebar) {
+  animation: slide-from-right 0.32s ease both;
 }
 
 @media (max-width: 720px) {

--- a/src/views/Games/Pictionary/PictionaryDrawing.vue
+++ b/src/views/Games/Pictionary/PictionaryDrawing.vue
@@ -93,9 +93,9 @@ defineExpose({
 .pictionary-drawing :deep(.canvas-editor-canvas) {
   flex-grow: 0;
   height: auto;
-  border: 3px solid #111;
+  border: 3px solid var(--game-border);
   border-radius: 1.25rem;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
 }
 
 .pictionary-drawing :deep(.btn) {
@@ -115,10 +115,10 @@ defineExpose({
   align-items: center;
   gap: var(--spacing-1);
   padding: var(--spacing-3) var(--spacing-4, 1rem);
-  border: 4px dashed #111;
+  border: 4px dashed var(--game-border);
   border-radius: 1.25rem;
   background: linear-gradient(135deg, var(--pic-yellow), var(--pic-orange));
-  box-shadow: 5px 5px 0 #111;
+  box-shadow: 5px 5px 0 var(--game-border);
   text-align: center;
   z-index: 3;
 }
@@ -126,7 +126,7 @@ defineExpose({
 .pictionary-drawing__banner-label {
   font-size: var(--font-size-sm);
   font-weight: 700;
-  color: #111;
+  color: var(--game-ink);
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
@@ -136,7 +136,7 @@ defineExpose({
   font-size: clamp(1.25rem, 4vw, 2.5rem);
   font-weight: 900;
   letter-spacing: 0.1em;
-  color: #111;
+  color: var(--game-ink);
   text-transform: uppercase;
   text-shadow: 2px 2px 0 #fff;
   word-break: break-word;
@@ -146,13 +146,13 @@ defineExpose({
 
 .pictionary-drawing__banner-word--masked {
   font-family: var(--font-mono);
-  color: #333;
+  color: var(--game-ink-medium);
 }
 
 .pictionary-drawing__banner-def {
   font-size: var(--font-size-sm);
   font-weight: 600;
-  color: #111;
+  color: var(--game-ink);
   opacity: 0.8;
   font-style: italic;
   max-width: 36ch;
@@ -165,7 +165,7 @@ defineExpose({
 .pictionary-drawing__banner-meta {
   font-size: var(--font-size-sm);
   font-weight: 600;
-  color: #111;
+  color: var(--game-ink);
   opacity: 0.8;
 }
 

--- a/src/views/Games/Pictionary/PictionaryHeader.vue
+++ b/src/views/Games/Pictionary/PictionaryHeader.vue
@@ -58,21 +58,21 @@ const fromLobby = computed(() => !!route.query.game)
 
 .pictionary-header__lobby-btn {
   padding: var(--spacing-1) var(--spacing-3);
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 999px;
-  background: #fff7e6;
-  color: #111;
+  background: var(--pic-bg);
+  color: var(--game-ink);
   font-size: var(--font-size-sm);
   font-weight: 700;
   cursor: pointer;
-  box-shadow: 2px 2px 0 #111;
+  box-shadow: 2px 2px 0 var(--game-border);
   transition: transform 0.1s ease;
   font-family: inherit;
 }
 
 .pictionary-header__lobby-btn:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
 }
 
 .pictionary-header__room-id {
@@ -84,26 +84,26 @@ const fromLobby = computed(() => !!route.query.game)
 }
 
 .pictionary-header__room-label {
-  color: #111;
+  color: var(--game-ink);
   font-weight: 700;
 }
 
 .pictionary-header__copy-btn {
   padding: var(--spacing-2) var(--spacing-4, 1rem);
-  border: 3px solid #111;
+  border: 3px solid var(--game-border);
   border-radius: 999px;
   background: var(--pic-yellow);
-  color: #111;
+  color: var(--game-ink);
   font-size: var(--font-size-sm);
   font-weight: 700;
   cursor: pointer;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
   transition: transform 0.1s ease;
 }
 
 .pictionary-header__copy-btn:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 4px 4px 0 #111;
+  box-shadow: 4px 4px 0 var(--game-border);
 }
 
 .pictionary-header__rules {
@@ -116,14 +116,14 @@ const fromLobby = computed(() => !!route.query.game)
   justify-content: center;
   width: 1.5rem;
   height: 1.5rem;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 50%;
-  background: #fff;
-  color: #111;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
   font-size: 0.875rem;
   font-weight: 900;
   cursor: pointer;
-  box-shadow: 2px 2px 0 #111;
+  box-shadow: 2px 2px 0 var(--game-border);
   transition: transform 0.1s ease;
   user-select: none;
   font-family: inherit;
@@ -131,7 +131,7 @@ const fromLobby = computed(() => !!route.query.game)
 
 .pictionary-header__rules-btn:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
 }
 
 .pictionary-header__rules-panel {
@@ -140,10 +140,10 @@ const fromLobby = computed(() => !!route.query.game)
   left: 50%;
   transform: translateX(-50%);
   z-index: 100;
-  background: #fff;
-  border: 2px solid #111;
+  background: var(--game-surface-subtle);
+  border: 2px solid var(--game-border);
   border-radius: 0.75rem;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
   width: 18rem;
   padding: var(--spacing-3) var(--spacing-3) var(--spacing-3) var(--spacing-5);
 }
@@ -157,7 +157,7 @@ const fromLobby = computed(() => !!route.query.game)
   border: none;
   border-radius: 50%;
   background: transparent;
-  color: #888;
+  color: var(--game-ink-muted);
   font-size: 1rem;
   line-height: 1;
   cursor: pointer;
@@ -169,7 +169,7 @@ const fromLobby = computed(() => !!route.query.game)
 }
 
 .pictionary-header__rules-close:hover {
-  color: #111;
+  color: var(--game-ink);
 }
 
 .pictionary-header__rules-list {
@@ -180,7 +180,7 @@ const fromLobby = computed(() => !!route.query.game)
   gap: var(--spacing-1);
   font-size: var(--font-size-sm);
   line-height: 1.4;
-  color: #111;
+  color: var(--game-ink);
 }
 
 @media (max-width: 720px) {

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -95,7 +95,7 @@ const handleConfig = (key: string, value: string | number): void => {
     :player-list="playerList"
     :room-id="roomId"
     :matchmaker-room="MATCHMAKER_ROOM"
-    accent-color="var(--pic-pink)"
+    accent-color="var(--pic-orange)"
     :config-fields="configFields"
     @update:player-name="emit('update:playerName', $event)"
     @update:player-color="emit('update:playerColor', $event)"

--- a/src/views/Games/Pictionary/PictionarySidebar.vue
+++ b/src/views/Games/Pictionary/PictionarySidebar.vue
@@ -74,7 +74,7 @@ const emit = defineEmits<{
 .pictionary-sidebar__title {
   margin: 0 0 var(--spacing-2) 0;
   font-size: var(--font-size-sm);
-  color: #111;
+  color: var(--game-ink);
   font-weight: 700;
 }
 
@@ -97,13 +97,13 @@ const emit = defineEmits<{
   align-items: center;
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-3);
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 999px;
-  background: #fff;
+  background: var(--game-surface-subtle);
   font-size: var(--font-size-sm);
   font-weight: 700;
-  color: #111;
-  box-shadow: 2px 2px 0 #111;
+  color: var(--game-ink);
+  box-shadow: 2px 2px 0 var(--game-border);
 }
 
 .pictionary-sidebar__player--drawer {
@@ -140,10 +140,10 @@ const emit = defineEmits<{
 
 .pictionary-sidebar__chat :deep(.chat) {
   flex: 1;
-  background: #fff;
-  border: 3px solid #111;
+  background: var(--game-surface-subtle);
+  border: 3px solid var(--game-border);
   border-radius: 1.25rem;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
   padding: var(--spacing-2);
   box-sizing: border-box;
 }
@@ -152,13 +152,13 @@ const emit = defineEmits<{
 .pictionary-sidebar__chat :deep(.chat__send-btn),
 .pictionary-sidebar__chat :deep(.chat__zoom-btn) {
   border-radius: 999px;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
 }
 
 .pictionary-sidebar__chat :deep(.chat__list) {
   border-radius: 1rem;
-  border: 2px solid #111;
-  background: #fff;
+  border: 2px solid var(--game-border);
+  background: var(--game-surface-subtle);
 }
 
 .pictionary-sidebar__chat :deep(.chat-message) {
@@ -169,13 +169,13 @@ const emit = defineEmits<{
 
 .pictionary-sidebar__chat :deep(.chat-message--success) {
   --chat-success-bg: var(--pic-yellow);
-  --chat-success-color: #111;
-  --chat-success-border: #111;
+  --chat-success-color: var(--game-ink);
+  --chat-success-border: var(--game-border);
 }
 
 .pictionary-sidebar__chat :deep(.chat-message--system) {
-  --chat-system-bg: #fff4c2;
-  --chat-system-color: #111;
+  --chat-system-bg: var(--game-msg-system-bg);
+  --chat-system-color: var(--game-ink);
 }
 
 @media (max-width: 720px) {

--- a/src/views/Games/SquaresMultiplayer/SquaresMultiplayer.vue
+++ b/src/views/Games/SquaresMultiplayer/SquaresMultiplayer.vue
@@ -46,7 +46,7 @@ const playerName = ref(
   storedProfile?.name ?? `${randomPick(NAME_ADJECTIVES)}${randomPick(NAME_ANIMALS)}`
 )
 const playerColor = ref(storedProfile?.color ?? randomPick(PLAYER_COLORS))
-const backgroundStyle = { background: buildRandomGradient() }
+const backgroundStyle = { backgroundImage: buildRandomGradient() }
 
 const resolvedRoomId = ((): string => {
   const existing = route.query.room as string | undefined
@@ -245,8 +245,19 @@ onMounted(() => {
   padding-top: calc(var(--nav-height) + var(--spacing-3));
   min-height: 100vh;
   box-sizing: border-box;
-  background: #f0fff4;
+  background: var(--wm-bg);
   font-family: 'Segoe UI', system-ui, sans-serif;
+}
+
+.wm :deep(.glw),
+.wm :deep(.wm-game),
+.wm :deep(.wm-intermission),
+.wm :deep(.ws-summary) {
+  animation: slide-up 0.28s ease both;
+}
+
+.wm :deep(.ws-sidebar) {
+  animation: slide-from-right 0.32s ease both;
 }
 
 @media (max-width: 720px) {

--- a/src/views/Games/SquaresMultiplayer/SquaresMultiplayerGame.vue
+++ b/src/views/Games/SquaresMultiplayer/SquaresMultiplayerGame.vue
@@ -306,12 +306,12 @@ onUnmounted(() => {
   align-items: center;
   gap: var(--spacing-3);
   padding: var(--spacing-2) var(--spacing-4);
-  background: #fff;
-  border: 3px solid #111;
+  background: var(--game-surface-subtle);
+  border: 3px solid var(--game-border);
   border-radius: 999px;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
   font-weight: 700;
-  color: #111;
+  color: var(--game-ink);
 }
 
 .wm-game__banner-meta {
@@ -373,16 +373,16 @@ onUnmounted(() => {
 .wm-game__grid-cell {
   width: 3rem;
   height: 3rem;
-  border: 3px solid #111;
+  border: 3px solid var(--game-border);
   border-radius: var(--radius-sm);
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 1.25rem;
   font-weight: 900;
-  color: #111;
-  background: #fff;
-  box-shadow: 2px 2px 0 #111;
+  color: var(--game-ink);
+  background: var(--game-surface-subtle);
+  box-shadow: 2px 2px 0 var(--game-border);
   text-transform: uppercase;
   cursor: pointer;
   touch-action: none;
@@ -399,7 +399,7 @@ onUnmounted(() => {
 }
 
 .wm-game__grid-cell:hover {
-  background: #f5f5f5;
+  background: var(--game-surface-subtle);
 }
 
 .wm-game__grid-cell--selected {
@@ -428,18 +428,18 @@ onUnmounted(() => {
   font-size: 1.5rem;
   font-weight: 900;
   letter-spacing: 0.12em;
-  color: #111;
+  color: var(--game-ink);
   text-transform: uppercase;
   padding: var(--spacing-1) var(--spacing-3);
-  background: #fff;
-  border: 3px solid #111;
+  background: var(--game-surface-subtle);
+  border: 3px solid var(--game-border);
   border-radius: 999px;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
 }
 
 .wm-game__current-word-hint {
   font-size: var(--font-size-sm);
-  color: #aaa;
+  color: var(--game-border-secondary);
   font-style: italic;
 }
 
@@ -448,7 +448,7 @@ onUnmounted(() => {
   font-weight: 700;
   padding: var(--spacing-1) var(--spacing-3);
   border-radius: 999px;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   animation: wm-fade-in 0.1s ease;
 }
 
@@ -469,7 +469,7 @@ onUnmounted(() => {
 }
 
 .wm-game__flash--miss {
-  background: #ffeaea;
+  background: var(--game-msg-error-bg);
   color: #d32f2f;
 }
 
@@ -491,12 +491,12 @@ onUnmounted(() => {
   font-weight: 800;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #555;
+  color: var(--game-ink-medium);
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  background: #f5f5f5;
-  border: 2px solid #ddd;
+  background: var(--game-surface-subtle);
+  border: 2px solid var(--game-border-light);
   border-radius: var(--radius-sm);
   padding: var(--spacing-1) var(--spacing-2);
   cursor: pointer;
@@ -507,7 +507,7 @@ onUnmounted(() => {
 }
 
 .wm-game__group-label:hover {
-  background: #ebebeb;
+  background: var(--game-surface-dim);
 }
 
 .wm-game__group-chevron {
@@ -525,10 +525,10 @@ onUnmounted(() => {
 .wm-game__group-count {
   font-size: var(--font-size-xs);
   font-weight: 700;
-  background: #e0e0e0;
+  background: var(--game-surface-dim);
   border-radius: 999px;
   padding: 0 var(--spacing-1);
-  color: #555;
+  color: var(--game-ink-medium);
 }
 
 .wm-game__group-pts {
@@ -550,7 +550,7 @@ onUnmounted(() => {
 
 .wm-game__group-empty {
   font-size: var(--font-size-xs);
-  color: #aaa;
+  color: var(--game-border-secondary);
   font-style: italic;
   padding: var(--spacing-1) var(--spacing-2);
 }
@@ -565,7 +565,7 @@ onUnmounted(() => {
   border-radius: 999px;
   font-size: var(--font-size-sm);
   font-weight: 700;
-  background: #f0fff4;
+  background: var(--wm-bg);
 }
 
 .wm-game__slot-dot {
@@ -573,11 +573,11 @@ onUnmounted(() => {
   height: 0.5rem;
   border-radius: 50%;
   flex-shrink: 0;
-  border: 1.5px solid #111;
+  border: 1.5px solid var(--game-border);
 }
 
 .wm-game__slot-word {
-  color: #111;
+  color: var(--game-ink);
   letter-spacing: 0.04em;
 }
 
@@ -587,7 +587,7 @@ onUnmounted(() => {
   bottom: calc(100% + 6px);
   left: calc(50% + var(--tt-offset, 0px));
   transform: translateX(-50%);
-  background: #111;
+  background: var(--game-ink);
   color: #fff;
   font-size: var(--font-size-xs);
   font-weight: 500;
@@ -610,7 +610,7 @@ onUnmounted(() => {
   left: calc(50% - var(--tt-offset, 0px));
   transform: translateX(-50%);
   border: 5px solid transparent;
-  border-top-color: #111;
+  border-top-color: var(--game-border);
 }
 
 .wm-game__slot:hover .wm-game__slot-tooltip,

--- a/src/views/Games/SquaresMultiplayer/SquaresMultiplayerHeader.vue
+++ b/src/views/Games/SquaresMultiplayer/SquaresMultiplayerHeader.vue
@@ -54,25 +54,25 @@ const fromLobby = computed(() => !!route.query.game)
 
 .wm-header__lobby-btn {
   padding: var(--spacing-1) var(--spacing-3);
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 999px;
-  background: #fff;
-  color: #111;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
   font-size: var(--font-size-sm);
   font-weight: 700;
   cursor: pointer;
-  box-shadow: 2px 2px 0 #111;
+  box-shadow: 2px 2px 0 var(--game-border);
   transition: transform 0.1s ease;
   font-family: inherit;
 }
 
 .wm-header__lobby-btn:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
 }
 
 .wm-header__room-label {
-  color: #111;
+  color: var(--game-ink);
   font-weight: 700;
 }
 
@@ -86,20 +86,20 @@ const fromLobby = computed(() => !!route.query.game)
 
 .wm-header__copy-btn {
   padding: var(--spacing-2) var(--spacing-4, 1rem);
-  border: 3px solid #111;
+  border: 3px solid var(--game-border);
   border-radius: 999px;
   background: var(--ws-yellow);
-  color: #111;
+  color: var(--game-ink);
   font-size: var(--font-size-sm);
   font-weight: 700;
   cursor: pointer;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
   transition: transform 0.1s ease;
 }
 
 .wm-header__copy-btn:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 4px 4px 0 #111;
+  box-shadow: 4px 4px 0 var(--game-border);
 }
 
 .wm-header__rules {
@@ -112,14 +112,14 @@ const fromLobby = computed(() => !!route.query.game)
   justify-content: center;
   width: 1.5rem;
   height: 1.5rem;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 50%;
-  background: #fff;
-  color: #111;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
   font-size: 0.875rem;
   font-weight: 900;
   cursor: pointer;
-  box-shadow: 2px 2px 0 #111;
+  box-shadow: 2px 2px 0 var(--game-border);
   transition: transform 0.1s ease;
   user-select: none;
   font-family: inherit;
@@ -127,7 +127,7 @@ const fromLobby = computed(() => !!route.query.game)
 
 .wm-header__rules-btn:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
 }
 
 .wm-header__rules-panel {
@@ -136,10 +136,10 @@ const fromLobby = computed(() => !!route.query.game)
   left: 50%;
   transform: translateX(-50%);
   z-index: 100;
-  background: #fff;
-  border: 2px solid #111;
+  background: var(--game-surface-subtle);
+  border: 2px solid var(--game-border);
   border-radius: 0.75rem;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
   width: 18rem;
   padding: var(--spacing-3) var(--spacing-3) var(--spacing-3) var(--spacing-5);
 }
@@ -153,7 +153,7 @@ const fromLobby = computed(() => !!route.query.game)
   border: none;
   border-radius: 50%;
   background: transparent;
-  color: #888;
+  color: var(--game-ink-muted);
   font-size: 1rem;
   line-height: 1;
   cursor: pointer;
@@ -165,7 +165,7 @@ const fromLobby = computed(() => !!route.query.game)
 }
 
 .wm-header__rules-close:hover {
-  color: #111;
+  color: var(--game-ink);
 }
 
 .wm-header__rules-list {
@@ -176,6 +176,6 @@ const fromLobby = computed(() => !!route.query.game)
   gap: var(--spacing-1);
   font-size: var(--font-size-sm);
   line-height: 1.4;
-  color: #111;
+  color: var(--game-ink);
 }
 </style>

--- a/src/views/Games/SquaresMultiplayer/SquaresMultiplayerIntermission.vue
+++ b/src/views/Games/SquaresMultiplayer/SquaresMultiplayerIntermission.vue
@@ -93,11 +93,11 @@ const wordGroups = computed((): WordGroup[] => {
 }
 
 .wm-intermission__card {
-  background: #fff;
-  color: #111;
-  border: 3px solid #111;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
+  border: 3px solid var(--game-border);
   border-radius: 1.25rem;
-  box-shadow: 5px 5px 0 #111;
+  box-shadow: 5px 5px 0 var(--game-border);
   padding: var(--spacing-4);
   max-width: 28rem;
   width: 100%;
@@ -111,7 +111,7 @@ const wordGroups = computed((): WordGroup[] => {
   margin: 0;
   font-size: 1.5rem;
   font-weight: 900;
-  color: #111;
+  color: var(--game-ink);
 }
 
 .wm-intermission__groups {
@@ -132,7 +132,7 @@ const wordGroups = computed((): WordGroup[] => {
   font-weight: 800;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #555;
+  color: var(--game-ink-medium);
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
@@ -141,10 +141,10 @@ const wordGroups = computed((): WordGroup[] => {
 .wm-intermission__group-count {
   font-size: var(--font-size-xs);
   font-weight: 700;
-  background: #f0f0f0;
+  background: var(--game-surface-dim);
   border-radius: 999px;
   padding: 0 var(--spacing-1);
-  color: #777;
+  color: var(--game-ink-muted);
 }
 
 .wm-intermission__group-pts {
@@ -168,15 +168,15 @@ const wordGroups = computed((): WordGroup[] => {
   align-items: center;
   gap: var(--spacing-1);
   padding: var(--spacing-1) var(--spacing-2);
-  border: 2px solid #ddd;
+  border: 2px solid var(--game-border-light);
   border-radius: 999px;
   font-size: var(--font-size-sm);
   font-weight: 700;
-  background: #fafafa;
+  background: var(--game-surface-subtle);
 }
 
 .wm-intermission__slot--found {
-  background: #f0fff4;
+  background: var(--wm-bg);
   border-color: var(--ws-green);
 }
 
@@ -189,11 +189,11 @@ const wordGroups = computed((): WordGroup[] => {
   height: 0.5rem;
   border-radius: 50%;
   flex-shrink: 0;
-  border: 1.5px solid #111;
+  border: 1.5px solid var(--game-border);
 }
 
 .wm-intermission__slot-word {
-  color: #111;
+  color: var(--game-ink);
 }
 
 .wm-intermission__scores {
@@ -203,7 +203,7 @@ const wordGroups = computed((): WordGroup[] => {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-2);
-  border-top: 2px solid #f0f0f0;
+  border-top: 2px solid var(--game-surface-dim);
   padding-top: var(--spacing-3);
 }
 
@@ -212,7 +212,7 @@ const wordGroups = computed((): WordGroup[] => {
   align-items: center;
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-3);
-  border: 2px solid #f0f0f0;
+  border: 2px solid var(--game-surface-dim);
   border-radius: 999px;
 }
 
@@ -220,7 +220,7 @@ const wordGroups = computed((): WordGroup[] => {
   width: 0.75rem;
   height: 0.75rem;
   border-radius: 50%;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   flex-shrink: 0;
 }
 
@@ -241,6 +241,6 @@ const wordGroups = computed((): WordGroup[] => {
 .wm-intermission__next {
   margin: 0;
   font-size: var(--font-size-sm);
-  color: #888;
+  color: var(--game-ink-muted);
 }
 </style>

--- a/src/views/Games/SquaresMultiplayer/SquaresMultiplayerSidebar.vue
+++ b/src/views/Games/SquaresMultiplayer/SquaresMultiplayerSidebar.vue
@@ -112,14 +112,14 @@ const handleSend = (): void => {
   font-weight: 800;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #555;
+  color: var(--game-ink-medium);
 }
 
 .ws-sidebar__players {
-  background: #fff;
-  border: 3px solid #111;
+  background: var(--game-surface-subtle);
+  border: 3px solid var(--game-border);
   border-radius: 1.25rem;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
   padding: var(--spacing-3);
 }
 
@@ -141,14 +141,14 @@ const handleSend = (): void => {
 }
 
 .ws-sidebar__player--local {
-  background: #f5f5f5;
+  background: var(--game-surface-subtle);
 }
 
 .ws-sidebar__player-dot {
   width: 0.75rem;
   height: 0.75rem;
   border-radius: 50%;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   flex-shrink: 0;
 }
 
@@ -156,7 +156,7 @@ const handleSend = (): void => {
   flex: 1;
   font-size: var(--font-size-sm);
   font-weight: 700;
-  color: #111;
+  color: var(--game-ink);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -168,8 +168,8 @@ const handleSend = (): void => {
 .ws-sidebar__player-host {
   font-size: var(--font-size-xs);
   font-weight: 600;
-  color: #888;
-  border: 1px solid #ccc;
+  color: var(--game-ink-muted);
+  border: 1px solid var(--game-border-secondary);
   border-radius: 999px;
   padding: 0 var(--spacing-1);
 }
@@ -183,7 +183,7 @@ const handleSend = (): void => {
 .ws-sidebar__player-score {
   font-size: var(--font-size-sm);
   font-weight: 800;
-  color: #111;
+  color: var(--game-ink);
   min-width: 2.5rem;
   text-align: right;
 }
@@ -193,10 +193,10 @@ const handleSend = (): void => {
   min-height: 0;
   display: flex;
   flex-direction: column;
-  background: #fff;
-  border: 3px solid #111;
+  background: var(--game-surface-subtle);
+  border: 3px solid var(--game-border);
   border-radius: 1.25rem;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
   padding: var(--spacing-3);
   overflow: hidden;
 }
@@ -216,13 +216,13 @@ const handleSend = (): void => {
 .ws-sidebar__message {
   font-size: var(--font-size-xs);
   line-height: 1.4;
-  color: #111;
+  color: var(--game-ink);
   padding: var(--spacing-1) 0;
-  border-bottom: 1px solid #f0f0f0;
+  border-bottom: 1px solid var(--game-surface-dim);
 }
 
 .ws-sidebar__message--system {
-  color: #888;
+  color: var(--game-ink-muted);
   font-style: italic;
 }
 
@@ -244,30 +244,30 @@ const handleSend = (): void => {
 .ws-sidebar__chat-input {
   flex: 1;
   padding: var(--spacing-1) var(--spacing-2);
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 999px;
   font-size: var(--font-size-sm);
-  background: #fff;
-  color: #111;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
   outline: none;
 }
 
 .ws-sidebar__chat-send {
   padding: var(--spacing-1) var(--spacing-3);
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 999px;
   background: var(--ws-green);
   color: #fff;
   font-size: var(--font-size-sm);
   font-weight: 700;
   cursor: pointer;
-  box-shadow: 2px 2px 0 #111;
+  box-shadow: 2px 2px 0 var(--game-border);
   transition: transform 0.1s ease;
 }
 
 .ws-sidebar__chat-send:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
 }
 
 /* Mobile chat toggle button — hidden on desktop */
@@ -314,12 +314,12 @@ const handleSend = (): void => {
     right: var(--spacing-4);
     width: 3rem;
     height: 3rem;
-    border: 3px solid #111;
+    border: 3px solid var(--game-border);
     border-radius: 50%;
     background: var(--ws-green);
     font-size: 1.25rem;
     cursor: pointer;
-    box-shadow: 3px 3px 0 #111;
+    box-shadow: 3px 3px 0 var(--game-border);
     z-index: 100;
     touch-action: manipulation;
     position: relative;

--- a/src/views/Games/SquaresMultiplayer/SquaresMultiplayerSummary.vue
+++ b/src/views/Games/SquaresMultiplayer/SquaresMultiplayerSummary.vue
@@ -102,11 +102,11 @@ const wordGroups = computed((): WordGroup[] => {
 }
 
 .ws-summary__card {
-  background: #fff;
-  color: #111;
-  border: 3px solid #111;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
+  border: 3px solid var(--game-border);
   border-radius: 1.25rem;
-  box-shadow: 5px 5px 0 #111;
+  box-shadow: 5px 5px 0 var(--game-border);
   padding: var(--spacing-5, 2rem);
   max-width: 28rem;
   width: 100%;
@@ -120,7 +120,7 @@ const wordGroups = computed((): WordGroup[] => {
   margin: 0;
   font-size: 2rem;
   font-weight: 900;
-  color: #111;
+  color: var(--game-ink);
 }
 
 .ws-summary__scores {
@@ -137,19 +137,19 @@ const wordGroups = computed((): WordGroup[] => {
   align-items: center;
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-3);
-  border: 2px solid #f0f0f0;
+  border: 2px solid var(--game-surface-dim);
   border-radius: 999px;
 }
 
 .ws-summary__score-row--winner {
   border-color: var(--ws-yellow);
-  background: #fffbe6;
+  background: var(--game-msg-system-bg);
 }
 
 .ws-summary__rank {
   font-size: var(--font-size-sm);
   font-weight: 800;
-  color: #888;
+  color: var(--game-ink-muted);
   min-width: 1.25rem;
   text-align: center;
 }
@@ -158,7 +158,7 @@ const wordGroups = computed((): WordGroup[] => {
   width: 0.75rem;
   height: 0.75rem;
   border-radius: 50%;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   flex-shrink: 0;
 }
 
@@ -183,26 +183,26 @@ const wordGroups = computed((): WordGroup[] => {
 
 .ws-summary__restart-btn {
   padding: var(--spacing-3) var(--spacing-5, 1.5rem);
-  border: 3px solid #111;
+  border: 3px solid var(--game-border);
   border-radius: 999px;
   background: var(--ws-green);
   color: #fff;
   font-size: var(--font-size-md, 1rem);
   font-weight: 800;
   cursor: pointer;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
   transition: transform 0.1s ease;
 }
 
 .ws-summary__restart-btn:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 4px 4px 0 #111;
+  box-shadow: 4px 4px 0 var(--game-border);
 }
 
 .ws-summary__waiting {
   margin: 0;
   font-size: var(--font-size-sm);
-  color: #888;
+  color: var(--game-ink-muted);
 }
 
 .ws-summary__words {
@@ -210,7 +210,7 @@ const wordGroups = computed((): WordGroup[] => {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-2);
-  border-top: 2px solid #f0f0f0;
+  border-top: 2px solid var(--game-surface-dim);
   padding-top: var(--spacing-3);
 }
 
@@ -220,7 +220,7 @@ const wordGroups = computed((): WordGroup[] => {
   font-weight: 800;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #555;
+  color: var(--game-ink-medium);
 }
 
 .ws-summary__word-group {
@@ -232,7 +232,7 @@ const wordGroups = computed((): WordGroup[] => {
 .ws-summary__word-group-label {
   font-size: var(--font-size-xs);
   font-weight: 700;
-  color: #888;
+  color: var(--game-ink-muted);
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
@@ -258,14 +258,14 @@ const wordGroups = computed((): WordGroup[] => {
   align-items: center;
   gap: var(--spacing-1);
   padding: var(--spacing-1) var(--spacing-2);
-  border: 2px solid #ddd;
+  border: 2px solid var(--game-border-light);
   border-radius: 999px;
   font-size: var(--font-size-sm);
   font-weight: 700;
 }
 
 .ws-summary__word-slot--found {
-  background: #f0fff4;
+  background: var(--wm-bg);
   border-color: var(--ws-green);
 }
 
@@ -278,10 +278,10 @@ const wordGroups = computed((): WordGroup[] => {
   height: 0.5rem;
   border-radius: 50%;
   flex-shrink: 0;
-  border: 1.5px solid #111;
+  border: 1.5px solid var(--game-border);
 }
 
 .ws-summary__word-text {
-  color: #111;
+  color: var(--game-ink);
 }
 </style>

--- a/src/views/Games/WordleMultiplayer/WordleMultiplayer.vue
+++ b/src/views/Games/WordleMultiplayer/WordleMultiplayer.vue
@@ -45,7 +45,7 @@ const playerName = ref(
   storedProfile?.name ?? `${randomPick(NAME_ADJECTIVES)}${randomPick(NAME_ANIMALS)}`
 )
 const playerColor = ref(storedProfile?.color ?? randomPick(PLAYER_COLORS))
-const backgroundStyle = { background: buildRandomGradient() }
+const backgroundStyle = { backgroundImage: buildRandomGradient() }
 const showChat = ref(false)
 
 const resolvedRoomId = ((): string => {
@@ -244,8 +244,19 @@ onMounted(() => {
   padding-top: calc(var(--nav-height) + var(--spacing-3));
   min-height: 100vh;
   box-sizing: border-box;
-  background: #f9f9f9;
+  background: var(--wl-bg);
   font-family: 'Segoe UI', system-ui, sans-serif;
+}
+
+.wl :deep(.glw),
+.wl :deep(.wl-game),
+.wl :deep(.wl-intermission),
+.wl :deep(.wl-summary) {
+  animation: slide-up 0.28s ease both;
+}
+
+.wl :deep(.wl-sidebar) {
+  animation: slide-from-right 0.32s ease both;
 }
 
 @media (max-width: 720px) {

--- a/src/views/Games/WordleMultiplayer/WordleMultiplayerGame.vue
+++ b/src/views/Games/WordleMultiplayer/WordleMultiplayerGame.vue
@@ -177,12 +177,12 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
   align-items: center;
   gap: var(--spacing-3);
   padding: var(--spacing-2) var(--spacing-4);
-  background: #fff;
-  border: 3px solid #111;
+  background: var(--game-surface-subtle);
+  border: 3px solid var(--game-border);
   border-radius: 999px;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
   font-weight: 700;
-  color: #111;
+  color: var(--game-ink);
 }
 
 .wl-game__banner-meta,
@@ -223,15 +223,15 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 .wl-game__tile {
   width: 3rem;
   height: 3rem;
-  border: 3px solid #ccc;
+  border: 3px solid var(--game-border-secondary);
   border-radius: var(--radius-sm);
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 1.25rem;
   font-weight: 900;
-  color: #111;
-  background: #fff;
+  color: var(--game-ink);
+  background: var(--game-surface-subtle);
   text-transform: uppercase;
   user-select: none;
   transition:
@@ -240,7 +240,7 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 }
 
 .wl-game__tile--active {
-  border-color: #111;
+  border-color: var(--game-border);
 }
 
 .wl-game__tile--correct {
@@ -252,12 +252,12 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 .wl-game__tile--present {
   background: var(--wl-yellow);
   border-color: var(--wl-yellow);
-  color: #111;
+  color: var(--game-ink);
 }
 
 .wl-game__tile--absent {
-  background: #888;
-  border-color: #888;
+  background: var(--game-ink-muted);
+  border-color: var(--game-ink-muted);
   color: #fff;
 }
 
@@ -266,7 +266,7 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
   font-weight: 700;
   padding: var(--spacing-1) var(--spacing-3);
   border-radius: 999px;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
 }
 
 .wl-game__status--solved {
@@ -275,13 +275,13 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 }
 
 .wl-game__status--failed {
-  background: #ffeaea;
+  background: var(--game-msg-error-bg);
   color: #d32f2f;
 }
 
 .wl-game__status--waiting {
-  background: #f5f5f5;
-  color: #555;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink-medium);
 }
 
 .wl-game__keyboard {
@@ -299,14 +299,14 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 .wl-game__key {
   min-width: 2.25rem;
   height: 3.5rem;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: var(--radius-sm);
-  background: #fff;
-  color: #111;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
   font-size: var(--font-size-sm);
   font-weight: 700;
   cursor: pointer;
-  box-shadow: 2px 2px 0 #111;
+  box-shadow: 2px 2px 0 var(--game-border);
   transition: transform 0.1s ease;
   display: flex;
   align-items: center;
@@ -322,12 +322,12 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 
 .wl-game__key:hover:not(:disabled) {
   transform: translate(-1px, -1px);
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
 }
 
 .wl-game__key:active:not(:disabled) {
   transform: translate(1px, 1px);
-  box-shadow: 1px 1px 0 #111;
+  box-shadow: 1px 1px 0 var(--game-border);
 }
 
 .wl-game__key:disabled {
@@ -344,12 +344,12 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 .wl-game__key--present {
   background: var(--wl-yellow);
   border-color: var(--wl-yellow);
-  color: #111;
+  color: var(--game-ink);
 }
 
 .wl-game__key--absent {
-  background: #888;
-  border-color: #888;
+  background: var(--game-ink-muted);
+  border-color: var(--game-ink-muted);
   color: #fff;
 }
 
@@ -368,10 +368,10 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 .wl-game__surrender {
   margin-top: var(--spacing-2);
   padding: var(--spacing-1) var(--spacing-3);
-  border: 2px solid #888;
+  border: 2px solid var(--game-ink-muted);
   border-radius: 999px;
-  background: #fff;
-  color: #888;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink-muted);
   font-size: var(--font-size-xs);
   font-weight: 700;
   cursor: pointer;

--- a/src/views/Games/WordleMultiplayer/WordleMultiplayerHeader.vue
+++ b/src/views/Games/WordleMultiplayer/WordleMultiplayerHeader.vue
@@ -54,25 +54,25 @@ const fromLobby = computed(() => !!route.query.game)
 
 .wl-header__lobby-btn {
   padding: var(--spacing-1) var(--spacing-3);
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 999px;
-  background: #fff;
-  color: #111;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
   font-size: var(--font-size-sm);
   font-weight: 700;
   cursor: pointer;
-  box-shadow: 2px 2px 0 #111;
+  box-shadow: 2px 2px 0 var(--game-border);
   transition: transform 0.1s ease;
   font-family: inherit;
 }
 
 .wl-header__lobby-btn:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
 }
 
 .wl-header__room-label {
-  color: #111;
+  color: var(--game-ink);
   font-weight: 700;
 }
 
@@ -86,20 +86,20 @@ const fromLobby = computed(() => !!route.query.game)
 
 .wl-header__copy-btn {
   padding: var(--spacing-2) var(--spacing-4, 1rem);
-  border: 3px solid #111;
+  border: 3px solid var(--game-border);
   border-radius: 999px;
   background: var(--wl-yellow);
-  color: #111;
+  color: var(--game-ink);
   font-size: var(--font-size-sm);
   font-weight: 700;
   cursor: pointer;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
   transition: transform 0.1s ease;
 }
 
 .wl-header__copy-btn:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 4px 4px 0 #111;
+  box-shadow: 4px 4px 0 var(--game-border);
 }
 
 .wl-header__rules {
@@ -112,14 +112,14 @@ const fromLobby = computed(() => !!route.query.game)
   justify-content: center;
   width: 1.5rem;
   height: 1.5rem;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 50%;
-  background: #fff;
-  color: #111;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
   font-size: 0.875rem;
   font-weight: 900;
   cursor: pointer;
-  box-shadow: 2px 2px 0 #111;
+  box-shadow: 2px 2px 0 var(--game-border);
   transition: transform 0.1s ease;
   user-select: none;
   font-family: inherit;
@@ -127,7 +127,7 @@ const fromLobby = computed(() => !!route.query.game)
 
 .wl-header__rules-btn:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
 }
 
 .wl-header__rules-panel {
@@ -136,10 +136,10 @@ const fromLobby = computed(() => !!route.query.game)
   left: 50%;
   transform: translateX(-50%);
   z-index: 100;
-  background: #fff;
-  border: 2px solid #111;
+  background: var(--game-surface-subtle);
+  border: 2px solid var(--game-border);
   border-radius: 0.75rem;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
   width: 18rem;
   padding: var(--spacing-3) var(--spacing-3) var(--spacing-3) var(--spacing-5);
 }
@@ -153,7 +153,7 @@ const fromLobby = computed(() => !!route.query.game)
   border: none;
   border-radius: 50%;
   background: transparent;
-  color: #888;
+  color: var(--game-ink-muted);
   font-size: 1rem;
   line-height: 1;
   cursor: pointer;
@@ -165,7 +165,7 @@ const fromLobby = computed(() => !!route.query.game)
 }
 
 .wl-header__rules-close:hover {
-  color: #111;
+  color: var(--game-ink);
 }
 
 .wl-header__rules-list {
@@ -176,6 +176,6 @@ const fromLobby = computed(() => !!route.query.game)
   gap: var(--spacing-1);
   font-size: var(--font-size-sm);
   line-height: 1.4;
-  color: #111;
+  color: var(--game-ink);
 }
 </style>

--- a/src/views/Games/WordleMultiplayer/WordleMultiplayerIntermission.vue
+++ b/src/views/Games/WordleMultiplayer/WordleMultiplayerIntermission.vue
@@ -62,10 +62,10 @@ defineProps<{
 }
 
 .wl-intermission__card {
-  background: #fff;
-  border: 3px solid #111;
+  background: var(--game-surface-subtle);
+  border: 3px solid var(--game-border);
   border-radius: 1.25rem;
-  box-shadow: 5px 5px 0 #111;
+  box-shadow: 5px 5px 0 var(--game-border);
   padding: var(--spacing-5, 2rem);
   max-width: 32rem;
   width: 100%;
@@ -79,13 +79,13 @@ defineProps<{
   margin: 0;
   font-size: 1.5rem;
   font-weight: 900;
-  color: #111;
+  color: var(--game-ink);
 }
 
 .wl-intermission__word {
   margin: 0;
   font-size: var(--font-size-md, 1rem);
-  color: #555;
+  color: var(--game-ink-medium);
 }
 
 .wl-intermission__players {
@@ -102,7 +102,7 @@ defineProps<{
   flex-direction: column;
   gap: var(--spacing-1);
   padding: var(--spacing-2) var(--spacing-3);
-  border: 2px solid #f0f0f0;
+  border: 2px solid var(--game-surface-dim);
   border-radius: var(--radius-sm);
 }
 
@@ -116,7 +116,7 @@ defineProps<{
   width: 0.75rem;
   height: 0.75rem;
   border-radius: 50%;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   flex-shrink: 0;
 }
 
@@ -160,7 +160,7 @@ defineProps<{
   width: 1rem;
   height: 1rem;
   border-radius: 2px;
-  background: #ccc;
+  background: var(--game-border-secondary);
 }
 
 .wl-intermission__mini-tile--correct {
@@ -172,12 +172,12 @@ defineProps<{
 }
 
 .wl-intermission__mini-tile--absent {
-  background: #888;
+  background: var(--game-ink-muted);
 }
 
 .wl-intermission__next {
   margin: 0;
   font-size: var(--font-size-sm);
-  color: #888;
+  color: var(--game-ink-muted);
 }
 </style>

--- a/src/views/Games/WordleMultiplayer/WordleMultiplayerSidebar.vue
+++ b/src/views/Games/WordleMultiplayer/WordleMultiplayerSidebar.vue
@@ -108,14 +108,14 @@ const handleSend = (): void => {
   font-weight: 800;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #555;
+  color: var(--game-ink-medium);
 }
 
 .wl-sidebar__players {
-  background: #fff;
-  border: 3px solid #111;
+  background: var(--game-surface-subtle);
+  border: 3px solid var(--game-border);
   border-radius: 1.25rem;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
   padding: var(--spacing-3);
 }
 
@@ -137,14 +137,14 @@ const handleSend = (): void => {
 }
 
 .wl-sidebar__player--local {
-  background: #f5f5f5;
+  background: var(--game-surface-subtle);
 }
 
 .wl-sidebar__player-dot {
   width: 0.75rem;
   height: 0.75rem;
   border-radius: 50%;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   flex-shrink: 0;
 }
 
@@ -152,7 +152,7 @@ const handleSend = (): void => {
   flex: 1;
   font-size: var(--font-size-sm);
   font-weight: 700;
-  color: #111;
+  color: var(--game-ink);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -164,8 +164,8 @@ const handleSend = (): void => {
 .wl-sidebar__player-host {
   font-size: var(--font-size-xs);
   font-weight: 600;
-  color: #888;
-  border: 1px solid #ccc;
+  color: var(--game-ink-muted);
+  border: 1px solid var(--game-border-secondary);
   border-radius: 999px;
   padding: 0 var(--spacing-1);
 }
@@ -179,7 +179,7 @@ const handleSend = (): void => {
 .wl-sidebar__player-score {
   font-size: var(--font-size-sm);
   font-weight: 800;
-  color: #111;
+  color: var(--game-ink);
   min-width: 2.5rem;
   text-align: right;
 }
@@ -189,10 +189,10 @@ const handleSend = (): void => {
   min-height: 0;
   display: flex;
   flex-direction: column;
-  background: #fff;
-  border: 3px solid #111;
+  background: var(--game-surface-subtle);
+  border: 3px solid var(--game-border);
   border-radius: 1.25rem;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
   padding: var(--spacing-3);
   overflow: hidden;
 }
@@ -212,13 +212,13 @@ const handleSend = (): void => {
 .wl-sidebar__message {
   font-size: var(--font-size-xs);
   line-height: 1.4;
-  color: #111;
+  color: var(--game-ink);
   padding: var(--spacing-1) 0;
-  border-bottom: 1px solid #f0f0f0;
+  border-bottom: 1px solid var(--game-surface-dim);
 }
 
 .wl-sidebar__message--system {
-  color: #888;
+  color: var(--game-ink-muted);
   font-style: italic;
 }
 
@@ -240,30 +240,30 @@ const handleSend = (): void => {
 .wl-sidebar__chat-input {
   flex: 1;
   padding: var(--spacing-1) var(--spacing-2);
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 999px;
   font-size: var(--font-size-sm);
-  background: #fff;
-  color: #111;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
   outline: none;
 }
 
 .wl-sidebar__chat-send {
   padding: var(--spacing-1) var(--spacing-3);
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   border-radius: 999px;
   background: var(--wl-green);
   color: #fff;
   font-size: var(--font-size-sm);
   font-weight: 700;
   cursor: pointer;
-  box-shadow: 2px 2px 0 #111;
+  box-shadow: 2px 2px 0 var(--game-border);
   transition: transform 0.1s ease;
 }
 
 .wl-sidebar__chat-send:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
 }
 
 /* Mobile chat toggle button — hidden on desktop */
@@ -309,12 +309,12 @@ const handleSend = (): void => {
     right: var(--spacing-4);
     width: 3rem;
     height: 3rem;
-    border: 3px solid #111;
+    border: 3px solid var(--game-border);
     border-radius: 50%;
     background: var(--wl-green);
     font-size: 1.25rem;
     cursor: pointer;
-    box-shadow: 3px 3px 0 #111;
+    box-shadow: 3px 3px 0 var(--game-border);
     z-index: 100;
     touch-action: manipulation;
     position: relative;

--- a/src/views/Games/WordleMultiplayer/WordleMultiplayerSummary.vue
+++ b/src/views/Games/WordleMultiplayer/WordleMultiplayerSummary.vue
@@ -51,10 +51,10 @@ const emit = defineEmits<{
 }
 
 .wl-summary__card {
-  background: #fff;
-  border: 3px solid #111;
+  background: var(--game-surface-subtle);
+  border: 3px solid var(--game-border);
   border-radius: 1.25rem;
-  box-shadow: 5px 5px 0 #111;
+  box-shadow: 5px 5px 0 var(--game-border);
   padding: var(--spacing-5, 2rem);
   max-width: 28rem;
   width: 100%;
@@ -68,7 +68,7 @@ const emit = defineEmits<{
   margin: 0;
   font-size: 2rem;
   font-weight: 900;
-  color: #111;
+  color: var(--game-ink);
 }
 
 .wl-summary__scores {
@@ -85,19 +85,19 @@ const emit = defineEmits<{
   align-items: center;
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-3);
-  border: 2px solid #f0f0f0;
+  border: 2px solid var(--game-surface-dim);
   border-radius: 999px;
 }
 
 .wl-summary__score-row--winner {
   border-color: var(--wl-yellow);
-  background: #fffbe6;
+  background: var(--game-msg-system-bg);
 }
 
 .wl-summary__rank {
   font-size: var(--font-size-sm);
   font-weight: 800;
-  color: #888;
+  color: var(--game-ink-muted);
   min-width: 1.25rem;
   text-align: center;
 }
@@ -106,7 +106,7 @@ const emit = defineEmits<{
   width: 0.75rem;
   height: 0.75rem;
   border-radius: 50%;
-  border: 2px solid #111;
+  border: 2px solid var(--game-border);
   flex-shrink: 0;
 }
 
@@ -131,25 +131,25 @@ const emit = defineEmits<{
 
 .wl-summary__restart-btn {
   padding: var(--spacing-3) var(--spacing-5, 1.5rem);
-  border: 3px solid #111;
+  border: 3px solid var(--game-border);
   border-radius: 999px;
   background: var(--wl-green);
   color: #fff;
   font-size: var(--font-size-md, 1rem);
   font-weight: 800;
   cursor: pointer;
-  box-shadow: 3px 3px 0 #111;
+  box-shadow: 3px 3px 0 var(--game-border);
   transition: transform 0.1s ease;
 }
 
 .wl-summary__restart-btn:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 4px 4px 0 #111;
+  box-shadow: 4px 4px 0 var(--game-border);
 }
 
 .wl-summary__waiting {
   margin: 0;
   font-size: var(--font-size-sm);
-  color: #888;
+  color: var(--game-ink-muted);
 }
 </style>


### PR DESCRIPTION
Closes #116

## Summary

- Full system-preference dark mode via CSS custom properties (`--game-ink`, `--game-border`, `--game-surface`, per-game bg vars) across all multiplayer game views
- Directional entrance animations: sidebars slide+fade from right, main panels slide up
- Semi-transparent `var(--game-border)` for all borders/shadows so they adapt to both themes
- Gradient backgrounds emit only `background-image` (no base color) so CSS `background-color: var(--pic-bg)` handles dark mode correctly
- Lobby sidebar uses outer border instead of per-section borders for clean slide animation; section dividers restored at 3px
- Pictionary wizard accent changed to orange; button borders reduced; ghost style for secondary actions
- Chat send button text uses `var(--game-surface)` for dark mode compatibility

## Key Changes

- `_variables.scss` — game UI CSS tokens + `slide-up`/`slide-from-right` keyframes; dark theme overrides
- `playerProfile.ts` — `buildRandomGradient()` returns `background-image` layers only
- `Lobby.vue` — per-section clearance, sidebar animation, border polish
- `GameLobbyWizard.vue` — wizard button styling and orange accent
- All 3 game views + 12 sub-components — `var(--game-border)` borders, slide animations via `:deep()`

## Test Plan

- [ ] Toggle system dark mode — all game views switch theme automatically
- [ ] Open lobby, pick a game — picker cards slide up on mount; sidebar slides from right
- [ ] Enter any game — phase transitions animate correctly
- [ ] Verify lobby sidebar border is solid single-width; section dividers visible
- [ ] Verify gradient backgrounds don't override dark background color