### PR TITLE
feat: solo mode for WordleMultiplayer and SquaresMultiplayer

### DIFF
--- a/src/components/GameLobbyWizard.vue
+++ b/src/components/GameLobbyWizard.vue
@@ -33,6 +33,7 @@ const route = useRoute()
 const fromLobby = computed(() => !!route.query.game)
 
 const step = ref(1)
+const soloMode = ref(false)
 // From lobby: matchmaking step is skipped. Host: profile + settings (2). Guest: profile only (1).
 const totalSteps = computed(() => {
   if (fromLobby.value) return props.isHost ? 2 : 1
@@ -40,7 +41,7 @@ const totalSteps = computed(() => {
 })
 // Maps visual step to content slot: when fromLobby, step 2 shows settings (slot 3).
 const contentStep = computed(() => (fromLobby.value && step.value === 2 ? 3 : step.value))
-const required = computed(() => props.minPlayers ?? 2)
+const required = computed(() => (soloMode.value ? 1 : (props.minPlayers ?? 2)))
 
 const {
   isSearching,
@@ -71,6 +72,11 @@ const canGoNext = computed(() => {
 
 const goNext = (): void => {
   if (step.value < totalSteps.value) step.value++
+}
+
+const playSolo = (): void => {
+  soloMode.value = true
+  goNext()
 }
 
 const goBack = (): void => {
@@ -162,6 +168,9 @@ watch(
             <div class="glw__actions">
               <button class="glw__btn" type="button" @click="startSearching">
                 Search for players
+              </button>
+              <button class="glw__btn glw__btn--ghost" type="button" @click="playSolo">
+                Play Solo
               </button>
               <button
                 v-if="playerList.length >= required"

--- a/src/components/GameLobbyWizard.vue
+++ b/src/components/GameLobbyWizard.vue
@@ -16,7 +16,6 @@ const props = defineProps<{
   matchmakerRoom: string
   configFields: LobbyConfigField[]
   accentColor: string
-  minPlayers?: number
 }>()
 
 const emit = defineEmits<{
@@ -33,7 +32,6 @@ const route = useRoute()
 const fromLobby = computed(() => !!route.query.game)
 
 const step = ref(1)
-const soloMode = ref(false)
 // From lobby: matchmaking step is skipped. Host: profile + settings (2). Guest: profile only (1).
 const totalSteps = computed(() => {
   if (fromLobby.value) return props.isHost ? 2 : 1
@@ -41,7 +39,6 @@ const totalSteps = computed(() => {
 })
 // Maps visual step to content slot: when fromLobby, step 2 shows settings (slot 3).
 const contentStep = computed(() => (fromLobby.value && step.value === 2 ? 3 : step.value))
-const required = computed(() => (soloMode.value ? 1 : (props.minPlayers ?? 2)))
 
 const {
   isSearching,
@@ -62,21 +59,10 @@ const handleAccept = (entry: Parameters<typeof acceptRequest>[0]): void => {
   if (gameRoomId) emit('matchFound', gameRoomId)
 }
 
-const canGoNext = computed(() => {
-  // Require minimum players only on the matchmaking step (step 2 when NOT from lobby)
-  if (step.value === 2 && props.isHost && !fromLobby.value) {
-    return props.playerList.length >= required.value
-  }
-  return step.value < totalSteps.value
-})
+const canGoNext = computed(() => step.value < totalSteps.value)
 
 const goNext = (): void => {
   if (step.value < totalSteps.value) step.value++
-}
-
-const playSolo = (): void => {
-  soloMode.value = true
-  goNext()
 }
 
 const goBack = (): void => {
@@ -150,10 +136,7 @@ watch(
         <template v-if="isHost">
           <h3 class="glw__step-title">Find players</h3>
           <div class="glw__players">
-            <span class="glw__player-count">
-              {{ playerList.length }} /
-              {{ playerList.length < required ? `${required}+` : playerList.length }} players
-            </span>
+            <span class="glw__player-count">{{ playerList.length }} players</span>
             <span
               v-for="player in playerList"
               :key="player.id"
@@ -164,21 +147,10 @@ watch(
           </div>
 
           <template v-if="!isSearching">
-            <p v-if="playerList.length < required" class="glw__hint">No one else here yet.</p>
+            <p v-if="playerList.length < 2" class="glw__hint">No one else here yet.</p>
             <div class="glw__actions">
               <button class="glw__btn" type="button" @click="startSearching">
                 Search for players
-              </button>
-              <button class="glw__btn glw__btn--ghost" type="button" @click="playSolo">
-                Play Solo
-              </button>
-              <button
-                v-if="playerList.length >= required"
-                class="glw__btn glw__btn--ghost"
-                type="button"
-                @click="emit('leaveRoom')"
-              >
-                Leave room
               </button>
             </div>
           </template>
@@ -214,14 +186,6 @@ watch(
             <div class="glw__actions">
               <button class="glw__btn glw__btn--ghost" type="button" @click="stopSearching">
                 Stop searching
-              </button>
-              <button
-                v-if="playerList.length >= required"
-                class="glw__btn glw__btn--ghost"
-                type="button"
-                @click="emit('leaveRoom')"
-              >
-                Leave room
               </button>
             </div>
           </template>
@@ -326,7 +290,7 @@ watch(
           v-else-if="isHost"
           class="glw__start-btn"
           type="button"
-          :disabled="playerList.length < required"
+          :disabled="false"
           @click="emit('startGame')"
         >
           Start

--- a/src/views/Games/SquaresMultiplayer/SquaresMultiplayerGame.vue
+++ b/src/views/Games/SquaresMultiplayer/SquaresMultiplayerGame.vue
@@ -262,13 +262,16 @@ onUnmounted(() => {
               'wm-game__grid-cell--selected': isInPath(rowIndex, colIndex),
               'wm-game__grid-cell--first': pathIndex(rowIndex, colIndex) === 0
             }"
-            :data-row="rowIndex"
-            :data-col="colIndex"
-            @pointerdown="handlePointerDown($event, rowIndex, colIndex)"
-            @pointerenter="handlePointerEnter(rowIndex, colIndex)"
-            @touchstart.prevent="startSelection(rowIndex, colIndex)"
           >
             {{ letter }}
+            <span
+              class="wm-game__grid-cell-hit"
+              :data-row="rowIndex"
+              :data-col="colIndex"
+              @pointerdown="handlePointerDown($event, rowIndex, colIndex)"
+              @pointerenter="handlePointerEnter(rowIndex, colIndex)"
+              @touchstart.prevent="startSelection(rowIndex, colIndex)"
+            />
           </div>
         </div>
       </div>
@@ -384,7 +387,6 @@ onUnmounted(() => {
   background: var(--game-surface-subtle);
   box-shadow: 2px 2px 0 var(--game-border);
   text-transform: uppercase;
-  cursor: pointer;
   touch-action: none;
   transition:
     background 0.08s ease,
@@ -392,14 +394,12 @@ onUnmounted(() => {
   position: relative;
 }
 
-.wm-game__grid-cell::after {
-  content: '';
+/* Invisible hit zone — smaller than the tile to create dead space between adjacent cells */
+.wm-game__grid-cell-hit {
   position: absolute;
-  inset: -5px;
-}
-
-.wm-game__grid-cell:hover {
-  background: var(--game-surface-subtle);
+  inset: 20%;
+  cursor: pointer;
+  touch-action: none;
 }
 
 .wm-game__grid-cell--selected {

--- a/src/views/Games/SquaresMultiplayer/SquaresMultiplayerGame.vue
+++ b/src/views/Games/SquaresMultiplayer/SquaresMultiplayerGame.vue
@@ -364,13 +364,13 @@ onUnmounted(() => {
 .wm-game__grid {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-3);
+  gap: var(--spacing-1);
   position: relative;
 }
 
 .wm-game__grid-row {
   display: flex;
-  gap: var(--spacing-3);
+  gap: var(--spacing-1);
 }
 
 .wm-game__grid-cell {

--- a/src/views/Games/SquaresMultiplayer/SquaresMultiplayerGame.vue
+++ b/src/views/Games/SquaresMultiplayer/SquaresMultiplayerGame.vue
@@ -394,10 +394,11 @@ onUnmounted(() => {
   position: relative;
 }
 
-/* Invisible hit zone — smaller than the tile to create dead space between adjacent cells */
+/* Invisible circular hit zone — corners cut off so diagonal neighbours don't bleed */
 .wm-game__grid-cell-hit {
   position: absolute;
-  inset: 20%;
+  inset: 15%;
+  border-radius: 50%;
   cursor: pointer;
   touch-action: none;
 }


### PR DESCRIPTION
Closes #125

## Summary

- Add a "Play Solo" button to the matchmaking step of `GameLobbyWizard`
- Clicking it sets an internal `soloMode` flag, lowering the minimum player requirement to 1, then advances directly to the settings step
- The host can then start a single-player round without waiting for others

## Key Changes

- `src/components/GameLobbyWizard.vue` — `soloMode` ref, `required` computed updated, `playSolo()` handler, "Play Solo" button in step 2 host section

## Why no session changes were needed

Both `useWordleMultiplayerSession` and `useSquaresMultiplayerSession` already handle 1-player rounds correctly: `endRound` assigns the sole player as winner, and the `allSolved` check fires as soon as that one player solves (or time runs out). The only blocker was the wizard's minimum-player gate.

## Test Plan

- [ ] Open WordleMultiplayer standalone → step 2 → "Play Solo" → settings → Start → game plays through to summary with 1 player
- [ ] Open SquaresMultiplayer standalone → same flow
- [ ] Open either game with a second player present → "Play Solo" still visible but clicking it still works (solo mode with the extra player in the room is valid)
- [ ] Lobby path (`?game=WordleMultiplayer`) — matchmaking already skipped; confirm start still works
- [ ] Multiplayer flow with ≥2 players — confirm "Search for players" path unchanged