### PR TITLE
chore: add Lighthouse performance badges to README

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,52 @@
+name: Lighthouse
+
+on:
+  workflow_run:
+    workflows: ["Deploy to GitHub Pages"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  lighthouse:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Lighthouse
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: https://cnotv.github.io/generative-art/
+          uploadArtifacts: true
+          temporaryPublicStorage: false
+        id: lighthouse
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate badge JSON files
+        run: |
+          REPORT=$(ls .lighthouseci/lhr-*.json | head -1)
+          node scripts/generate-lighthouse-badges.mjs "$REPORT"
+
+      - name: Commit badge files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add badges/
+          git diff --cached --quiet || git commit -m "chore: update Lighthouse performance badges [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 A monorepo containing **WebGameKit** - a framework-agnostic toolkit for creating 3D games, environments, and animations - along with a personal playground for generative art and Three.js experiments.
 
+## Performance
+
+Scores measured by [Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci) against the live site after each deploy to GitHub Pages.
+
+[![Performance](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/cnotv/generative-art/main/badges/lighthouse-performance.json)](https://cnotv.github.io/generative-art/)
+[![Accessibility](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/cnotv/generative-art/main/badges/lighthouse-accessibility.json)](https://cnotv.github.io/generative-art/)
+[![Best Practices](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/cnotv/generative-art/main/badges/lighthouse-best-practices.json)](https://cnotv.github.io/generative-art/)
+[![SEO](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/cnotv/generative-art/main/badges/lighthouse-seo.json)](https://cnotv.github.io/generative-art/)
+
 ## 🎮 Live Demo
 
 **Main App**: [https://cnotv.github.io/generative-art/](https://cnotv.github.io/generative-art/)
@@ -10,13 +19,13 @@ A monorepo containing **WebGameKit** - a framework-agnostic toolkit for creating
 
 ## 📦 Packages
 
-| Package | Description |
-|---------|-------------|
-| [@webgamekit/threejs](./packages/threejs) | Three.js + Rapier physics integration |
-| [@webgamekit/controls](./packages/controls) | Multi-input controller (keyboard, gamepad, touch) |
-| [@webgamekit/animation](./packages/animation) | Timeline-based animation system |
-| [@webgamekit/game](./packages/game) | Reactive game state management |
-| [@webgamekit/audio](./packages/audio) | Audio playback utilities |
+| Package                                       | Description                                       |
+| --------------------------------------------- | ------------------------------------------------- |
+| [@webgamekit/threejs](./packages/threejs)     | Three.js + Rapier physics integration             |
+| [@webgamekit/controls](./packages/controls)   | Multi-input controller (keyboard, gamepad, touch) |
+| [@webgamekit/animation](./packages/animation) | Timeline-based animation system                   |
+| [@webgamekit/game](./packages/game)           | Reactive game state management                    |
+| [@webgamekit/audio](./packages/audio)         | Audio playback utilities                          |
 
 ## 🚀 Quick Start
 
@@ -54,15 +63,15 @@ pnpm docs:build
 
 ### Scripts
 
-| Command | Description |
-|---------|-------------|
-| `pnpm dev` | Start development server |
-| `pnpm host` | Start dev server accessible on network |
-| `pnpm build` | Build for production |
-| `pnpm test:unit` | Run unit tests |
-| `pnpm lint` | Lint and fix code |
-| `pnpm docs:dev` | Start documentation server |
-| `pnpm docs:build` | Build documentation |
+| Command           | Description                            |
+| ----------------- | -------------------------------------- |
+| `pnpm dev`        | Start development server               |
+| `pnpm host`       | Start dev server accessible on network |
+| `pnpm build`      | Build for production                   |
+| `pnpm test:unit`  | Run unit tests                         |
+| `pnpm lint`       | Lint and fix code                      |
+| `pnpm docs:dev`   | Start documentation server             |
+| `pnpm docs:build` | Build documentation                    |
 
 ### Project Structure
 

--- a/badges/lighthouse-accessibility.json
+++ b/badges/lighthouse-accessibility.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "accessibility",
+  "message": "—",
+  "color": "lightgrey"
+}

--- a/badges/lighthouse-best-practices.json
+++ b/badges/lighthouse-best-practices.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "best practices",
+  "message": "—",
+  "color": "lightgrey"
+}

--- a/badges/lighthouse-performance.json
+++ b/badges/lighthouse-performance.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "performance",
+  "message": "—",
+  "color": "lightgrey"
+}

--- a/badges/lighthouse-seo.json
+++ b/badges/lighthouse-seo.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "seo",
+  "message": "—",
+  "color": "lightgrey"
+}

--- a/scripts/generate-lighthouse-badges.mjs
+++ b/scripts/generate-lighthouse-badges.mjs
@@ -1,0 +1,53 @@
+/**
+ * Reads a Lighthouse JSON report and writes shields.io endpoint badge files
+ * to the badges/ directory.
+ *
+ * Usage: node scripts/generate-lighthouse-badges.mjs <report.json>
+ *
+ * Badge files are read by shields.io via:
+ *   https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/...
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const BADGES_DIR = resolve(ROOT, 'badges')
+
+const reportPath = process.argv[2]
+if (!reportPath) {
+  process.stderr.write('Usage: node scripts/generate-lighthouse-badges.mjs <report.json>\n')
+  process.exit(1)
+}
+
+const report = JSON.parse(readFileSync(reportPath, 'utf8'))
+
+const scoreColor = (score) => {
+  if (score >= 90) return 'brightgreen'
+  if (score >= 50) return 'orange'
+  return 'red'
+}
+
+const categories = {
+  performance: report.categories?.performance?.score,
+  accessibility: report.categories?.accessibility?.score,
+  'best-practices': report.categories?.['best-practices']?.score,
+  seo: report.categories?.seo?.score
+}
+
+mkdirSync(BADGES_DIR, { recursive: true })
+
+Object.entries(categories).forEach(([key, rawScore]) => {
+  if (rawScore == null) return
+  const score = Math.round(rawScore * 100)
+  const badge = {
+    schemaVersion: 1,
+    label: key.replace(/-/g, ' '),
+    message: String(score),
+    color: scoreColor(score)
+  }
+  const outPath = resolve(BADGES_DIR, `lighthouse-${key}.json`)
+  writeFileSync(outPath, `${JSON.stringify(badge, null, 2)  }\n`)
+  process.stdout.write(`Wrote ${outPath} (score: ${score})\n`)
+})

--- a/scripts/generate-lighthouse-badges.test.mjs
+++ b/scripts/generate-lighthouse-badges.test.mjs
@@ -1,0 +1,92 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, writeFileSync, readFileSync, rmSync, readdirSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execFileSync } from 'node:child_process'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const SCRIPT = resolve(ROOT, 'scripts/generate-lighthouse-badges.mjs')
+const BADGES_DIR = resolve(ROOT, 'badges')
+const FIXTURES_DIR = resolve(ROOT, 'scripts/__fixtures__')
+
+const makeReport = (categoryScores = {}) => ({
+  categories: {
+    performance: { score: 0.92 },
+    accessibility: { score: 0.85 },
+    'best-practices': { score: 0.58 },
+    seo: { score: 0.43 },
+    ...categoryScores
+  }
+})
+
+const savedBadges = {}
+
+beforeEach(() => {
+  mkdirSync(FIXTURES_DIR, { recursive: true })
+  const entries = Object.fromEntries(
+    readdirSync(BADGES_DIR).map((file) => [file, readFileSync(resolve(BADGES_DIR, file), 'utf8')])
+  )
+  Object.assign(savedBadges, entries)
+})
+
+afterEach(() => {
+  rmSync(FIXTURES_DIR, { recursive: true, force: true })
+  Object.entries(savedBadges).forEach(([file, content]) => {
+    writeFileSync(resolve(BADGES_DIR, file), content)
+  })
+})
+
+const runWithReport = (report) => {
+  const reportPath = resolve(FIXTURES_DIR, 'report.json')
+  writeFileSync(reportPath, JSON.stringify(report))
+  return execFileSync('node', [SCRIPT, reportPath], { encoding: 'utf8' })
+}
+
+const readBadge = (key) =>
+  JSON.parse(readFileSync(resolve(BADGES_DIR, `lighthouse-${key}.json`), 'utf8'))
+
+describe('generate-lighthouse-badges', () => {
+  it('writes all four badge files', () => {
+    runWithReport(makeReport())
+    ;['performance', 'accessibility', 'best-practices', 'seo'].forEach((key) => {
+      const badge = readBadge(key)
+      expect(badge.schemaVersion).toBe(1)
+      expect(typeof badge.label).toBe('string')
+      expect(typeof badge.message).toBe('string')
+      expect(typeof badge.color).toBe('string')
+    })
+  })
+
+  it.each([
+    [0.92, '92', 'brightgreen'],
+    [0.9, '90', 'brightgreen'],
+    [0.89, '89', 'orange'],
+    [0.85, '85', 'orange'],
+    [0.5, '50', 'orange'],
+    [0.49, '49', 'red'],
+    [0.43, '43', 'red'],
+    [0.0, '0', 'red']
+  ])('score %.2f → message "%s", color "%s"', (rawScore, expectedMessage, expectedColor) => {
+    runWithReport({ categories: { performance: { score: rawScore } } })
+    const badge = readBadge('performance')
+    expect(badge.message).toBe(expectedMessage)
+    expect(badge.color).toBe(expectedColor)
+  })
+
+  it('label uses spaces not hyphens', () => {
+    runWithReport(makeReport())
+    const badge = readBadge('best-practices')
+    expect(badge.label).toBe('best practices')
+  })
+
+  it('skips categories with null or missing scores', () => {
+    expect(() =>
+      runWithReport({ categories: { performance: { score: 0.9 }, accessibility: null } })
+    ).not.toThrow()
+  })
+
+  it('exits non-zero when no report path is given', () => {
+    expect(() => execFileSync('node', [SCRIPT], { encoding: 'utf8', stdio: 'pipe' })).toThrow()
+  })
+})


### PR DESCRIPTION
Closes #130

## Summary

- Adds a GitHub Actions workflow (`.github/workflows/lighthouse.yml`) that runs Lighthouse CI against `https://cnotv.github.io/generative-art/` after each GitHub Pages deploy
- A Node.js script (`scripts/generate-lighthouse-badges.mjs`) reads the Lighthouse JSON report and writes shields.io endpoint badge files to `badges/`
- The workflow commits updated badge files to main with `[skip ci]` so they stay current
- Four badges added to `README.md`: Performance, Accessibility, Best Practices, SEO

## How it works

1. GitHub Pages deploy completes
2. `lighthouse.yml` triggers via `workflow_run`
3. `treosh/lighthouse-ci-action` runs Lighthouse against the live URL
4. `generate-lighthouse-badges.mjs` converts scores to shields.io endpoint JSON
5. Badge files are committed to `badges/` on main
6. README badge images update automatically via the raw GitHub URL

## Badge color thresholds

- 90–100 → green
- 50–89 → orange
- 0–49 → red

## Test Plan

- [x] 12 Vitest tests cover score→color thresholds, shields.io schema, label formatting, null-score resilience, and missing-arg exit code
- [ ] Merge to main and verify the Lighthouse workflow triggers after the next GitHub Pages deploy
- [ ] Confirm `badges/lighthouse-*.json` files are committed with actual scores
- [ ] Verify README badges render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)