### PR TITLE
feat: Bubble Shooter game + shared LobbyLayout, GameHeader, and lobby composables

### DIFF
--- a/.github/rules/code-style.md
+++ b/.github/rules/code-style.md
@@ -106,6 +106,17 @@
 - **Layout contract**: Multiplayer game views must use a two-column CSS grid with `grid-area: main` for the game area and `grid-area: sidebar` for `MultiplayerSidebar`. On mobile (≤720px), sidebar is hidden/shown by a CSS modifier class toggled by `GameTabBar`.
 - **Adding a new multiplayer game**: Before building any UI, check that you are using `MultiplayerSidebar`, `GameTabBar`, and the two-column grid layout. Reuse `useMinigolfSession` as the reference pattern for P2P session management.
 
+## Lobby Game Development
+
+- **Single-player + multiplayer by default**: Every game must work in both solo mode and multiplayer unless the issue explicitly states otherwise. When only one player is present at game start, the game auto-starts in solo mode without requiring any extra UI.
+- **Always use `GameLobbyWizard`**: The lobby/profile/settings step must always use `src/components/GameLobbyWizard.vue`. Wrap it in a game-specific `<GameName>Lobby.vue` component that passes `configFields` (game-specific settings) and a `#rules` slot. Never build a custom lobby form.
+- **Standalone + Lobby-embedded**: Every game must work both as a direct route (`/games/<name>`) and when embedded in the Lobby view. Do not assume a parent context.
+- **Use `useRoomId()`**: Call `useRoomId()` from `src/composables/useRoomId.ts` at the top of the root game component to resolve or create a stable room ID. Never inline an IIFE pattern for this purpose.
+- **Use `useMultiplayerLobbyHandlers()`**: Call `useMultiplayerLobbyHandlers()` from `src/composables/useMultiplayerLobbyHandlers.ts` for standard lobby events (name change, color change, match found, leave room). Add only game-specific overrides on top; do not duplicate the shared logic.
+- **Vue-only logic → composable**: Any logic that is exclusively Vue reactive (refs, watchers, router, lifecycle hooks) and shared across games belongs in `src/composables/`. Framework-agnostic game logic belongs in `@webgamekit/*` packages.
+- **Header with "← Lobby" navigation**: Every game view must include a header component that navigates back to the Lobby. Follow the pattern established by `PictionaryHeader.vue` and `BubbleShooterHeader.vue` — a dedicated `<GameName>Header.vue` component that emits `leave-room`.
+- **Game-specific session composable**: Each game's P2P session logic must live in its own `use<GameName>Session.ts` composable co-located with the view. Use `useBubbleShooterSession` or `useMinigolfSession` as the reference pattern.
+
 ## Modular Architecture
 
 - **Reuse existing components**: Check and use existing components/libraries before creating new ones. Check `src/components/ui/` for shadcn UI components and other reusables in `src/components/`. Never reinvent the wheel.

--- a/documentation/docs/journey/bubble-shooter.md
+++ b/documentation/docs/journey/bubble-shooter.md
@@ -1,0 +1,113 @@
+---
+sidebar_position: 99
+---
+
+# Bubble Shooter: Hex Grid, Snap, Match, and Row Pressure
+
+This documents the non-obvious problems encountered while building the Bust-a-Move / Puzzle Bobble style bubble shooter (PR #145).
+
+## Hex grid: odd-row overflow
+
+The grid is 9 columns wide. Odd rows are offset right by half a bubble diameter to create the classic honeycomb pattern. The first implementation placed 9 bubbles in every row — but odd-row column 8 (zero-indexed) starts at x = 4.0 and has radius 0.5, so its right edge reaches x = 4.5, which is exactly on the wall boundary. Any floating-point overshoot caused the ball to clip through.
+
+The fix: odd rows have **8 columns** (`GRID_COLS - 1`), not 9. A single helper encapsulates this:
+
+```ts
+const rowColCount = (row: number): number => (row % 2 === 0 ? GRID_COLS : GRID_COLS - 1)
+```
+
+Every function that iterates columns — `createGrid`, `snapToCell`, `addGarbageRows`, `addTopRows` — uses this helper. Skipping it in any one place reintroduces the overflow.
+
+## Row drop parity: always add two rows
+
+When the grid descends under time pressure, adding **one** row flips the odd/even parity of every existing row. A bubble that was in an even row (straight alignment) becomes an odd row (offset alignment) — it visually jumps half a bubble width to the right. This looks like a glitch and shifts all snapping calculations.
+
+The invariant: **always add rows in multiples of 2**. `addTopRows(grid, 2)` is the only call site. Adding 2 preserves parity for all existing cells.
+
+## Camera aspect ratio: bypassing `getTools()`
+
+The `getEnvironment` helper inside `@webgamekit/threejs` initialises the camera aspect ratio from `window.innerWidth / window.innerHeight`. When a 280 px sidebar is present, the actual canvas is roughly 280 px narrower than the window. The result is an aspect ratio that is too wide — the grid appears shifted to the right and partially off-screen.
+
+The fix is to bypass `getTools()` entirely and initialise Three.js directly from the canvas element:
+
+```ts
+const w = el.clientWidth || el.offsetWidth || 400
+const h = el.clientHeight || el.offsetHeight || 600
+const renderer = new THREE.WebGLRenderer({ canvas: el, antialias: true })
+renderer.setSize(w, h, false)
+const camera = new THREE.PerspectiveCamera(CAMERA_FOV, w / h, 0.1, 1000)
+```
+
+A `ResizeObserver` watches the canvas element and updates the renderer and camera aspect whenever the sidebar appears or disappears.
+
+## Bubble generation: two-slot color queue
+
+The HUD shows two circles: the bubble currently loaded in the barrel (fires next) and a preview of the one after. The first implementation populated both from a single `pickNextColor()` call on shoot, so the "next" preview was replaced the moment the player fired — the displayed color changed mid-flight, making it impossible to plan.
+
+The correct model: **shift on landing, not on shoot**.
+
+```
+currentColor  ← the bubble that fires
+nextColor     ← the preview shown in HUD
+```
+
+On collision and snap:
+
+```ts
+ctx.currentColor.value = ctx.nextColor.value // shift
+ctx.nextColor.value = pickNextColor(ctx.grid) // refill preview
+ctx.loadedMesh.material = getMaterial(ctx, ctx.currentColor.value)
+ctx.loadedMesh.visible = true
+```
+
+On shoot, the loaded mesh is hidden (it becomes the in-flight mesh) but `currentColor` does not change until landing.
+
+## Stick logic: snapping to the nearest empty cell
+
+When the in-flight bubble collides with a grid bubble or reaches the ceiling, it must snap to the nearest valid empty hex cell. `snapToCell(hitX, hitY, grid)` iterates all cells, converts each to world coordinates via `cellToWorld(row, col)`, and returns the cell with the minimum Euclidean distance to the hit point. Cells where `col >= rowColCount(row)` are excluded.
+
+After snap:
+
+1. Set `grid[row][col].color` to the bubble's color.
+2. Place a mesh at the cell's world position.
+3. Run `findMatch` to check for a group of ≥ 3.
+4. Run `findDangling` to drop any bubbles disconnected from the ceiling.
+
+## Explode logic: BFS match and dangle
+
+**Match (pop):** `findMatch(row, col, grid)` runs a BFS from the placed cell, collecting all connected cells with the same color. If the group size is ≥ `MIN_MATCH_SIZE` (3), every cell in the group is cleared from the grid and its mesh is removed from the scene. Each popped bubble spawns 6 pop particles with randomised directions, 0.35 s lifetime, and 3.5 units/s speed.
+
+**Dangle (fall):** `findDangling(grid)` runs a second BFS starting from every filled cell in row 0 (the ceiling row). Any filled cell not reachable from row 0 is "dangling" — it has no path to the ceiling. Dangling cells are cleared and their meshes removed. This handles the common Bust-a-Move mechanic where popping a cluster causes a chain of unsupported bubbles to fall.
+
+Both passes happen on every landing, in order: match first, then dangle on whatever remains.
+
+## Advance logic: row pressure and game over
+
+**Row pressure:** every `rowDropMs` milliseconds (driven by the `speed` setting — 30 s slow, 20 s medium, 12 s fast), two new rows of randomly colored bubbles are prepended to the top of the grid. The accumulator pattern avoids `setInterval` drift:
+
+```ts
+ctx.rowDropAccumulator += delta * 1000
+if (ctx.rowDropAccumulator >= rowDropMs) {
+  ctx.rowDropAccumulator -= rowDropMs
+  ctx.grid = addTopRows(ctx.grid, 2)
+  rebuildAllMeshes(ctx)
+}
+```
+
+**Game over:** `hasReachedFireLine(grid, FIRE_LINE_Y)` scans all occupied cells and returns `true` if any cell's world Y coordinate is ≤ the fire line.
+
+The fire line Y is derived, not hardcoded:
+
+```ts
+export const FIRE_LINE_Y = GRID_TOP_Y - (GRID_ROWS - 2) * HEX_ROW_HEIGHT
+```
+
+An earlier version used `-6.0`. The grid bottom sits at approximately `-4.0`, so game-over never triggered — the fire line was below the grid entirely. The formula places it just above the last playable row regardless of grid dimensions.
+
+## Multiplayer: separate grids, garbage rows
+
+Each player manages their own local grid. The opponent's grid is never transmitted — only their score is broadcast via a `bs-score` channel.
+
+Clearing a complete row sends a `bs-garbage` message with a count. The opponent calls `addGarbageRows(grid, count)`, which prepends gray (`'garbage'`) rows to their grid. Gray bubbles participate in snap and dangle but not in match (they cannot form a color group).
+
+Game over is self-reported: `bs-gameover {}` tells the peer they are out. The receiver becomes the winner. This avoids needing to synchronise exact grid state across the network.

--- a/documentation/docs/journey/bubble-shooter.md
+++ b/documentation/docs/journey/bubble-shooter.md
@@ -8,106 +8,130 @@ This documents the non-obvious problems encountered while building the Bust-a-Mo
 
 ## Hex grid: odd-row overflow
 
-The grid is 9 columns wide. Odd rows are offset right by half a bubble diameter to create the classic honeycomb pattern. The first implementation placed 9 bubbles in every row — but odd-row column 8 (zero-indexed) starts at x = 4.0 and has radius 0.5, so its right edge reaches x = 4.5, which is exactly on the wall boundary. Any floating-point overshoot caused the ball to clip through.
+The grid is 9 columns wide. Odd rows are offset right by half a bubble diameter to create the classic honeycomb pattern. The first implementation placed 9 bubbles in every row — but the rightmost bubble in an offset row exceeds the wall boundary by half a radius, causing balls to clip through the wall.
 
-The fix: odd rows have **8 columns** (`GRID_COLS - 1`), not 9. A single helper encapsulates this:
-
-```ts
-const rowColCount = (row: number): number => (row % 2 === 0 ? GRID_COLS : GRID_COLS - 1)
-```
-
-Every function that iterates columns — `createGrid`, `snapToCell`, `addGarbageRows`, `addTopRows` — uses this helper. Skipping it in any one place reintroduces the overflow.
+The fix: odd rows hold one fewer column than even rows. A single helper encapsulates this rule, and every function that touches grid columns — creation, snapping, garbage insertion, row addition — delegates to it. Forgetting it in any one place reintroduces the overflow.
 
 ## Row drop parity: always add two rows
 
-When the grid descends under time pressure, adding **one** row flips the odd/even parity of every existing row. A bubble that was in an even row (straight alignment) becomes an odd row (offset alignment) — it visually jumps half a bubble width to the right. This looks like a glitch and shifts all snapping calculations.
+When the grid descends under time pressure, adding a single row flips the odd/even parity of every existing row. A bubble that was in an even row (straight alignment) becomes an odd row (offset by half a cell) — it visually jumps sideways. This looks like a glitch and corrupts all snapping calculations.
 
-The invariant: **always add rows in multiples of 2**. `addTopRows(grid, 2)` is the only call site. Adding 2 preserves parity for all existing cells.
+The invariant: **always add rows in multiples of 2**. Adding two rows preserves the parity of all existing cells and is the only valid call site for the row-addition utility.
 
 ## Camera aspect ratio: bypassing `getTools()`
 
-The `getEnvironment` helper inside `@webgamekit/threejs` initialises the camera aspect ratio from `window.innerWidth / window.innerHeight`. When a 280 px sidebar is present, the actual canvas is roughly 280 px narrower than the window. The result is an aspect ratio that is too wide — the grid appears shifted to the right and partially off-screen.
+The shared Three.js environment helper initialises the camera aspect ratio from the full window dimensions. When a sidebar is present, the actual canvas is several hundred pixels narrower than the window, making the aspect ratio too wide — the grid appears shifted to the right and partially off-screen.
 
-The fix is to bypass `getTools()` entirely and initialise Three.js directly from the canvas element:
-
-```ts
-const w = el.clientWidth || el.offsetWidth || 400
-const h = el.clientHeight || el.offsetHeight || 600
-const renderer = new THREE.WebGLRenderer({ canvas: el, antialias: true })
-renderer.setSize(w, h, false)
-const camera = new THREE.PerspectiveCamera(CAMERA_FOV, w / h, 0.1, 1000)
-```
-
-A `ResizeObserver` watches the canvas element and updates the renderer and camera aspect whenever the sidebar appears or disappears.
+The fix is to bypass the shared helper entirely and read the canvas element's own dimensions at init time. A `ResizeObserver` then watches the canvas and corrects the camera aspect whenever the sidebar is toggled.
 
 ## Bubble generation: two-slot color queue
 
-The HUD shows two circles: the bubble currently loaded in the barrel (fires next) and a preview of the one after. The first implementation populated both from a single `pickNextColor()` call on shoot, so the "next" preview was replaced the moment the player fired — the displayed color changed mid-flight, making it impossible to plan.
+The HUD shows two circles: the bubble loaded in the barrel (fires next) and a preview of the one after. The first implementation refilled both slots the moment the player fired — the preview changed mid-flight, making ahead planning impossible.
 
-The correct model: **shift on landing, not on shoot**.
+The correct model shifts the queue **on landing, not on shoot**:
 
+```mermaid
+sequenceDiagram
+    participant Player
+    participant Barrel
+    participant Queue
+
+    Player->>Barrel: Shoot
+    Barrel-->>Player: In-flight bubble (currentColor)
+    Note over Queue: nextColor unchanged during flight
+
+    Barrel->>Queue: Ball lands
+    Queue->>Barrel: currentColor ← nextColor
+    Queue->>Queue: nextColor ← pick new color from grid
+    Barrel-->>Player: Load new bubble
 ```
-currentColor  ← the bubble that fires
-nextColor     ← the preview shown in HUD
-```
 
-On collision and snap:
-
-```ts
-ctx.currentColor.value = ctx.nextColor.value // shift
-ctx.nextColor.value = pickNextColor(ctx.grid) // refill preview
-ctx.loadedMesh.material = getMaterial(ctx, ctx.currentColor.value)
-ctx.loadedMesh.visible = true
-```
-
-On shoot, the loaded mesh is hidden (it becomes the in-flight mesh) but `currentColor` does not change until landing.
+On shoot, the loaded mesh is hidden and the in-flight mesh takes its place. `currentColor` does not change until the ball lands and snaps.
 
 ## Stick logic: snapping to the nearest empty cell
 
-When the in-flight bubble collides with a grid bubble or reaches the ceiling, it must snap to the nearest valid empty hex cell. `snapToCell(hitX, hitY, grid)` iterates all cells, converts each to world coordinates via `cellToWorld(row, col)`, and returns the cell with the minimum Euclidean distance to the hit point. Cells where `col >= rowColCount(row)` are excluded.
+When the in-flight bubble collides with a grid bubble or reaches the ceiling, it snaps to the nearest valid empty hex cell. The snap function iterates all grid cells, converts each to world coordinates, and picks the one with the shortest distance to the hit point. Cells beyond the column limit for their row are excluded.
 
-After snap:
-
-1. Set `grid[row][col].color` to the bubble's color.
-2. Place a mesh at the cell's world position.
-3. Run `findMatch` to check for a group of ≥ 3.
-4. Run `findDangling` to drop any bubbles disconnected from the ceiling.
+```mermaid
+flowchart TD
+    A[Ball collides or hits ceiling] --> B[Find nearest empty cell]
+    B --> C[Place bubble in grid]
+    C --> D[Run match check]
+    D --> E{Group ≥ 3?}
+    E -- Yes --> F[Pop matched bubbles]
+    E -- No --> G[Skip]
+    F --> H[Run dangle check]
+    G --> H
+    H --> I{Cells unreachable from ceiling?}
+    I -- Yes --> J[Drop dangling bubbles]
+    I -- No --> K[Done]
+    J --> K
+```
 
 ## Explode logic: BFS match and dangle
 
-**Match (pop):** `findMatch(row, col, grid)` runs a BFS from the placed cell, collecting all connected cells with the same color. If the group size is ≥ `MIN_MATCH_SIZE` (3), every cell in the group is cleared from the grid and its mesh is removed from the scene. Each popped bubble spawns 6 pop particles with randomised directions, 0.35 s lifetime, and 3.5 units/s speed.
+Two breadth-first searches run on every landing, in sequence.
 
-**Dangle (fall):** `findDangling(grid)` runs a second BFS starting from every filled cell in row 0 (the ceiling row). Any filled cell not reachable from row 0 is "dangling" — it has no path to the ceiling. Dangling cells are cleared and their meshes removed. This handles the common Bust-a-Move mechanic where popping a cluster causes a chain of unsupported bubbles to fall.
+**Match (pop):** Starting from the placed cell, BFS collects all connected cells of the same color. If the group reaches the minimum size (3), every cell in the group is cleared and removed from the scene. Each popped bubble spawns a small burst of particles.
 
-Both passes happen on every landing, in order: match first, then dangle on whatever remains.
+**Dangle (fall):** A second BFS starts from every filled cell in the top row (the ceiling). Any filled cell not reachable from the ceiling is dangling — it has no structural path upward. Dangling cells are cleared and removed. This handles the classic chain reaction where popping a cluster drops a hanging group below it.
+
+```mermaid
+flowchart LR
+    subgraph Match BFS
+        A[Start at placed cell] --> B[Collect same-color neighbors]
+        B --> C{Size ≥ min?}
+        C -- Yes --> D[Clear group + spawn particles]
+        C -- No --> E[Leave in place]
+    end
+
+    subgraph Dangle BFS
+        F[Start from ceiling row] --> G[Mark all reachable cells]
+        G --> H[Remaining filled cells = dangling]
+        H --> I[Clear dangling cells]
+    end
+
+    D --> F
+    E --> F
+```
 
 ## Advance logic: row pressure and game over
 
-**Row pressure:** every `rowDropMs` milliseconds (driven by the `speed` setting — 30 s slow, 20 s medium, 12 s fast), two new rows of randomly colored bubbles are prepended to the top of the grid. The accumulator pattern avoids `setInterval` drift:
+**Row pressure:** on a configurable interval (30 s slow / 20 s medium / 12 s fast), two new rows of randomly colored bubbles are prepended to the top. An accumulator tracks elapsed time per frame to avoid drift — no `setInterval`. After each addition, the grid checks whether any bubble has crossed the fire line.
 
-```ts
-ctx.rowDropAccumulator += delta * 1000
-if (ctx.rowDropAccumulator >= rowDropMs) {
-  ctx.rowDropAccumulator -= rowDropMs
-  ctx.grid = addTopRows(ctx.grid, 2)
-  rebuildAllMeshes(ctx)
-}
+**Game over trigger:**
+
+```mermaid
+flowchart TD
+    A[Frame tick] --> B[Add delta to accumulator]
+    B --> C{Accumulator ≥ interval?}
+    C -- No --> A
+    C -- Yes --> D[Subtract interval from accumulator]
+    D --> E[Add 2 rows at top]
+    E --> F[Rebuild all meshes]
+    F --> G{Any bubble below fire line?}
+    G -- No --> A
+    G -- Yes --> H[Game over]
 ```
 
-**Game over:** `hasReachedFireLine(grid, FIRE_LINE_Y)` scans all occupied cells and returns `true` if any cell's world Y coordinate is ≤ the fire line.
-
-The fire line Y is derived, not hardcoded:
-
-```ts
-export const FIRE_LINE_Y = GRID_TOP_Y - (GRID_ROWS - 2) * HEX_ROW_HEIGHT
-```
-
-An earlier version used `-6.0`. The grid bottom sits at approximately `-4.0`, so game-over never triggered — the fire line was below the grid entirely. The formula places it just above the last playable row regardless of grid dimensions.
+**Fire line position:** the fire line Y coordinate is derived from the grid dimensions — `top position minus (rows − 2) × row height`. An earlier version hardcoded it to a fixed value that sat below the grid's actual bottom, so the game-over check never triggered. The formula ensures the line is always just above the last playable row, regardless of grid size.
 
 ## Multiplayer: separate grids, garbage rows
 
-Each player manages their own local grid. The opponent's grid is never transmitted — only their score is broadcast via a `bs-score` channel.
+Each player manages their own local grid. The opponent's grid is never transmitted — only their score is broadcast over the network.
 
-Clearing a complete row sends a `bs-garbage` message with a count. The opponent calls `addGarbageRows(grid, count)`, which prepends gray (`'garbage'`) rows to their grid. Gray bubbles participate in snap and dangle but not in match (they cannot form a color group).
+```mermaid
+sequenceDiagram
+    participant A as Player A
+    participant B as Player B
 
-Game over is self-reported: `bs-gameover {}` tells the peer they are out. The receiver becomes the winner. This avoids needing to synchronise exact grid state across the network.
+    A->>A: Clear a complete row
+    A->>B: bs-garbage { count }
+    B->>B: Prepend gray rows to grid
+
+    B->>B: Bubbles reach fire line
+    B->>A: bs-gameover {}
+    A->>A: Declare self winner
+```
+
+Gray (garbage) bubbles participate in snap and dangle but not in match — they cannot form a color group and cannot be popped directly.

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -5,6 +5,7 @@
 // Light mode defaults; overridden in the dark-mode block below.
 :root {
   --game-ink: #111;
+  --game-own-msg-bg: #111;
   --game-ink-medium: #555;
   --game-ink-muted: #888;
   --game-border: rgba(0, 0, 0, 0.28);
@@ -173,6 +174,7 @@
 
   --game-msg-system-bg: #2a2208;
   --game-msg-error-bg: #2a0d0d;
+  --game-own-msg-bg: #3a3020;
 
   --panel-item-bg: hsl(0 0% 12%);
   --panel-item-bg-hover: hsl(0 0% 18%);

--- a/src/components/Chat/Chat.vue
+++ b/src/components/Chat/Chat.vue
@@ -171,7 +171,7 @@ watch(() => props.messages.length, scrollToBottom)
   border-radius: var(--radius-sm);
   background: var(--color-background);
   color: var(--color-foreground);
-  font-size: inherit;
+  font-size: var(--font-size-md, 1rem);
 }
 
 .chat__input:disabled {

--- a/src/components/GameHeader.vue
+++ b/src/components/GameHeader.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+const props = defineProps<{
+  roomId?: string
+}>()
+
+const emit = defineEmits<{
+  leaveRoom: []
+  copyLink: []
+}>()
+
+const route = useRoute()
+const router = useRouter()
+const fromLobby = computed(() => !!route.query.game)
+
+const handleBack = (): void => {
+  if (fromLobby.value) {
+    router.replace({ query: {} })
+  } else {
+    emit('leaveRoom')
+  }
+}
+</script>
+
+<template>
+  <header class="game-header">
+    <div class="game-header__left">
+      <button class="game-header__back" type="button" @click="handleBack">← Lobby</button>
+    </div>
+    <div v-if="!fromLobby && roomId" class="game-header__room">
+      <span class="game-header__room-label">Room:</span>
+      <code class="game-header__room-id">{{ roomId.slice(0, 8) }}</code>
+      <button class="game-header__copy-btn" type="button" @click="emit('copyLink')">
+        Copy link
+      </button>
+    </div>
+  </header>
+</template>
+
+<style scoped>
+.game-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+}
+
+.game-header__left,
+.game-header__room {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.game-header__back {
+  padding: var(--spacing-1) var(--spacing-3);
+  border: 2px solid var(--game-border);
+  border-radius: 999px;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 2px 2px 0 var(--game-border);
+  transition: transform 0.1s ease;
+  font-family: inherit;
+}
+
+.game-header__back:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 3px 3px 0 var(--game-border);
+}
+
+.game-header__room-label {
+  color: var(--game-ink);
+  font-weight: 700;
+}
+
+.game-header__room-id {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  padding: var(--spacing-1) var(--spacing-2);
+  background: var(--color-secondary);
+  border-radius: var(--radius-sm);
+}
+
+.game-header__copy-btn {
+  padding: var(--spacing-2) var(--spacing-4, 1rem);
+  border: 3px solid var(--game-border);
+  border-radius: 999px;
+  background: var(--game-accent, var(--color-primary));
+  color: var(--game-ink);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 3px 3px 0 var(--game-border);
+  transition: transform 0.1s ease;
+  font-family: inherit;
+}
+
+.game-header__copy-btn:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 4px 4px 0 var(--game-border);
+}
+</style>

--- a/src/components/GameLobbyWizard.vue
+++ b/src/components/GameLobbyWizard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, useSlots } from 'vue'
+import { ref, computed, watch, onMounted, useSlots, inject } from 'vue'
 import { useRoute } from 'vue-router'
 import { Check } from 'lucide-vue-next'
 import GameCard from '@/components/GameCard.vue'
@@ -73,11 +73,12 @@ const handleFieldChange = (field: LobbyConfigField, event: Event): void => {
 }
 
 const slots = useSlots()
-const hasRules = computed(() => !!slots.rules)
 const hasConfig = computed(() => !!slots.config)
-const rulesOpen = ref(false)
+
+const setRoomHidden = inject<((hidden: boolean) => void) | undefined>('setRoomHidden', undefined)
 
 watch(isPrivate, (priv) => {
+  setRoomHidden?.(priv)
   if (priv) stopSearching()
   else if (!fromLobby.value) startSearching()
 })
@@ -235,14 +236,6 @@ onMounted(() => {
         <button v-if="step > 1" class="glw__btn glw__btn--ghost" type="button" @click="goBack">
           ← Back
         </button>
-        <div v-if="hasRules" class="glw__rules">
-          <button class="glw__rules-btn" type="button" @click="rulesOpen = !rulesOpen">?</button>
-          <Transition name="glw-rules">
-            <div v-if="rulesOpen" class="glw__rules-panel">
-              <slot name="rules" />
-            </div>
-          </Transition>
-        </div>
         <span class="glw__nav-spacer" />
         <button
           v-if="step < totalSteps"
@@ -599,63 +592,6 @@ onMounted(() => {
 
 .glw__nav-spacer {
   flex: 1;
-}
-
-.glw__rules {
-  position: relative;
-}
-
-.glw__rules-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.5rem;
-  height: 1.5rem;
-  border: 2px solid var(--game-border);
-  border-radius: 50%;
-  background: var(--game-surface-subtle);
-  color: var(--game-ink);
-  font-size: 0.875rem;
-  font-weight: 900;
-  cursor: pointer;
-  box-shadow: 2px 2px 0 var(--game-border);
-  transition: transform 0.1s ease;
-  font-family: inherit;
-}
-
-.glw__rules-btn:hover {
-  transform: translate(-1px, -1px);
-  box-shadow: 3px 3px 0 var(--game-border);
-}
-
-.glw__rules-panel {
-  position: absolute;
-  bottom: calc(100% + var(--spacing-2));
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 100;
-  background: var(--game-surface-subtle);
-  border: 2px solid var(--game-border);
-  border-radius: 0.75rem;
-  box-shadow: 3px 3px 0 var(--game-border);
-  width: 18rem;
-  padding: var(--spacing-3) var(--spacing-3) var(--spacing-3) var(--spacing-5);
-  font-size: var(--font-size-sm);
-  line-height: 1.4;
-  color: var(--game-ink);
-}
-
-.glw-rules-enter-active,
-.glw-rules-leave-active {
-  transition:
-    opacity 0.15s ease,
-    transform 0.15s ease;
-}
-
-.glw-rules-enter-from,
-.glw-rules-leave-to {
-  opacity: 0;
-  transform: translateX(-50%) translateY(6px);
 }
 
 .glw__start-btn {

--- a/src/components/ui/color-picker/ColorPicker.vue
+++ b/src/components/ui/color-picker/ColorPicker.vue
@@ -13,7 +13,6 @@ const emit = defineEmits<{
 }>()
 
 const internalValue = ref(props.modelValue ?? '#000000')
-const colorInputReference = ref<HTMLInputElement | null>(null)
 
 watch(
   () => props.modelValue,
@@ -29,20 +28,10 @@ const handleColorChange = (event: Event) => {
   internalValue.value = target.value
   emit('update:modelValue', target.value)
 }
-
-const handleClick = () => {
-  if (!props.disabled && colorInputReference.value) {
-    colorInputReference.value.click()
-  }
-}
 </script>
 
 <template>
-  <div
-    class="color-picker"
-    :class="[$props.class, { 'color-picker--disabled': disabled }]"
-    @click="handleClick"
-  >
+  <div class="color-picker" :class="[$props.class, { 'color-picker--disabled': disabled }]">
     <div class="color-picker__swatch" :style="{ backgroundColor: internalValue }" />
     <span v-if="!hideValue" class="color-picker__hex">{{ internalValue }}</span>
     <input
@@ -61,6 +50,7 @@ const handleClick = () => {
   display: flex;
   align-items: center;
   cursor: pointer;
+  position: relative;
 }
 
 .color-picker--disabled {
@@ -83,9 +73,12 @@ const handleClick = () => {
 
 .color-picker__input {
   position: absolute;
+  inset: 0;
   opacity: 0;
-  pointer-events: none;
-  width: 0;
-  height: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+  border: none;
+  padding: 0;
 }
 </style>

--- a/src/composables/useMultiplayerLobbyHandlers.ts
+++ b/src/composables/useMultiplayerLobbyHandlers.ts
@@ -1,0 +1,55 @@
+import type { Ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { saveProfile } from '@/utils/playerProfile'
+
+type SessionInterface = {
+  updateProfile: (name: string, color: string) => void
+  reconnect: (roomId: string) => void
+}
+
+/**
+ * Shared lobby event handlers for all multiplayer games.
+ * Covers player profile updates and room navigation (match found, leave room).
+ * Game-specific logic (start, restart, solo) belongs in each game's component.
+ * @param playerName - Reactive player name ref.
+ * @param playerColor - Reactive player color ref.
+ * @param roomId - Reactive room ID ref.
+ * @param session - Session object exposing updateProfile and reconnect.
+ * @returns Event handler functions for use in the lobby template.
+ */
+export const useMultiplayerLobbyHandlers = (
+  playerName: Ref<string>,
+  playerColor: Ref<string>,
+  roomId: Ref<string>,
+  session: SessionInterface
+) => {
+  const router = useRouter()
+
+  const handleNameChange = (): void => {
+    const trimmed = playerName.value.trim()
+    if (!trimmed) return
+    session.updateProfile(trimmed, playerColor.value)
+    saveProfile(trimmed, playerColor.value)
+  }
+
+  const handleColorChange = (color: string): void => {
+    playerColor.value = color
+    session.updateProfile(playerName.value, color)
+    saveProfile(playerName.value, color)
+  }
+
+  const handleMatchFound = (gameRoomId: string): void => {
+    roomId.value = gameRoomId
+    router.replace({ query: { room: gameRoomId } })
+    session.reconnect(gameRoomId)
+  }
+
+  const handleLeaveRoom = (): void => {
+    const freshId = crypto.randomUUID()
+    roomId.value = freshId
+    router.replace({ query: { room: freshId } })
+    session.reconnect(freshId)
+  }
+
+  return { handleNameChange, handleColorChange, handleMatchFound, handleLeaveRoom }
+}

--- a/src/composables/useRoomId.ts
+++ b/src/composables/useRoomId.ts
@@ -1,0 +1,21 @@
+import { ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+/**
+ * Resolve or create a stable room ID from the current route query.
+ * If no `room` query param exists, a new UUID is generated and pushed to the URL.
+ * @returns Reactive `roomId` ref and the resolved string value.
+ */
+export const useRoomId = () => {
+  const route = useRoute()
+  const router = useRouter()
+
+  const existing = route.query.room as string | undefined
+  const resolved = existing ?? crypto.randomUUID()
+
+  if (!existing) {
+    router.replace({ query: { ...route.query, room: resolved } })
+  }
+
+  return { roomId: ref(resolved), resolvedRoomId: resolved }
+}

--- a/src/stores/bubbleShooter.ts
+++ b/src/stores/bubbleShooter.ts
@@ -1,0 +1,73 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import type { ChatMessage } from '@webgamekit/chat'
+import type { BsColorCount, BsSpeed } from '@/views/Games/BubbleShooter/config'
+
+export type BsPlayer = {
+  id: string
+  name: string
+  color: string
+  score: number
+}
+
+export type BsPhase = 'lobby' | 'playing' | 'summary'
+
+export const useBubbleShooterStore = defineStore('bubbleShooter', () => {
+  const players = ref<Record<string, BsPlayer>>({})
+  const messages = ref<ChatMessage[]>([])
+  const phase = ref<BsPhase>('lobby')
+  const winnerId = ref<string | null>(null)
+  const solo = ref(false)
+  const colorCount = ref<BsColorCount>(4)
+  const speed = ref<BsSpeed>('medium')
+
+  const playerList = computed(() => Object.values(players.value).sort((a, b) => b.score - a.score))
+
+  const hostId = computed(() => {
+    const ids = Object.keys(players.value)
+    return ids.length > 0 ? ids[0] : ''
+  })
+
+  const upsertPlayer = (player: BsPlayer): void => {
+    players.value = { ...players.value, [player.id]: { ...players.value[player.id], ...player } }
+  }
+
+  const removePlayer = (id: string): void => {
+    players.value = Object.fromEntries(Object.entries(players.value).filter(([pid]) => pid !== id))
+  }
+
+  const addScore = (id: string, points: number): void => {
+    const player = players.value[id]
+    if (!player) return
+    upsertPlayer({ ...player, score: player.score + points })
+  }
+
+  const appendMessage = (message: ChatMessage): void => {
+    messages.value = [...messages.value, message].slice(-200)
+  }
+
+  const reset = (): void => {
+    players.value = {}
+    messages.value = []
+    phase.value = 'lobby'
+    winnerId.value = null
+    solo.value = false
+  }
+
+  return {
+    players,
+    messages,
+    phase,
+    winnerId,
+    solo,
+    colorCount,
+    speed,
+    playerList,
+    hostId,
+    upsertPlayer,
+    removePlayer,
+    addScore,
+    appendMessage,
+    reset
+  }
+})

--- a/src/types/lobby.ts
+++ b/src/types/lobby.ts
@@ -2,7 +2,8 @@ export const GAME_TYPES = [
   'Pictionary',
   'SquaresMultiplayer',
   'WordleMultiplayer',
-  'Minigolf'
+  'Minigolf',
+  'BubbleShooter'
 ] as const
 
 export type GameType = (typeof GAME_TYPES)[number]

--- a/src/views/Games/BubbleShooter/BubbleShooter.vue
+++ b/src/views/Games/BubbleShooter/BubbleShooter.vue
@@ -1,0 +1,229 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, nextTick } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useBubbleShooterStore } from '@/stores/bubbleShooter'
+import { useBubbleShooterSession } from './useBubbleShooterSession'
+import { useBubbleShooterGame } from './useBubbleShooterGame'
+import { useRoomId } from '@/composables/useRoomId'
+import { useMultiplayerLobbyHandlers } from '@/composables/useMultiplayerLobbyHandlers'
+import {
+  loadProfile,
+  randomPick,
+  NAME_ADJECTIVES,
+  NAME_ANIMALS,
+  PLAYER_COLORS,
+  buildRandomGradient
+} from '@/utils/playerProfile'
+import MultiplayerSidebar, { type MultiplayerPlayer } from '@/components/MultiplayerSidebar.vue'
+import GameTabBar from '@/components/GameTabBar.vue'
+import GameHeader from '@/components/GameHeader.vue'
+import LobbyLayout from '@/views/Games/layout/LobbyLayout.vue'
+import BubbleShooterLobby from './BubbleShooterLobby.vue'
+import BubbleShooterGame from './BubbleShooterGame.vue'
+import BubbleShooterSummary from './BubbleShooterSummary.vue'
+
+const store = useBubbleShooterStore()
+const { phase, playerList, messages, winnerId, hostId, colorCount, speed } = storeToRefs(store)
+
+const storedProfile = loadProfile()
+const playerName = ref(
+  storedProfile?.name ?? `${randomPick(NAME_ADJECTIVES)}${randomPick(NAME_ANIMALS)}`
+)
+const playerColor = ref(storedProfile?.color ?? randomPick(PLAYER_COLORS))
+const backgroundStyle = { backgroundImage: buildRandomGradient() }
+
+const { roomId, resolvedRoomId } = useRoomId()
+
+// ---- game ref (canvas exposure) ----
+const gameReference = ref<InstanceType<typeof BubbleShooterGame> | null>(null)
+const canvas = computed(() => gameReference.value?.canvas ?? null)
+
+// ---- session (P2P) ----
+const session = useBubbleShooterSession(
+  { name: playerName.value, color: playerColor.value, roomId: resolvedRoomId },
+  (count) => game.receiveGarbage(count)
+)
+const { isHost, localPeerId } = session
+
+const solo = computed(() => store.solo)
+
+// ---- game (Three.js) ----
+const game = useBubbleShooterGame({
+  canvas,
+  isSolo: solo,
+  colorCount,
+  speed,
+  onScore: (points) => {
+    store.addScore(localPeerId.value, points)
+    if (!store.solo) session.broadcastScore(store.players[localPeerId.value]?.score ?? 0)
+  },
+  onGarbageSent: (count) => session.broadcastGarbage(count),
+  onGameOver: () => {
+    if (store.solo) {
+      store.phase = 'summary'
+    } else {
+      session.broadcastGameOver()
+    }
+  }
+})
+
+// ---- sidebar / tab bar ----
+const showSidebar = ref(false)
+const lastReadCount = ref(0)
+const unreadCount = computed(() => Math.max(0, messages.value.length - lastReadCount.value))
+
+watch(showSidebar, (open) => {
+  if (open) lastReadCount.value = messages.value.length
+})
+watch(messages, () => {
+  if (showSidebar.value) lastReadCount.value = messages.value.length
+})
+
+const sidebarPlayers = computed((): MultiplayerPlayer[] =>
+  playerList.value.map((p) => ({
+    id: p.id,
+    name: p.name,
+    color: p.color,
+    score: p.score,
+    isHost: p.id === hostId.value
+  }))
+)
+
+const opponentPlayer = computed(() => playerList.value.find((p) => p.id !== localPeerId.value))
+
+// ---- lifecycle ----
+watch(phase, async (newPhase) => {
+  if (newPhase === 'playing') {
+    await nextTick()
+    game.init()
+  }
+})
+
+const {
+  handleNameChange,
+  handleColorChange,
+  handleMatchFound,
+  handleLeaveRoom: leaveRoom
+} = useMultiplayerLobbyHandlers(playerName, playerColor, roomId, session)
+
+const handleLeaveRoom = (): void => {
+  store.solo = false
+  leaveRoom()
+}
+
+const handleStartGame = (): void => {
+  const isSolo = playerList.value.length <= 1
+  if (isSolo) {
+    store.solo = true
+    store.upsertPlayer({
+      id: localPeerId.value || 'solo',
+      name: playerName.value,
+      color: playerColor.value,
+      score: 0
+    })
+    store.phase = 'playing'
+  } else {
+    session.startGame()
+  }
+}
+
+const handleRestart = (): void => {
+  if (store.solo) {
+    store.phase = 'lobby'
+    store.solo = false
+  } else {
+    session.restartGame()
+  }
+}
+
+onMounted(() => {
+  session.init()
+})
+</script>
+
+<template>
+  <LobbyLayout
+    class="bs"
+    :phase="phase"
+    :show-sidebar="showSidebar"
+    :main-placement="phase === 'playing' ? 'fill' : 'center'"
+    :style="backgroundStyle"
+  >
+    <template #header>
+      <GameHeader @leave-room="handleLeaveRoom" />
+    </template>
+
+    <template #rules>
+      <ul>
+        <li>Aim with your mouse or finger and click/tap to shoot</li>
+        <li>Match <strong>3 or more</strong> bubbles of the same color to pop them</li>
+        <li>Bubbles no longer attached to the ceiling also fall</li>
+        <li>In multiplayer — clearing rows sends <strong>garbage</strong> to your opponent</li>
+        <li>Game ends when bubbles reach the fire line</li>
+      </ul>
+    </template>
+
+    <BubbleShooterLobby
+      v-if="phase === 'lobby'"
+      :player-name="playerName"
+      :player-color="playerColor"
+      :is-host="isHost"
+      :player-list="playerList"
+      :room-id="roomId"
+      :color-count="colorCount"
+      :speed="speed"
+      @update:player-name="playerName = $event"
+      @update:player-color="handleColorChange"
+      @update:color-count="colorCount = $event"
+      @update:speed="speed = $event"
+      @name-change="handleNameChange"
+      @start-game="handleStartGame"
+      @match-found="handleMatchFound"
+      @leave-room="handleLeaveRoom"
+    />
+
+    <BubbleShooterGame
+      v-else-if="phase === 'playing'"
+      ref="gameReference"
+      :score="game.score.value"
+      :shot-count="game.shotCount.value"
+      :current-color="game.currentColor.value"
+      :next-color="game.nextColor.value"
+      :opponent-score="opponentPlayer?.score"
+      :opponent-name="opponentPlayer?.name"
+    />
+
+    <BubbleShooterSummary
+      v-else
+      :player-list="playerList"
+      :winner-id="winnerId"
+      :local-peer-id="localPeerId"
+      :is-host="isHost || store.solo"
+      @restart="handleRestart"
+      @leave-room="handleLeaveRoom"
+    />
+
+    <template v-if="!store.solo" #sidebar>
+      <MultiplayerSidebar
+        :players="sidebarPlayers"
+        :local-peer-id="localPeerId"
+        :messages="messages"
+        chat-placeholder="Say something…"
+        @send="session.broadcastChat($event)"
+      />
+    </template>
+
+    <template v-if="!store.solo" #tabbar>
+      <GameTabBar v-model:show-sidebar="showSidebar" :unread-count="unreadCount" />
+    </template>
+  </LobbyLayout>
+</template>
+
+<style scoped>
+.bs {
+  --bs-accent: #4ecdc4;
+
+  background: var(--lb-bg);
+  font-family: 'Segoe UI', system-ui, sans-serif;
+}
+</style>

--- a/src/views/Games/BubbleShooter/BubbleShooterGame.vue
+++ b/src/views/Games/BubbleShooter/BubbleShooterGame.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { BubbleColor } from './config'
+import { COLOR_HEX } from './config'
+
+defineProps<{
+  score: number
+  shotCount: number
+  currentColor: BubbleColor
+  nextColor: BubbleColor
+  opponentScore?: number
+  opponentName?: string
+}>()
+
+const canvas = ref<HTMLCanvasElement | null>(null)
+defineExpose({ canvas })
+</script>
+
+<template>
+  <div class="bs-game">
+    <div class="bs-game__hud">
+      <div class="bs-game__hud-left">
+        <span class="bs-game__label">Score</span>
+        <span class="bs-game__value">{{ score }}</span>
+      </div>
+      <div class="bs-game__next">
+        <span
+          class="bs-game__next-bubble"
+          :style="{ background: `#${COLOR_HEX[currentColor].toString(16).padStart(6, '0')}` }"
+        />
+        <span class="bs-game__label">Next</span>
+        <span
+          class="bs-game__next-bubble bs-game__next-bubble--small"
+          :style="{ background: `#${COLOR_HEX[nextColor].toString(16).padStart(6, '0')}` }"
+        />
+      </div>
+      <div v-if="opponentName !== undefined" class="bs-game__hud-right">
+        <span class="bs-game__label">{{ opponentName }}</span>
+        <span class="bs-game__value">{{ opponentScore ?? 0 }}</span>
+      </div>
+    </div>
+    <div class="bs-game__canvas-wrap">
+      <canvas ref="canvas" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.bs-game {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  border-radius: var(--radius-lg, 1.25rem);
+  border: 3px solid var(--game-border);
+  box-shadow: 4px 4px 0 var(--game-border);
+}
+
+.bs-game__hud {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-2) var(--spacing-3);
+  background: var(--game-surface-subtle);
+  border-bottom: 2px solid var(--game-border);
+  flex-shrink: 0;
+  gap: var(--spacing-3);
+}
+
+.bs-game__hud-left,
+.bs-game__hud-right,
+.bs-game__next {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.bs-game__label {
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  color: var(--game-ink-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.bs-game__value {
+  font-size: var(--font-size-md, 1rem);
+  font-weight: 900;
+  color: var(--game-ink);
+  min-width: 3ch;
+  text-align: right;
+}
+
+.bs-game__next-bubble {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  border: 2px solid var(--game-border);
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.bs-game__next-bubble--small {
+  width: 0.875rem;
+  height: 0.875rem;
+  opacity: 0.75;
+}
+
+.bs-game__canvas-wrap {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+</style>

--- a/src/views/Games/BubbleShooter/BubbleShooterHeader.vue
+++ b/src/views/Games/BubbleShooter/BubbleShooterHeader.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+const route = useRoute()
+const router = useRouter()
+const fromLobby = computed(() => !!route.query.game)
+
+const emit = defineEmits<{ leaveRoom: [] }>()
+
+const handleBack = (): void => {
+  if (fromLobby.value) {
+    router.replace({ query: {} })
+  } else {
+    emit('leaveRoom')
+  }
+}
+</script>
+
+<template>
+  <header class="bs-header">
+    <button class="bs-header__back" type="button" @click="handleBack">← Lobby</button>
+  </header>
+</template>
+
+<style scoped>
+.bs-header {
+  grid-area: header;
+  display: flex;
+  align-items: center;
+  padding: 0 var(--spacing-3);
+  background: var(--game-surface-subtle);
+  border-bottom: 2px solid var(--game-border);
+  min-height: 2.5rem;
+  flex-shrink: 0;
+}
+
+.bs-header__back {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  color: var(--game-ink-muted);
+  padding: var(--spacing-1) var(--spacing-2);
+  border-radius: var(--radius-sm);
+  font-family: inherit;
+}
+
+.bs-header__back:hover {
+  color: var(--game-ink);
+  background: var(--game-surface-dim);
+}
+</style>

--- a/src/views/Games/BubbleShooter/BubbleShooterLobby.vue
+++ b/src/views/Games/BubbleShooter/BubbleShooterLobby.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import GameLobbyWizard from '@/components/GameLobbyWizard.vue'
+import type { LobbyPlayer } from '@/types/lobbyWizard'
+import type { LobbyConfigField } from '@/types/lobbyWizard'
+import { MATCHMAKER_ROOM, type BsColorCount, type BsSpeed } from './config'
+
+const props = defineProps<{
+  playerName: string
+  playerColor: string
+  isHost: boolean
+  playerList: LobbyPlayer[]
+  roomId: string
+  colorCount: BsColorCount
+  speed: BsSpeed
+}>()
+
+const emit = defineEmits<{
+  'update:playerName': [value: string]
+  'update:playerColor': [value: string]
+  'update:colorCount': [value: BsColorCount]
+  'update:speed': [value: BsSpeed]
+  nameChange: []
+  startGame: []
+  matchFound: [roomId: string]
+  leaveRoom: []
+}>()
+
+const configFields = computed((): LobbyConfigField[] => [
+  {
+    type: 'select',
+    key: 'colorCount',
+    label: 'Colors',
+    value: props.colorCount,
+    options: [
+      { value: 3, label: '3 colors — easier' },
+      { value: 4, label: '4 colors' },
+      { value: 5, label: '5 colors — harder' }
+    ]
+  },
+  {
+    type: 'select',
+    key: 'speed',
+    label: 'Speed',
+    value: props.speed,
+    options: [
+      { value: 'slow', label: 'Slow — rows drop rarely' },
+      { value: 'medium', label: 'Medium' },
+      { value: 'fast', label: 'Fast — rows drop quickly' }
+    ]
+  }
+])
+
+const handleConfig = (key: string, value: string | number): void => {
+  if (key === 'colorCount') emit('update:colorCount', Number(value) as BsColorCount)
+  if (key === 'speed') emit('update:speed', value as BsSpeed)
+}
+</script>
+
+<template>
+  <section class="bs-lobby">
+    <GameLobbyWizard
+      :player-name="playerName"
+      :player-color="playerColor"
+      :is-host="isHost"
+      :player-list="playerList"
+      :room-id="roomId"
+      :matchmaker-room="MATCHMAKER_ROOM"
+      :config-fields="configFields"
+      accent-color="var(--bs-accent)"
+      @update:player-name="emit('update:playerName', $event)"
+      @update:player-color="emit('update:playerColor', $event)"
+      @name-change="emit('nameChange')"
+      @config-change="handleConfig"
+      @start-game="emit('startGame')"
+      @match-found="emit('matchFound', $event)"
+      @leave-room="emit('leaveRoom')"
+    />
+  </section>
+</template>
+
+<style scoped>
+.bs-lobby {
+  grid-area: main;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
+}
+</style>

--- a/src/views/Games/BubbleShooter/BubbleShooterSummary.vue
+++ b/src/views/Games/BubbleShooter/BubbleShooterSummary.vue
@@ -1,0 +1,174 @@
+<script setup lang="ts">
+import type { BsPlayer } from '@/stores/bubbleShooter'
+
+defineProps<{
+  playerList: BsPlayer[]
+  winnerId: string | null
+  localPeerId: string
+  isHost: boolean
+}>()
+
+const emit = defineEmits<{
+  restart: []
+  leaveRoom: []
+}>()
+</script>
+
+<template>
+  <section class="bs-summary">
+    <div class="bs-summary__card">
+      <h2 class="bs-summary__title">
+        {{ winnerId === localPeerId ? 'You win! 🎉' : 'Game over!' }}
+      </h2>
+
+      <ul class="bs-summary__scores">
+        <li
+          v-for="(player, index) in playerList"
+          :key="player.id"
+          class="bs-summary__row"
+          :class="{ 'bs-summary__row--winner': player.id === winnerId }"
+        >
+          <span class="bs-summary__rank">{{ index + 1 }}</span>
+          <span class="bs-summary__dot" :style="{ background: player.color }" />
+          <span class="bs-summary__name">{{ player.name }}</span>
+          <span class="bs-summary__pts">{{ player.score }} pts</span>
+        </li>
+      </ul>
+
+      <div class="bs-summary__actions">
+        <button
+          v-if="isHost"
+          class="bs-summary__btn bs-summary__btn--primary"
+          type="button"
+          @click="emit('restart')"
+        >
+          Play again
+        </button>
+        <p v-else class="bs-summary__waiting">Waiting for host to restart…</p>
+        <button class="bs-summary__btn" type="button" @click="emit('leaveRoom')">
+          Back to lobby
+        </button>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.bs-summary {
+  grid-area: main;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-4);
+}
+
+.bs-summary__card {
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
+  border: 3px solid var(--game-border);
+  border-radius: var(--radius-lg, 1.25rem);
+  box-shadow: 5px 5px 0 var(--game-border);
+  padding: var(--spacing-5, 2rem);
+  max-width: 26rem;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4, 1.5rem);
+  text-align: center;
+}
+
+.bs-summary__title {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 900;
+  color: var(--game-ink);
+}
+
+.bs-summary__scores {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.bs-summary__row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 2px solid var(--game-surface-dim);
+  border-radius: 999px;
+}
+
+.bs-summary__row--winner {
+  border-color: var(--bs-accent);
+  background: color-mix(in srgb, var(--bs-accent) 10%, transparent);
+}
+
+.bs-summary__rank {
+  font-size: var(--font-size-sm);
+  font-weight: 800;
+  color: var(--game-ink-muted);
+  min-width: 1.25rem;
+  text-align: center;
+}
+
+.bs-summary__dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  border: 2px solid var(--game-border);
+  flex-shrink: 0;
+}
+
+.bs-summary__name {
+  flex: 1;
+  font-weight: 700;
+  font-size: var(--font-size-sm);
+  text-align: left;
+}
+
+.bs-summary__pts {
+  font-weight: 800;
+  font-size: var(--font-size-sm);
+}
+
+.bs-summary__actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  align-items: center;
+}
+
+.bs-summary__btn {
+  padding: var(--spacing-3) var(--spacing-5, 1.5rem);
+  border: 3px solid var(--game-border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--game-ink);
+  font-size: var(--font-size-md, 1rem);
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow: 3px 3px 0 var(--game-border);
+  transition: transform 0.1s ease;
+  font-family: inherit;
+}
+
+.bs-summary__btn--primary {
+  background: var(--bs-accent);
+  color: #fff;
+}
+
+.bs-summary__btn:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 4px 4px 0 var(--game-border);
+}
+
+.bs-summary__waiting {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--game-ink-muted);
+}
+</style>

--- a/src/views/Games/BubbleShooter/bubbleShooterUtilities.test.ts
+++ b/src/views/Games/BubbleShooter/bubbleShooterUtilities.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createGrid,
+  cellToWorld,
+  worldToNearestCell,
+  getNeighbors,
+  findMatch,
+  findDangling,
+  snapToCell,
+  trajectoryPoints,
+  hasReachedFireLine,
+  addGarbageRows,
+  addTopRows
+} from './bubbleShooterUtilities'
+import {
+  GRID_ROWS,
+  GRID_COLS,
+  GRID_TOP_Y,
+  BUBBLE_DIAMETER,
+  HEX_ROW_HEIGHT,
+  BUBBLE_RADIUS,
+  FIRE_LINE_Y,
+  WALL_LEFT,
+  WALL_RIGHT
+} from './config'
+import type { Grid } from './bubbleShooterUtilities'
+
+const emptyGrid = (): Grid =>
+  Array.from({ length: GRID_ROWS }, () =>
+    Array.from({ length: GRID_COLS }, () => ({ color: null }))
+  )
+
+describe('createGrid', () => {
+  it('creates a grid with correct dimensions', () => {
+    const grid = createGrid(0)
+    expect(grid).toHaveLength(GRID_ROWS)
+    expect(grid[0]).toHaveLength(GRID_COLS)
+  })
+
+  it('fills top rows with colors (respecting odd-row column limit)', () => {
+    const grid = createGrid(3)
+    const filledRange = Array.from({ length: 3 }, (_, i) => i)
+    const emptyRange = Array.from({ length: GRID_ROWS - 3 }, (_, i) => i + 3)
+    const colCount = (r: number): number => (r % 2 === 0 ? GRID_COLS : GRID_COLS - 1)
+
+    filledRange.forEach((r) =>
+      Array.from({ length: colCount(r) }, (_, c) => c).forEach((c) => {
+        expect(grid[r][c].color).not.toBeNull()
+      })
+    )
+    emptyRange.forEach((r) =>
+      Array.from({ length: GRID_COLS }, (_, c) => c).forEach((c) => {
+        expect(grid[r][c].color).toBeNull()
+      })
+    )
+  })
+})
+
+describe('cellToWorld', () => {
+  it('places row 0 col 0 at the correct world position', () => {
+    const { x, y } = cellToWorld(0, 0)
+    expect(y).toBeCloseTo(GRID_TOP_Y)
+    expect(x).toBeCloseTo(-((GRID_COLS - 1) / 2) * BUBBLE_DIAMETER)
+  })
+
+  it('shifts odd rows right by half a bubble', () => {
+    const even = cellToWorld(0, 0)
+    const odd = cellToWorld(1, 0)
+    expect(odd.x - even.x).toBeCloseTo(BUBBLE_RADIUS)
+  })
+
+  it('increases row index decreases y by HEX_ROW_HEIGHT', () => {
+    const r0 = cellToWorld(0, 0)
+    const r1 = cellToWorld(1, 0)
+    expect(r0.y - r1.y).toBeCloseTo(HEX_ROW_HEIGHT)
+  })
+})
+
+describe('worldToNearestCell', () => {
+  it('round-trips through cellToWorld', () => {
+    const { x, y } = cellToWorld(2, 4)
+    const { row, col } = worldToNearestCell(x, y)
+    expect(row).toBe(2)
+    expect(col).toBe(4)
+  })
+
+  it('clamps out-of-bounds positions', () => {
+    const { row, col } = worldToNearestCell(1000, 1000)
+    expect(row).toBeGreaterThanOrEqual(0)
+    expect(row).toBeLessThan(GRID_ROWS)
+    expect(col).toBeGreaterThanOrEqual(0)
+    expect(col).toBeLessThan(GRID_COLS)
+  })
+})
+
+describe('getNeighbors', () => {
+  it('returns left and right neighbors for same row', () => {
+    const grid = createGrid(5)
+    const neighbors = getNeighbors(0, 4, grid)
+    const cols = neighbors.map(([, c]) => c)
+    expect(cols).toContain(3)
+    expect(cols).toContain(5)
+  })
+
+  it('returns no neighbors for an empty grid', () => {
+    const grid = emptyGrid()
+    const neighbors = getNeighbors(2, 2, grid)
+    expect(neighbors).toHaveLength(0)
+  })
+
+  it.each([
+    [0, 0],
+    [0, GRID_COLS - 1],
+    [GRID_ROWS - 1, 0]
+  ])('does not return out-of-bounds neighbors for cell (%i, %i)', (row, col) => {
+    const grid = createGrid(GRID_ROWS)
+    const neighbors = getNeighbors(row, col, grid)
+    neighbors.forEach(([r, c]) => {
+      expect(r).toBeGreaterThanOrEqual(0)
+      expect(r).toBeLessThan(GRID_ROWS)
+      expect(c).toBeGreaterThanOrEqual(0)
+      expect(c).toBeLessThan(GRID_COLS)
+    })
+  })
+})
+
+describe('findMatch', () => {
+  it('returns empty array when group is smaller than MIN_MATCH_SIZE', () => {
+    const grid = emptyGrid()
+    grid[0][0] = { color: 'red' }
+    grid[0][1] = { color: 'red' }
+    const match = findMatch(0, 0, grid)
+    expect(match).toHaveLength(0)
+  })
+
+  it('returns the full connected group when ≥ 3', () => {
+    const grid = emptyGrid()
+    grid[0][0] = { color: 'blue' }
+    grid[0][1] = { color: 'blue' }
+    grid[0][2] = { color: 'blue' }
+    const match = findMatch(0, 0, grid)
+    expect(match).toHaveLength(3)
+  })
+
+  it('does not cross into different colors', () => {
+    const grid = emptyGrid()
+    grid[0][0] = { color: 'red' }
+    grid[0][1] = { color: 'red' }
+    grid[0][2] = { color: 'red' }
+    grid[0][3] = { color: 'blue' }
+    const match = findMatch(0, 3, grid)
+    expect(match).toHaveLength(0)
+  })
+
+  it('returns empty array for a null cell', () => {
+    const grid = emptyGrid()
+    const match = findMatch(5, 5, grid)
+    expect(match).toHaveLength(0)
+  })
+})
+
+describe('findDangling', () => {
+  it('returns empty array when all bubbles are connected to ceiling', () => {
+    const grid = emptyGrid()
+    grid[0][0] = { color: 'red' }
+    grid[1][0] = { color: 'red' }
+    const dangling = findDangling(grid)
+    expect(dangling).toHaveLength(0)
+  })
+
+  it('detects bubbles with no path to row 0', () => {
+    const grid = emptyGrid()
+    grid[3][3] = { color: 'green' }
+    const dangling = findDangling(grid)
+    expect(dangling).toHaveLength(1)
+    expect(dangling[0]).toEqual([3, 3])
+  })
+
+  it('returns empty array for a completely empty grid', () => {
+    const grid = emptyGrid()
+    expect(findDangling(grid)).toHaveLength(0)
+  })
+})
+
+describe('snapToCell', () => {
+  it('snaps to the nearest empty cell', () => {
+    const grid = emptyGrid()
+    const { x, y } = cellToWorld(3, 4)
+    const result = snapToCell(x, y, grid)
+    expect(result).not.toBeNull()
+    expect(result!.row).toBe(3)
+    expect(result!.col).toBe(4)
+  })
+
+  it('avoids occupied cells', () => {
+    const grid = emptyGrid()
+    grid[3][4] = { color: 'red' }
+    const { x, y } = cellToWorld(3, 4)
+    const result = snapToCell(x, y, grid)
+    if (result) {
+      expect(grid[result.row][result.col].color).toBeNull()
+    }
+  })
+})
+
+const defaultConfig = {
+  wallLeft: WALL_LEFT,
+  wallRight: WALL_RIGHT,
+  ceilingY: GRID_TOP_Y
+}
+
+describe('trajectoryPoints', () => {
+  it('returns at least 2 points', () => {
+    const grid = emptyGrid()
+    const pts = trajectoryPoints(0, 0, -7.5, grid, defaultConfig)
+    expect(pts.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('starts at the shooter position', () => {
+    const grid = emptyGrid()
+    const pts = trajectoryPoints(0, 0, -7.5, grid, defaultConfig)
+    expect(pts[0]).toEqual({ x: 0, y: -7.5 })
+  })
+
+  it('stops at or before the ceiling', () => {
+    const grid = emptyGrid()
+    const pts = trajectoryPoints(0, 0, -7.5, grid, defaultConfig)
+    const last = pts[pts.length - 1]
+    expect(last.y).toBeLessThanOrEqual(GRID_TOP_Y + 0.01)
+  })
+
+  it('reflects off walls (x stays within bounds)', () => {
+    const grid = emptyGrid()
+    const pts = trajectoryPoints(Math.PI * 0.4, 0, -7.5, grid, defaultConfig)
+    pts.forEach(({ x }) => {
+      expect(x).toBeGreaterThanOrEqual(WALL_LEFT - 0.5)
+      expect(x).toBeLessThanOrEqual(WALL_RIGHT + 0.5)
+    })
+  })
+})
+
+describe('hasReachedFireLine', () => {
+  it('returns false for an empty grid', () => {
+    expect(hasReachedFireLine(emptyGrid(), FIRE_LINE_Y)).toBe(false)
+  })
+
+  it('returns true when a bubble is at or below the fire line', () => {
+    const grid = emptyGrid()
+    const lastRow = GRID_ROWS - 1
+    grid[lastRow][0] = { color: 'red' }
+    expect(hasReachedFireLine(grid, GRID_TOP_Y)).toBe(true)
+  })
+})
+
+describe('addGarbageRows', () => {
+  it('inserts garbage rows at the top', () => {
+    const grid = emptyGrid()
+    grid[0][0] = { color: 'red' }
+    const newGrid = addGarbageRows(grid, 1)
+    expect(newGrid[0][0].color).toBe('garbage')
+    expect(newGrid[1][0].color).toBe('red')
+  })
+
+  it('keeps total row count the same', () => {
+    const newGrid = addGarbageRows(emptyGrid(), 2)
+    expect(newGrid).toHaveLength(GRID_ROWS)
+  })
+})
+
+describe('addTopRows', () => {
+  it('shifts existing content down', () => {
+    const grid = emptyGrid()
+    grid[0][0] = { color: 'blue' }
+    const newGrid = addTopRows(grid, 1)
+    expect(newGrid[1][0].color).toBe('blue')
+  })
+
+  it('fills new top rows with non-null colors (respecting odd-row column limit)', () => {
+    const newGrid = addTopRows(emptyGrid(), 2)
+    const colCount = (r: number): number => (r % 2 === 0 ? GRID_COLS : GRID_COLS - 1)
+    Array.from({ length: colCount(0) }, (_, c) => c).forEach((c) => {
+      expect(newGrid[0][c].color).not.toBeNull()
+    })
+    Array.from({ length: colCount(1) }, (_, c) => c).forEach((c) => {
+      expect(newGrid[1][c].color).not.toBeNull()
+    })
+  })
+})

--- a/src/views/Games/BubbleShooter/bubbleShooterUtilities.ts
+++ b/src/views/Games/BubbleShooter/bubbleShooterUtilities.ts
@@ -1,0 +1,365 @@
+import {
+  GRID_ROWS,
+  GRID_COLS,
+  BUBBLE_DIAMETER,
+  HEX_ROW_HEIGHT,
+  BUBBLE_RADIUS,
+  GRID_TOP_Y,
+  MIN_MATCH_SIZE,
+  BUBBLE_COLORS,
+  INITIAL_FILLED_ROWS,
+  type BubbleColor
+} from './config'
+import type { GridCell, Grid, Coord, TrajectoryConfig } from './types'
+
+export type { GridCell, Grid, Coord, TrajectoryConfig }
+
+const rowRange = Array.from({ length: GRID_ROWS }, (_, i) => i)
+const colRange = Array.from({ length: GRID_COLS }, (_, i) => i)
+
+/** Odd rows have one fewer column to stay within the wall boundaries. */
+const rowColCount = (row: number): number => (row % 2 === 0 ? GRID_COLS : GRID_COLS - 1)
+
+/**
+ * Create an empty grid with a given number of pre-filled rows at the top.
+ * @param filledRows - Number of rows to fill with random colors.
+ * @returns A fresh GRID_ROWS × GRID_COLS grid.
+ */
+export const createGrid = (
+  filledRows = INITIAL_FILLED_ROWS,
+  colorCount: number = BUBBLE_COLORS.length
+): Grid => {
+  const palette = BUBBLE_COLORS.slice(0, colorCount)
+  return rowRange.map((row) =>
+    colRange.map((col) => ({
+      color:
+        row < filledRows && col < rowColCount(row)
+          ? (palette[Math.floor(Math.random() * palette.length)] as BubbleColor)
+          : null
+    }))
+  )
+}
+
+/**
+ * Convert grid coordinates to world-space center position.
+ * @param row - Grid row (0 = top).
+ * @param col - Grid column.
+ * @returns World x/y center of that cell.
+ */
+export const cellToWorld = (row: number, col: number): { x: number; y: number } => ({
+  x: (col - (GRID_COLS - 1) / 2) * BUBBLE_DIAMETER + (row % 2 === 1 ? BUBBLE_RADIUS : 0),
+  y: GRID_TOP_Y - row * HEX_ROW_HEIGHT
+})
+
+/**
+ * Find the grid cell nearest to a world-space position (may be occupied).
+ * @param x - World x.
+ * @param y - World y.
+ * @returns Nearest { row, col } clamped to grid bounds.
+ */
+export const worldToNearestCell = (x: number, y: number): { row: number; col: number } => {
+  const rawRow = Math.round((GRID_TOP_Y - y) / HEX_ROW_HEIGHT)
+  const row = Math.max(0, Math.min(GRID_ROWS - 1, rawRow))
+  const offsetX = x - (row % 2 === 1 ? BUBBLE_RADIUS : 0)
+  const col = Math.round(offsetX / BUBBLE_DIAMETER + (GRID_COLS - 1) / 2)
+  return { row, col: Math.max(0, Math.min(GRID_COLS - 1, col)) }
+}
+
+const isInBounds = (r: number, c: number): boolean =>
+  r >= 0 && r < GRID_ROWS && c >= 0 && c < GRID_COLS
+
+/**
+ * Return all occupied neighbors of a grid cell, accounting for hex offset.
+ * @param row - Cell row.
+ * @param col - Cell column.
+ * @param grid - Current grid state.
+ * @returns Array of [row, col] pairs for occupied neighbors.
+ */
+export const getNeighbors = (row: number, col: number, grid: Grid): Coord[] => {
+  const isOdd = row % 2 === 1
+  const candidates: Coord[] = [
+    [row, col - 1],
+    [row, col + 1],
+    [row - 1, isOdd ? col : col - 1],
+    [row - 1, isOdd ? col + 1 : col],
+    [row + 1, isOdd ? col : col - 1],
+    [row + 1, isOdd ? col + 1 : col]
+  ]
+  return candidates.filter(([r, c]) => isInBounds(r, c) && grid[r][c].color !== null)
+}
+
+/**
+ * BFS from a cell to find all connected cells of the same color.
+ * @param startRow - Starting row.
+ * @param startCol - Starting column.
+ * @param grid - Current grid state.
+ * @returns All cells in the matching group (empty array if group < MIN_MATCH_SIZE).
+ */
+export const findMatch = (startRow: number, startCol: number, grid: Grid): Coord[] => {
+  const targetColor = grid[startRow]?.[startCol]?.color
+  if (!targetColor) return []
+
+  const bfsStep = (state: {
+    visited: Set<string>
+    result: Coord[]
+    queue: Coord[]
+  }): typeof state => {
+    if (state.queue.length === 0) return state
+    const [[r, c], ...rest] = state.queue
+    const key = `${r},${c}`
+    if (state.visited.has(key)) return bfsStep({ ...state, queue: rest })
+    const nextVisited = new Set(state.visited)
+    nextVisited.add(key)
+    if (grid[r][c].color !== targetColor)
+      return bfsStep({ ...state, visited: nextVisited, queue: rest })
+    const nextQueue = [
+      ...rest,
+      ...getNeighbors(r, c, grid).filter(
+        ([nr, nc]) => !nextVisited.has(`${nr},${nc}`) && grid[nr][nc].color === targetColor
+      )
+    ]
+    return bfsStep({ visited: nextVisited, result: [...state.result, [r, c]], queue: nextQueue })
+  }
+
+  const { result } = bfsStep({ visited: new Set(), result: [], queue: [[startRow, startCol]] })
+  return result.length >= MIN_MATCH_SIZE ? result : []
+}
+
+/**
+ * BFS from the top row to find all reachable cells; return all that are NOT reachable (dangling).
+ * @param grid - Current grid state.
+ * @returns Array of [row, col] pairs for dangling (unsupported) cells.
+ */
+export const findDangling = (grid: Grid): Coord[] => {
+  const initialQueue: Coord[] = colRange
+    .filter((c) => grid[0][c].color !== null)
+    .map((c): Coord => [0, c])
+
+  const bfsStep = (state: { visited: Set<string>; queue: Coord[] }): typeof state => {
+    if (state.queue.length === 0) return state
+    const [[r, c], ...rest] = state.queue
+    const key = `${r},${c}`
+    if (state.visited.has(key)) return bfsStep({ ...state, queue: rest })
+    const nextVisited = new Set(state.visited)
+    nextVisited.add(key)
+    const nextQueue = [
+      ...rest,
+      ...getNeighbors(r, c, grid).filter(([nr, nc]) => !nextVisited.has(`${nr},${nc}`))
+    ]
+    return bfsStep({ visited: nextVisited, queue: nextQueue })
+  }
+
+  const { visited: reachable } = bfsStep({ visited: new Set(), queue: initialQueue })
+
+  return rowRange.flatMap((r) =>
+    colRange
+      .filter((c) => grid[r][c].color !== null && !reachable.has(`${r},${c}`))
+      .map((c): Coord => [r, c])
+  )
+}
+
+/**
+ * Find the nearest empty grid cell to a world-space position.
+ * @param x - World x of landing point.
+ * @param y - World y of landing point.
+ * @param grid - Current grid state.
+ * @returns Nearest empty { row, col }, or null if none found nearby.
+ */
+export const snapToCell = (
+  x: number,
+  y: number,
+  grid: Grid
+): { row: number; col: number } | null => {
+  const { row: nearRow, col: nearCol } = worldToNearestCell(x, y)
+  const offsets = [-2, -1, 0, 1, 2]
+  const candidates = offsets.flatMap((dr) =>
+    offsets
+      .map((dc): Coord => [nearRow + dr, nearCol + dc])
+      .filter(([r, c]) => isInBounds(r, c) && c < rowColCount(r) && grid[r][c].color === null)
+  )
+  if (candidates.length === 0) return null
+  return candidates.reduce<{ row: number; col: number; dist: number }>(
+    (best, [r, c]) => {
+      const { x: wx, y: wy } = cellToWorld(r, c)
+      const distribution = Math.hypot(wx - x, wy - y)
+      return distribution < best.dist ? { row: r, col: c, dist: distribution } : best
+    },
+    { row: -1, col: -1, dist: Infinity }
+  )
+}
+
+/**
+ * Compute the preview trajectory as a series of world-space points.
+ * Reflects off left/right walls and stops at the ceiling or a grid bubble.
+ * @param angle - Aim angle in radians (0 = straight up).
+ * @param shooterX - Shooter world x.
+ * @param shooterY - Shooter world y.
+ * @param grid - Current grid state (to stop preview at existing bubbles).
+ * @param config - Wall/ceiling bounds and tuning parameters.
+ * @returns Array of {x, y} world points forming the trajectory.
+ */
+export const trajectoryPoints = (
+  angle: number,
+  shooterX: number,
+  shooterY: number,
+  grid: Grid,
+  config: TrajectoryConfig
+): { x: number; y: number }[] => {
+  const {
+    wallLeft,
+    wallRight,
+    ceilingY,
+    maxReflections = 2,
+    stepSize = 0.15,
+    maxSteps = 300
+  } = config
+
+  type TrajectoryState = {
+    x: number
+    y: number
+    dx: number
+    dy: number
+    reflections: number
+    points: { x: number; y: number }[]
+    done: boolean
+  }
+
+  const step = (state: TrajectoryState): TrajectoryState => {
+    if (state.done) return state
+    let { x, y, dx, reflections } = state
+    const { dy } = state
+    x += dx * stepSize
+    y += dy * stepSize
+
+    if (x <= wallLeft) {
+      x = wallLeft
+      dx = Math.abs(dx)
+      reflections++
+    } else if (x >= wallRight) {
+      x = wallRight
+      dx = -Math.abs(dx)
+      reflections++
+    }
+
+    if (reflections > maxReflections || y >= ceilingY) {
+      return {
+        ...state,
+        x,
+        y: Math.min(y, ceilingY),
+        dx,
+        dy,
+        reflections,
+        points: [...state.points, { x, y: Math.min(y, ceilingY) }],
+        done: true
+      }
+    }
+
+    const { row, col } = worldToNearestCell(x, y)
+    if (isInBounds(row, col) && grid[row][col].color !== null) {
+      const { x: bx, y: by } = cellToWorld(row, col)
+      if (Math.hypot(x - bx, y - by) < BUBBLE_DIAMETER) {
+        return {
+          ...state,
+          x,
+          y,
+          dx,
+          dy,
+          reflections,
+          points: [...state.points, { x, y }],
+          done: true
+        }
+      }
+    }
+
+    return { x, y, dx, dy, reflections, points: [...state.points, { x, y }], done: false }
+  }
+
+  const initial: TrajectoryState = {
+    x: shooterX,
+    y: shooterY,
+    dx: Math.sin(angle),
+    dy: Math.cos(angle),
+    reflections: 0,
+    points: [{ x: shooterX, y: shooterY }],
+    done: false
+  }
+
+  const iterate = (state: TrajectoryState, remaining: number): TrajectoryState => {
+    if (state.done || remaining <= 0) return state
+    return iterate(step(state), remaining - 1)
+  }
+
+  return iterate(initial, maxSteps).points
+}
+
+/**
+ * Pick a random color that exists in the current grid (avoids introducing new colors).
+ * @param grid - Current grid state.
+ * @returns A BubbleColor present in the grid, or a random base color if grid is empty.
+ */
+export const pickNextColor = (grid: Grid): BubbleColor => {
+  const present = grid.flatMap((row) =>
+    row.flatMap((cell) => (cell.color && cell.color !== 'garbage' ? [cell.color] : []))
+  )
+  const pool = present.length > 0 ? present : [...BUBBLE_COLORS]
+  return pool[Math.floor(Math.random() * pool.length)]
+}
+
+/**
+ * Check whether any bubble has descended at or below the fire line.
+ * @param grid - Current grid state.
+ * @param fireLineY - The y threshold.
+ * @returns True if game should end.
+ */
+export const hasReachedFireLine = (grid: Grid, fireLineY: number): boolean =>
+  rowRange.some((r) =>
+    colRange.some((c) => grid[r][c].color !== null && cellToWorld(r, c).y <= fireLineY)
+  )
+
+/**
+ * Add rows of garbage bubbles to the top of the grid (shifting existing content down).
+ * @param grid - Current grid state.
+ * @param count - Number of garbage rows to add.
+ * @returns New grid with garbage rows inserted at the top.
+ */
+export const addGarbageRows = (grid: Grid, count: number): Grid =>
+  rowRange.map((r) =>
+    colRange.map((c) => ({
+      color:
+        c >= rowColCount(r)
+          ? null
+          : r < count
+            ? ('garbage' as BubbleColor)
+            : (grid[r - count]?.[c]?.color ?? null)
+    }))
+  )
+
+/**
+ * Push all existing rows down and insert new random rows at the top (single-player pressure).
+ * @param grid - Current grid state.
+ * @param count - Number of new rows to add at the top.
+ * @returns New grid with additional rows prepended.
+ */
+export const addTopRows = (grid: Grid, count: number): Grid =>
+  rowRange.map((r) =>
+    colRange.map((c) => ({
+      color:
+        c >= rowColCount(r)
+          ? null
+          : r < count
+            ? (BUBBLE_COLORS[Math.floor(Math.random() * BUBBLE_COLORS.length)] as BubbleColor)
+            : (grid[r - count]?.[c]?.color ?? null)
+    }))
+  )
+
+/**
+ * Count the number of fully-cleared rows (all null) starting from the bottom.
+ * @param grid - Current grid state.
+ * @returns Number of empty rows cleared from the bottom.
+ */
+export const countClearedRows = (grid: Grid): number => {
+  const firstNonEmpty = [...rowRange]
+    .reverse()
+    .findIndex((r) => grid[r].some((cell) => cell.color !== null))
+  return firstNonEmpty === -1 ? GRID_ROWS : firstNonEmpty
+}

--- a/src/views/Games/BubbleShooter/config.ts
+++ b/src/views/Games/BubbleShooter/config.ts
@@ -1,0 +1,38 @@
+export const MATCHMAKER_ROOM = 'bubble-shooter-matchmaker'
+export const GRID_ROWS = 12
+export const GRID_COLS = 9
+export const BUBBLE_RADIUS = 0.5
+export const BUBBLE_DIAMETER = 1.0
+export const HEX_ROW_HEIGHT = Math.sqrt(3) / 2
+export const GRID_TOP_Y = 5.5
+export const SHOOTER_X = 0
+export const SHOOTER_Y = -7.5
+export const FIRE_LINE_Y = GRID_TOP_Y - (GRID_ROWS - 2) * HEX_ROW_HEIGHT
+export const BUBBLE_SPEED = 20
+export const MIN_MATCH_SIZE = 3
+export const SHOTS_PER_NEW_ROW = 10
+export const ROW_DROP_INTERVAL_MS = 20_000
+export const GARBAGE_THRESHOLD = 1
+export const WALL_LEFT = -(GRID_COLS / 2) * BUBBLE_DIAMETER
+export const WALL_RIGHT = (GRID_COLS / 2) * BUBBLE_DIAMETER
+export const INITIAL_FILLED_ROWS = 5
+
+export const BUBBLE_COLORS = ['red', 'blue', 'green', 'yellow', 'purple'] as const
+export type BubbleColor = (typeof BUBBLE_COLORS)[number] | 'garbage'
+export type BsColorCount = 3 | 4 | 5
+export type BsSpeed = 'slow' | 'medium' | 'fast'
+
+export const SPEED_ROW_DROP_MS: Record<BsSpeed, number> = {
+  slow: 30_000,
+  medium: 20_000,
+  fast: 12_000
+}
+
+export const COLOR_HEX: Record<BubbleColor, number> = {
+  red: 0xe53935,
+  blue: 0x1e88e5,
+  green: 0x43a047,
+  yellow: 0xfdd835,
+  purple: 0x8e24aa,
+  garbage: 0x9e9e9e
+}

--- a/src/views/Games/BubbleShooter/types.ts
+++ b/src/views/Games/BubbleShooter/types.ts
@@ -1,0 +1,91 @@
+import type * as THREE from 'three'
+import type { Ref } from 'vue'
+import type { computed } from 'vue'
+import type { P2PSession } from '@webgamekit/multiplayer-p2p'
+import type { useBubbleShooterStore } from '@/stores/bubbleShooter'
+import type { BubbleColor, BsColorCount, BsSpeed } from './config'
+
+// ---- Grid ----
+
+export type GridCell = { color: BubbleColor | null }
+export type Grid = GridCell[][]
+export type Coord = [number, number]
+
+export type TrajectoryConfig = {
+  wallLeft: number
+  wallRight: number
+  ceilingY: number
+  maxReflections?: number
+  stepSize?: number
+  maxSteps?: number
+}
+
+// ---- Session ----
+
+export type HelloPayload = { name: string; color: string }
+export type AvatarPayload = { name: string; color: string }
+export type StartPayload = { seed: number }
+export type GarbagePayload = { count: number }
+export type ScorePayload = { playerId: string; score: number }
+export type GameOverPayload = { loserId: string }
+
+export type UseBubbleShooterSessionOptions = {
+  name: string
+  color: string
+  roomId: string
+}
+
+export type BsContext = {
+  options: UseBubbleShooterSessionOptions
+  store: ReturnType<typeof useBubbleShooterStore>
+  session: Ref<P2PSession | null>
+  localPeerId: Ref<string>
+  isHost: ReturnType<typeof computed<boolean>>
+  onGarbage: (count: number) => void
+}
+
+// ---- Game ----
+
+export type GameDeps = {
+  canvas: Ref<HTMLCanvasElement | null>
+  isSolo: Ref<boolean>
+  colorCount: Ref<BsColorCount>
+  speed: Ref<BsSpeed>
+  onScore: (points: number) => void
+  onGarbageSent: (count: number) => void
+  onGameOver: () => void
+}
+
+export type PopParticle = {
+  mesh: THREE.Mesh
+  vx: number
+  vy: number
+  life: number
+}
+
+export type BsGameContext = {
+  grid: Grid
+  aimAngle: number
+  isFlying: boolean
+  inFlightDx: number
+  inFlightDy: number
+  rowDropAccumulator: number
+  scene: THREE.Scene | null
+  camera: THREE.PerspectiveCamera | null
+  shooterGroup: THREE.Group | null
+  trajectoryLine: THREE.Line | null
+  loadedMesh: THREE.Mesh | null
+  nextMesh: THREE.Mesh | null
+  inFlightMesh: THREE.Mesh | null
+  bubbleGeo: THREE.SphereGeometry
+  bubbleMeshes: Map<string, THREE.Mesh>
+  materials: Partial<Record<BubbleColor, THREE.MeshStandardMaterial>>
+  popParticles: PopParticle[]
+  score: Ref<number>
+  shotCount: Ref<number>
+  currentColor: Ref<BubbleColor>
+  nextColor: Ref<BubbleColor>
+  isGameOver: Ref<boolean>
+  pendingGarbage: Ref<number>
+  deps: GameDeps
+}

--- a/src/views/Games/BubbleShooter/useBubbleShooterGame.ts
+++ b/src/views/Games/BubbleShooter/useBubbleShooterGame.ts
@@ -1,0 +1,596 @@
+import { ref, onUnmounted } from 'vue'
+import * as THREE from 'three'
+import { createSound } from '@webgamekit/audio'
+import {
+  GRID_COLS,
+  BUBBLE_RADIUS,
+  BUBBLE_DIAMETER,
+  GRID_TOP_Y,
+  SHOOTER_X,
+  SHOOTER_Y,
+  FIRE_LINE_Y,
+  BUBBLE_SPEED,
+  SPEED_ROW_DROP_MS,
+  GARBAGE_THRESHOLD,
+  WALL_LEFT,
+  WALL_RIGHT,
+  COLOR_HEX,
+  type BubbleColor
+} from './config'
+import {
+  createGrid,
+  cellToWorld,
+  findMatch,
+  findDangling,
+  snapToCell,
+  trajectoryPoints,
+  pickNextColor,
+  hasReachedFireLine,
+  addGarbageRows,
+  addTopRows
+} from './bubbleShooterUtilities'
+import type { GameDeps, BsGameContext } from './types'
+
+export type { GameDeps }
+
+const CAMERA_Y = -1
+const CAMERA_Z = 22
+const CAMERA_FOV = 65
+const AIM_MIN_ANGLE = -(Math.PI * 0.45)
+const AIM_MAX_ANGLE = Math.PI * 0.45
+const TRAJECTORY_Z = 0.1
+const SHOOTER_HEIGHT = 0.6
+const SHOOTER_BASE_RADIUS = 0.3
+const WALL_THICKNESS = 0.3
+const WALL_DEPTH = 0.5
+const FIRE_LINE_HEIGHT = 0.08
+const PREVIEW_SCALE = 0.7
+const PREVIEW_OFFSET_X = 1.5
+const MAX_TRAJ_PTS = 500
+const POP_PARTICLE_COUNT = 6
+const POP_LIFETIME = 0.35
+const POP_SPEED = 3.5
+
+const getMaterial = (ctx: BsGameContext, color: BubbleColor): THREE.MeshStandardMaterial => {
+  if (!ctx.materials[color]) {
+    ctx.materials[color] = new THREE.MeshStandardMaterial({
+      color: COLOR_HEX[color],
+      roughness: 0.3,
+      metalness: 0.1
+    })
+  }
+  return ctx.materials[color]!
+}
+
+const placeBubbleMesh = (
+  ctx: BsGameContext,
+  row: number,
+  col: number,
+  color: BubbleColor
+): void => {
+  if (!ctx.scene) return
+  const { x, y } = cellToWorld(row, col)
+  const mesh = new THREE.Mesh(ctx.bubbleGeo, getMaterial(ctx, color))
+  mesh.position.set(x, y, 0)
+  ctx.scene.add(mesh)
+  ctx.bubbleMeshes.set(`${row},${col}`, mesh)
+}
+
+const removeBubbleMesh = (ctx: BsGameContext, row: number, col: number): void => {
+  const mesh = ctx.bubbleMeshes.get(`${row},${col}`)
+  if (mesh && ctx.scene) {
+    ctx.scene.remove(mesh)
+    ctx.bubbleMeshes.delete(`${row},${col}`)
+  }
+}
+
+const rebuildAllMeshes = (ctx: BsGameContext): void => {
+  if (!ctx.scene) return
+  ctx.bubbleMeshes.forEach((mesh) => ctx.scene!.remove(mesh))
+  ctx.bubbleMeshes.clear()
+  ctx.grid.forEach((row, r) => {
+    row.forEach((cell, c) => {
+      if (cell.color) placeBubbleMesh(ctx, r, c, cell.color)
+    })
+  })
+}
+
+const updateTrajectoryLine = (ctx: BsGameContext): void => {
+  if (!ctx.trajectoryLine || !ctx.scene) return
+  const pts = trajectoryPoints(ctx.aimAngle, SHOOTER_X, SHOOTER_Y, ctx.grid, {
+    wallLeft: WALL_LEFT,
+    wallRight: WALL_RIGHT,
+    ceilingY: GRID_TOP_Y + BUBBLE_RADIUS
+  })
+  const positions = new Float32Array(pts.flatMap(({ x, y }) => [x, y, TRAJECTORY_Z]))
+  const geo = ctx.trajectoryLine.geometry as THREE.BufferGeometry
+  geo.setAttribute('position', new THREE.BufferAttribute(positions, 3))
+  geo.setDrawRange(0, pts.length)
+  geo.computeBoundingSphere()
+  ctx.trajectoryLine.computeLineDistances()
+}
+
+const buildStaticScene = (
+  ctx: BsGameContext,
+  sc: THREE.Scene,
+  cam: THREE.PerspectiveCamera
+): void => {
+  ctx.scene = sc
+  ctx.camera = cam
+
+  sc.background = new THREE.Color(0x1a1a2e)
+  sc.add(new THREE.AmbientLight(0xffffff, 0.8))
+  const dirLight = new THREE.DirectionalLight(0xffffff, 1.2)
+  dirLight.position.set(5, 10, 10)
+  sc.add(dirLight)
+
+  const surfaceMat = new THREE.MeshStandardMaterial({ color: 0x2a2a4e })
+  const ceiling = new THREE.Mesh(
+    new THREE.BoxGeometry(GRID_COLS + 1, WALL_THICKNESS, WALL_DEPTH),
+    surfaceMat
+  )
+  ceiling.position.set(0, GRID_TOP_Y + BUBBLE_RADIUS + WALL_THICKNESS / 2, 0)
+  sc.add(ceiling)
+
+  const wallHeight = Math.abs(GRID_TOP_Y - SHOOTER_Y) + 3
+  const wallGeo = new THREE.BoxGeometry(WALL_THICKNESS, wallHeight, WALL_DEPTH)
+  const wallCenterY = (GRID_TOP_Y + SHOOTER_Y) / 2
+  const wallL = new THREE.Mesh(wallGeo, surfaceMat)
+  wallL.position.set(WALL_LEFT - WALL_THICKNESS / 2, wallCenterY, 0)
+  sc.add(wallL)
+  const wallR = new THREE.Mesh(wallGeo, surfaceMat)
+  wallR.position.set(WALL_RIGHT + WALL_THICKNESS / 2, wallCenterY, 0)
+  sc.add(wallR)
+
+  const fireLineMat = new THREE.MeshStandardMaterial({
+    color: 0xff4444,
+    emissive: 0xff4444,
+    emissiveIntensity: 0.4
+  })
+  const fireLine = new THREE.Mesh(
+    new THREE.BoxGeometry(GRID_COLS + 1, FIRE_LINE_HEIGHT, WALL_DEPTH),
+    fireLineMat
+  )
+  fireLine.position.set(0, FIRE_LINE_Y, 0)
+  sc.add(fireLine)
+
+  ctx.shooterGroup = new THREE.Group()
+  const barrel = new THREE.Mesh(
+    new THREE.CylinderGeometry(
+      SHOOTER_BASE_RADIUS * 0.5,
+      SHOOTER_BASE_RADIUS * 0.5,
+      SHOOTER_HEIGHT,
+      8
+    ),
+    new THREE.MeshStandardMaterial({ color: 0xffffff })
+  )
+  barrel.position.set(0, SHOOTER_HEIGHT / 2, 0)
+  ctx.shooterGroup.add(barrel)
+  ctx.loadedMesh = new THREE.Mesh(ctx.bubbleGeo, getMaterial(ctx, ctx.currentColor.value))
+  ctx.loadedMesh.position.set(0, SHOOTER_HEIGHT + BUBBLE_RADIUS, 0)
+  ctx.loadedMesh.visible = true
+  ctx.shooterGroup.add(ctx.loadedMesh)
+  ctx.shooterGroup.position.set(SHOOTER_X, SHOOTER_Y, 0)
+  sc.add(ctx.shooterGroup)
+
+  ctx.nextMesh = new THREE.Mesh(ctx.bubbleGeo, getMaterial(ctx, ctx.nextColor.value))
+  ctx.nextMesh.position.set(WALL_LEFT - PREVIEW_OFFSET_X, SHOOTER_Y, 0)
+  ctx.nextMesh.scale.setScalar(PREVIEW_SCALE)
+  sc.add(ctx.nextMesh)
+
+  const trailGeo = new THREE.BufferGeometry()
+  trailGeo.setAttribute(
+    'position',
+    new THREE.BufferAttribute(new Float32Array(MAX_TRAJ_PTS * 3), 3)
+  )
+  ctx.trajectoryLine = new THREE.Line(
+    trailGeo,
+    new THREE.LineDashedMaterial({
+      color: 0xffffff,
+      opacity: 0.5,
+      transparent: true,
+      dashSize: 0.4,
+      gapSize: 0.2
+    })
+  )
+  sc.add(ctx.trajectoryLine)
+
+  ctx.grid = createGrid(undefined, ctx.deps.colorCount.value)
+  ctx.currentColor.value = pickNextColor(ctx.grid)
+  ctx.nextColor.value = pickNextColor(ctx.grid)
+  rebuildAllMeshes(ctx)
+  updateTrajectoryLine(ctx)
+}
+
+const playPopSound = (index: number): void => {
+  const baseFreq = 520 + (index % 5) * 40
+  createSound({
+    startFreq: baseFreq,
+    endFreq: baseFreq * 0.4,
+    duration: 0.09,
+    volume: 0.18,
+    waveType: 'sine',
+    attackTime: 0.004,
+    releaseTime: 0.07
+  })
+}
+
+const spawnPopParticles = (
+  ctx: BsGameContext,
+  x: number,
+  y: number,
+  color: BubbleColor,
+  index = 0
+): void => {
+  playPopSound(index)
+  if (!ctx.scene) return
+  const mat = new THREE.MeshStandardMaterial({
+    color: COLOR_HEX[color],
+    transparent: true,
+    opacity: 1
+  })
+  const geo = new THREE.SphereGeometry(BUBBLE_RADIUS * 0.35, 6, 6)
+  Array.from({ length: POP_PARTICLE_COUNT }).forEach((_, i) => {
+    const angle = (i / POP_PARTICLE_COUNT) * Math.PI * 2
+    const mesh = new THREE.Mesh(geo, mat.clone())
+    mesh.position.set(x, y, 0.2)
+    ctx.scene!.add(mesh)
+    ctx.popParticles.push({
+      mesh,
+      vx: Math.cos(angle) * POP_SPEED,
+      vy: Math.sin(angle) * POP_SPEED,
+      life: POP_LIFETIME
+    })
+  })
+  geo.dispose()
+}
+
+const tickPopParticles = (ctx: BsGameContext, delta: number): void => {
+  ctx.popParticles = ctx.popParticles.filter((p) => {
+    p.life -= delta
+    if (p.life <= 0) {
+      ctx.scene?.remove(p.mesh)
+      ;(p.mesh.material as THREE.MeshStandardMaterial).dispose()
+      return false
+    }
+    const t = 1 - p.life / POP_LIFETIME
+    p.mesh.position.x += p.vx * delta
+    p.mesh.position.y += p.vy * delta
+    p.mesh.scale.setScalar(1 - t * 0.7)
+    ;(p.mesh.material as THREE.MeshStandardMaterial).opacity = 1 - t
+    return true
+  })
+}
+
+const handleCollision = (
+  ctx: BsGameContext,
+  hitX: number,
+  hitY: number,
+  color: BubbleColor
+): void => {
+  const snapped = snapToCell(hitX, hitY, ctx.grid)
+  if (!snapped) {
+    ctx.isFlying = false
+    return
+  }
+
+  ctx.grid[snapped.row][snapped.col] = { color }
+  placeBubbleMesh(ctx, snapped.row, snapped.col, color)
+
+  const matched = findMatch(snapped.row, snapped.col, ctx.grid)
+  if (matched.length > 0) {
+    const pts = matched.length * 10
+    ctx.score.value += pts
+    ctx.deps.onScore(pts)
+    matched.forEach(([r, c], i) => {
+      const { x: px, y: py } = cellToWorld(r, c)
+      spawnPopParticles(ctx, px, py, ctx.grid[r][c].color ?? color, i)
+      ctx.grid[r][c] = { color: null }
+      removeBubbleMesh(ctx, r, c)
+    })
+    const dangling = findDangling(ctx.grid)
+    const dpts = dangling.length * 5
+    ctx.score.value += dpts
+    ctx.deps.onScore(dpts)
+    dangling.forEach(([r, c], i) => {
+      const { x: px, y: py } = cellToWorld(r, c)
+      spawnPopParticles(ctx, px, py, ctx.grid[r][c].color ?? 'garbage', matched.length + i)
+      ctx.grid[r][c] = { color: null }
+      removeBubbleMesh(ctx, r, c)
+    })
+    const rowsCleared = Math.floor((matched.length + dangling.length) / GRID_COLS)
+    if (rowsCleared >= GARBAGE_THRESHOLD) ctx.deps.onGarbageSent(rowsCleared)
+  }
+
+  if (ctx.pendingGarbage.value > 0) {
+    const count = ctx.pendingGarbage.value
+    ctx.pendingGarbage.value = 0
+    ctx.grid = addGarbageRows(ctx.grid, count)
+    rebuildAllMeshes(ctx)
+  }
+
+  ctx.shotCount.value++
+
+  if (hasReachedFireLine(ctx.grid, FIRE_LINE_Y)) {
+    ctx.isGameOver.value = true
+    ctx.isFlying = false
+    ctx.deps.onGameOver()
+    return
+  }
+
+  ctx.currentColor.value = ctx.nextColor.value
+  ctx.nextColor.value = pickNextColor(ctx.grid)
+  if (ctx.loadedMesh) {
+    ctx.loadedMesh.material = getMaterial(ctx, ctx.currentColor.value) as THREE.Material
+    ctx.loadedMesh.visible = true
+  }
+  if (ctx.nextMesh) ctx.nextMesh.material = getMaterial(ctx, ctx.nextColor.value) as THREE.Material
+  updateTrajectoryLine(ctx)
+  ctx.isFlying = false
+}
+
+const runGameLoop = (ctx: BsGameContext, delta: number): void => {
+  tickPopParticles(ctx, delta)
+
+  if (!ctx.isGameOver.value) {
+    ctx.rowDropAccumulator += delta * 1000
+    const rowDropMs = SPEED_ROW_DROP_MS[ctx.deps.speed.value]
+    if (ctx.rowDropAccumulator >= rowDropMs) {
+      ctx.rowDropAccumulator -= rowDropMs
+      ctx.grid = addTopRows(ctx.grid, 2)
+      rebuildAllMeshes(ctx)
+      if (hasReachedFireLine(ctx.grid, FIRE_LINE_Y)) {
+        ctx.isGameOver.value = true
+        ctx.deps.onGameOver()
+        return
+      }
+    }
+  }
+
+  if (ctx.isGameOver.value || !ctx.isFlying || !ctx.inFlightMesh) return
+  const distance = BUBBLE_SPEED * delta
+  let nx = ctx.inFlightMesh.position.x + ctx.inFlightDx * distance
+  const ny = ctx.inFlightMesh.position.y + ctx.inFlightDy * distance
+
+  if (nx <= WALL_LEFT) {
+    nx = WALL_LEFT
+    ctx.inFlightDx = Math.abs(ctx.inFlightDx)
+  } else if (nx >= WALL_RIGHT) {
+    nx = WALL_RIGHT
+    ctx.inFlightDx = -Math.abs(ctx.inFlightDx)
+  }
+
+  ctx.inFlightMesh.position.set(nx, ny, 0)
+
+  if (ny >= GRID_TOP_Y) {
+    const color = ctx.inFlightMesh.userData.color as BubbleColor
+    ctx.scene?.remove(ctx.inFlightMesh)
+    ctx.inFlightMesh = null
+    handleCollision(ctx, nx, GRID_TOP_Y, color)
+    return
+  }
+
+  const hit = ctx.grid
+    .flatMap((row, r) => row.map((cell, c) => ({ cell, r, c })))
+    .find(({ cell, r, c }) => {
+      if (!cell.color) return false
+      const { x: bx, y: by } = cellToWorld(r, c)
+      return Math.hypot(nx - bx, ny - by) < BUBBLE_DIAMETER * 0.95
+    })
+  if (hit && ctx.inFlightMesh) {
+    const color = ctx.inFlightMesh.userData.color as BubbleColor
+    ctx.scene?.remove(ctx.inFlightMesh)
+    ctx.inFlightMesh = null
+    handleCollision(ctx, nx, ny, color)
+  }
+}
+
+const computeAimAngle = (
+  clientX: number,
+  clientY: number,
+  canvasElement: HTMLCanvasElement,
+  cam: THREE.PerspectiveCamera
+): number | null => {
+  const rect = canvasElement.getBoundingClientRect()
+  const ndcX = ((clientX - rect.left) / rect.width) * 2 - 1
+  const ndcY = -((clientY - rect.top) / rect.height) * 2 + 1
+  const raycaster = new THREE.Raycaster()
+  raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), cam)
+  const plane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0)
+  const target = new THREE.Vector3()
+  raycaster.ray.intersectPlane(plane, target)
+  const dy = target.y - SHOOTER_Y
+  if (dy <= 0) return null
+  const raw = Math.atan2(target.x - SHOOTER_X, dy)
+  return Math.max(AIM_MIN_ANGLE, Math.min(AIM_MAX_ANGLE, raw))
+}
+
+const applyAim = (ctx: BsGameContext, angle: number): void => {
+  ctx.aimAngle = angle
+  if (ctx.shooterGroup) ctx.shooterGroup.rotation.z = -angle
+  if (!ctx.isFlying) updateTrajectoryLine(ctx)
+}
+
+const shoot = (ctx: BsGameContext): void => {
+  if (ctx.isFlying || ctx.isGameOver.value || !ctx.scene) return
+  const color = ctx.currentColor.value
+  const mesh = new THREE.Mesh(ctx.bubbleGeo, getMaterial(ctx, color))
+  mesh.position.set(SHOOTER_X, SHOOTER_Y + SHOOTER_HEIGHT, 0)
+  mesh.userData.color = color
+  ctx.scene.add(mesh)
+  ctx.inFlightMesh = mesh
+  ctx.inFlightDx = Math.sin(ctx.aimAngle)
+  ctx.inFlightDy = Math.cos(ctx.aimAngle)
+  ctx.isFlying = true
+  if (ctx.loadedMesh) ctx.loadedMesh.visible = false
+  updateTrajectoryLine(ctx)
+}
+
+const bindInputEvents = (ctx: BsGameContext): (() => void) => {
+  const element = ctx.deps.canvas.value!
+
+  const onPointerMove = (e: PointerEvent): void => {
+    if (!ctx.deps.canvas.value || !ctx.camera || ctx.isGameOver.value) return
+    const angle = computeAimAngle(e.clientX, e.clientY, ctx.deps.canvas.value, ctx.camera)
+    if (angle !== null) applyAim(ctx, angle)
+  }
+  const onPointerDown = (e: PointerEvent): void => {
+    if (ctx.isGameOver.value) return
+    onPointerMove(e)
+    if (e.pointerType !== 'touch') shoot(ctx)
+  }
+  const onTouchMove = (e: TouchEvent): void => {
+    const touch = e.touches[0]
+    if (!touch || !ctx.deps.canvas.value || !ctx.camera || ctx.isGameOver.value) return
+    const angle = computeAimAngle(touch.clientX, touch.clientY, ctx.deps.canvas.value, ctx.camera)
+    if (angle !== null) applyAim(ctx, angle)
+  }
+  const onTouchEnd = (): void => {
+    if (!ctx.isGameOver.value) shoot(ctx)
+  }
+  const onContextMenu = (e: Event): void => {
+    e.preventDefault()
+  }
+
+  element.addEventListener('pointermove', onPointerMove)
+  element.addEventListener('pointerdown', onPointerDown)
+  element.addEventListener('touchmove', onTouchMove, { passive: true })
+  element.addEventListener('touchend', onTouchEnd)
+  element.addEventListener('contextmenu', onContextMenu)
+  return () => {
+    element.removeEventListener('pointermove', onPointerMove)
+    element.removeEventListener('pointerdown', onPointerDown)
+    element.removeEventListener('touchmove', onTouchMove)
+    element.removeEventListener('touchend', onTouchEnd)
+    element.removeEventListener('contextmenu', onContextMenu)
+  }
+}
+
+/**
+ * Build and manage the Three.js bubble shooter scene.
+ * @param deps - Canvas ref, mode flags, and game-event callbacks.
+ * @returns Reactive game state refs and imperative controls.
+ */
+export const useBubbleShooterGame = (deps: GameDeps) => {
+  const score = ref(0)
+  const shotCount = ref(0)
+  const currentColor = ref<BubbleColor>('red')
+  const nextColor = ref<BubbleColor>('blue')
+  const isGameOver = ref(false)
+  const pendingGarbage = ref(0)
+
+  const ctx: BsGameContext = {
+    grid: [],
+    aimAngle: 0,
+    isFlying: false,
+    inFlightDx: 0,
+    inFlightDy: 0,
+    rowDropAccumulator: 0,
+    scene: null,
+    camera: null,
+    shooterGroup: null,
+    trajectoryLine: null,
+    loadedMesh: null,
+    nextMesh: null,
+    inFlightMesh: null,
+    bubbleGeo: new THREE.SphereGeometry(BUBBLE_RADIUS * 0.92, 16, 16),
+    bubbleMeshes: new Map(),
+    materials: {},
+    popParticles: [],
+    score,
+    shotCount,
+    currentColor,
+    nextColor,
+    isGameOver,
+    pendingGarbage,
+    deps
+  }
+
+  let cleanupTools: (() => void) | null = null
+  let unbindInput: (() => void) | null = null
+  let canvasResizeObserver: ResizeObserver | null = null
+  let lastTime = 0
+
+  const receiveGarbage = (count: number): void => {
+    const rows = count % 2 === 0 ? count : count + 1
+    if (ctx.isFlying) {
+      pendingGarbage.value += rows
+      return
+    }
+    ctx.grid = addGarbageRows(ctx.grid, rows)
+    rebuildAllMeshes(ctx)
+    if (hasReachedFireLine(ctx.grid, FIRE_LINE_Y)) {
+      isGameOver.value = true
+      deps.onGameOver()
+    }
+  }
+
+  let animFrameId = 0
+
+  const init = (): void => {
+    const element = deps.canvas.value
+    if (!element) return
+
+    const w = element.clientWidth || element.offsetWidth || 400
+    const h = element.clientHeight || element.offsetHeight || 600
+
+    const renderer = new THREE.WebGLRenderer({ canvas: element, antialias: true })
+    renderer.setSize(w, h, false)
+    renderer.setPixelRatio(window.devicePixelRatio)
+
+    const scene = new THREE.Scene()
+    const camera = new THREE.PerspectiveCamera(CAMERA_FOV, w / h, 0.1, 1000)
+    camera.position.set(0, CAMERA_Y, CAMERA_Z)
+    camera.lookAt(0, CAMERA_Y, 0)
+
+    buildStaticScene(ctx, scene, camera)
+
+    canvasResizeObserver = new ResizeObserver(() => {
+      const nw = element.clientWidth
+      const nh = element.clientHeight
+      if (nw > 0 && nh > 0) {
+        camera.aspect = nw / nh
+        camera.updateProjectionMatrix()
+        renderer.setSize(nw, nh, false)
+      }
+    })
+    canvasResizeObserver.observe(element)
+    unbindInput = bindInputEvents(ctx)
+
+    const tick = (): void => {
+      animFrameId = requestAnimationFrame(tick)
+      const now = performance.now()
+      const delta = Math.min((now - lastTime) / 1000, 0.05)
+      lastTime = now
+      runGameLoop(ctx, delta)
+      renderer.render(scene, camera)
+    }
+    tick()
+
+    cleanupTools = (): void => {
+      cancelAnimationFrame(animFrameId)
+      renderer.dispose()
+    }
+  }
+
+  const cleanup = (): void => {
+    unbindInput?.()
+    canvasResizeObserver?.disconnect()
+    cleanupTools?.()
+    Object.values(ctx.materials).forEach((mat) => mat?.dispose())
+    ctx.bubbleGeo.dispose()
+    ctx.bubbleMeshes.clear()
+    ctx.popParticles.forEach((p) => {
+      ctx.scene?.remove(p.mesh)
+      ;(p.mesh.material as THREE.MeshStandardMaterial).dispose()
+    })
+    ctx.popParticles = []
+    ctx.inFlightMesh = null
+    ctx.scene = null
+    ctx.camera = null
+  }
+
+  onUnmounted(cleanup)
+
+  return { score, shotCount, currentColor, nextColor, isGameOver, init, cleanup, receiveGarbage }
+}

--- a/src/views/Games/BubbleShooter/useBubbleShooterSession.ts
+++ b/src/views/Games/BubbleShooter/useBubbleShooterSession.ts
@@ -1,0 +1,250 @@
+import { ref, computed, onUnmounted } from 'vue'
+import {
+  p2pJoin,
+  p2pLeave,
+  p2pOnPeerJoin,
+  p2pOnPeerLeave,
+  p2pSendData,
+  p2pOnData,
+  p2pIsSupported,
+  type P2PSession
+} from '@webgamekit/multiplayer-p2p'
+import { chatMessageCreate, type ChatMessage } from '@webgamekit/chat'
+import { useBubbleShooterStore, type BsPlayer } from '@/stores/bubbleShooter'
+import { MATCHMAKER_ROOM } from './config'
+import type {
+  HelloPayload,
+  AvatarPayload,
+  StartPayload,
+  GarbagePayload,
+  ScorePayload,
+  GameOverPayload,
+  UseBubbleShooterSessionOptions,
+  BsContext
+} from './types'
+
+const CONFIG_CHANNEL = 'bs-config'
+const HELLO_CHANNEL = 'bs-hello'
+const AVATAR_CHANNEL = 'bs-avatar'
+const START_CHANNEL = 'bs-start'
+const GARBAGE_CHANNEL = 'bs-garbage'
+const SCORE_CHANNEL = 'bs-score'
+const GAMEOVER_CHANNEL = 'bs-gameover'
+const CHAT_CHANNEL = 'bs-chat'
+const RESTART_CHANNEL = 'bs-restart'
+
+const REANNOUNCE_DELAY_MS = 2000
+
+const announceSelf = (ctx: BsContext, joined: P2PSession): void => {
+  const player: BsPlayer = {
+    id: joined.peerId,
+    name: ctx.options.name,
+    color: ctx.options.color,
+    score: 0
+  }
+  ctx.store.upsertPlayer(player)
+  p2pSendData(joined, AVATAR_CHANNEL, { name: ctx.options.name, color: ctx.options.color })
+  setTimeout(() => {
+    if (ctx.session.value) {
+      p2pSendData(joined, AVATAR_CHANNEL, { name: ctx.options.name, color: ctx.options.color })
+    }
+  }, REANNOUNCE_DELAY_MS)
+}
+
+const bindPeerEvents = (ctx: BsContext, joined: P2PSession): void => {
+  p2pOnPeerJoin(joined, (_peerId) => {
+    p2pSendData(joined, AVATAR_CHANNEL, { name: ctx.options.name, color: ctx.options.color })
+    p2pSendData(joined, HELLO_CHANNEL, { name: ctx.options.name, color: ctx.options.color })
+    if (ctx.isHost.value) p2pSendData(joined, CONFIG_CHANNEL, { difficulty: ctx.store.difficulty })
+  })
+
+  p2pOnPeerLeave(joined, (peerId) => {
+    const player = ctx.store.players[peerId]
+    if (player) {
+      const leaveMessage: ChatMessage = {
+        id: crypto.randomUUID(),
+        senderId: 'system',
+        senderName: 'System',
+        text: `${player.name} left the game`,
+        timestamp: Date.now(),
+        kind: 'system'
+      }
+      ctx.store.appendMessage(leaveMessage)
+    }
+    ctx.store.removePlayer(peerId)
+    if (
+      ctx.store.phase === 'playing' &&
+      Object.keys(ctx.store.players).length <= 1 &&
+      ctx.isHost.value
+    ) {
+      ctx.store.winnerId = ctx.localPeerId.value
+      ctx.store.phase = 'summary'
+    }
+  })
+
+  p2pOnData<HelloPayload>(joined, HELLO_CHANNEL, (payload, peerId) => {
+    ctx.store.upsertPlayer({ id: peerId, name: payload.name, color: payload.color, score: 0 })
+    p2pSendData(joined, AVATAR_CHANNEL, { name: ctx.options.name, color: ctx.options.color })
+  })
+
+  p2pOnData<AvatarPayload>(joined, AVATAR_CHANNEL, (payload, peerId) => {
+    const existing = ctx.store.players[peerId]
+    ctx.store.upsertPlayer({
+      id: peerId,
+      name: payload.name,
+      color: payload.color,
+      score: existing?.score ?? 0
+    })
+  })
+}
+
+const bindGameEvents = (ctx: BsContext, joined: P2PSession): void => {
+  p2pOnData<ChatMessage>(joined, CHAT_CHANNEL, (message) => ctx.store.appendMessage(message))
+
+  p2pOnData<{ difficulty: string }>(joined, CONFIG_CHANNEL, (payload) => {
+    ctx.store.difficulty = payload.difficulty as typeof ctx.store.difficulty
+  })
+
+  p2pOnData<StartPayload>(joined, START_CHANNEL, () => {
+    ctx.store.phase = 'playing'
+  })
+
+  p2pOnData<GarbagePayload>(joined, GARBAGE_CHANNEL, (payload) => {
+    ctx.onGarbage(payload.count)
+  })
+
+  p2pOnData<ScorePayload>(joined, SCORE_CHANNEL, (payload, peerId) => {
+    const existing = ctx.store.players[peerId]
+    if (existing) ctx.store.upsertPlayer({ ...existing, score: payload.score })
+  })
+
+  p2pOnData<GameOverPayload>(joined, GAMEOVER_CHANNEL, (payload) => {
+    const survivorId = Object.keys(ctx.store.players).find((id) => id !== payload.loserId)
+    ctx.store.winnerId = survivorId ?? payload.loserId
+    ctx.store.phase = 'summary'
+  })
+
+  p2pOnData<Record<string, never>>(joined, RESTART_CHANNEL, () => {
+    const preserved = Object.fromEntries(
+      Object.entries(ctx.store.players).map(([id, p]) => [id, { ...p, score: 0 }])
+    )
+    ctx.store.$patch({ players: preserved, phase: 'lobby', winnerId: null, messages: [] })
+  })
+}
+
+const initSessionForContext = (ctx: BsContext, roomId: string): void => {
+  if (!p2pIsSupported()) return
+  const joined = p2pJoin(roomId)
+  ctx.session.value = joined
+  ctx.localPeerId.value = joined.peerId
+  announceSelf(ctx, joined)
+  bindPeerEvents(ctx, joined)
+  bindGameEvents(ctx, joined)
+}
+
+/**
+ * Manage a BubbleShooter P2P session (peers, chat, garbage sync, game-over).
+ * @param options - Session configuration including name, color, and room ID.
+ * @returns Session controls and reactive state for the consuming view.
+ */
+export const useBubbleShooterSession = (
+  options: UseBubbleShooterSessionOptions,
+  onGarbage: (count: number) => void = () => {}
+) => {
+  const store = useBubbleShooterStore()
+  const session = ref<P2PSession | null>(null)
+  const localPeerId = ref<string>('')
+  const isHost = computed(() => store.hostId === localPeerId.value && localPeerId.value !== '')
+
+  const ctx: BsContext = {
+    options,
+    store,
+    session,
+    localPeerId,
+    isHost,
+    onGarbage
+  }
+
+  const startGame = (): void => {
+    if (!session.value || !isHost.value) return
+    const payload: StartPayload = { seed: Math.floor(Math.random() * 1_000_000) }
+    p2pSendData(session.value, START_CHANNEL, payload)
+    store.phase = 'playing'
+  }
+
+  const broadcastGarbage = (count: number): void => {
+    if (!session.value) return
+    p2pSendData(session.value, GARBAGE_CHANNEL, { count })
+  }
+
+  const broadcastScore = (score: number): void => {
+    if (!session.value) return
+    p2pSendData(session.value, SCORE_CHANNEL, { playerId: localPeerId.value, score })
+  }
+
+  const broadcastGameOver = (): void => {
+    if (!session.value) return
+    p2pSendData(session.value, GAMEOVER_CHANNEL, { loserId: localPeerId.value })
+    const survivorId = Object.keys(store.players).find((id) => id !== localPeerId.value)
+    store.winnerId = survivorId ?? localPeerId.value
+    store.phase = 'summary'
+  }
+
+  const broadcastChat = (text: string): void => {
+    if (!session.value) return
+    const message = chatMessageCreate(localPeerId.value, options.name, text)
+    if (!message) return
+    store.appendMessage(message)
+    p2pSendData(session.value, CHAT_CHANNEL, message)
+  }
+
+  const updateProfile = (name: string, color: string): void => {
+    options.name = name
+    options.color = color
+    const existing = store.players[localPeerId.value]
+    store.upsertPlayer({ id: localPeerId.value, name, color, score: existing?.score ?? 0 })
+    if (session.value) p2pSendData(session.value, AVATAR_CHANNEL, { name, color })
+  }
+
+  const restartGame = (): void => {
+    if (!isHost.value || !session.value) return
+    p2pSendData(session.value, RESTART_CHANNEL, {})
+    const preserved = Object.fromEntries(
+      Object.entries(store.players).map(([id, p]) => [id, { ...p, score: 0 }])
+    )
+    store.$patch({ players: preserved, phase: 'lobby', winnerId: null, messages: [] })
+  }
+
+  const init = (): void => initSessionForContext(ctx, options.roomId)
+
+  const reconnect = (newRoomId: string): void => {
+    destroy()
+    initSessionForContext(ctx, newRoomId)
+  }
+
+  const destroy = (): void => {
+    if (session.value) {
+      p2pLeave(session.value)
+      session.value = null
+    }
+    store.reset()
+  }
+
+  onUnmounted(destroy)
+
+  return {
+    session,
+    localPeerId,
+    isHost,
+    matchmakerRoom: MATCHMAKER_ROOM,
+    startGame,
+    broadcastGarbage,
+    broadcastScore,
+    broadcastGameOver,
+    broadcastChat,
+    updateProfile,
+    restartGame,
+    init,
+    reconnect
+  }
+}

--- a/src/views/Games/Lobby/Lobby.vue
+++ b/src/views/Games/Lobby/Lobby.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, watch, provide } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useRoute, useRouter } from 'vue-router'
 import { Check } from 'lucide-vue-next'
@@ -16,6 +16,7 @@ import { useSquaresMultiplayerStore } from '@/stores/squaresMultiplayer'
 import { usePictionaryStore } from '@/stores/pictionary'
 import { useWordleMultiplayerStore } from '@/stores/wordleMultiplayer'
 import { useMinigolfStore } from '@/stores/minigolf'
+import { useBubbleShooterStore } from '@/stores/bubbleShooter'
 import LobbyChat from './LobbyChat.vue'
 import LobbyPresence from './LobbyPresence.vue'
 import LobbyRoomList from './LobbyRoomList.vue'
@@ -31,7 +32,8 @@ const gameStores: Record<GameType, { playerList: { id: string; name: string; col
     Pictionary: usePictionaryStore(),
     SquaresMultiplayer: useSquaresMultiplayerStore(),
     WordleMultiplayer: useWordleMultiplayerStore(),
-    Minigolf: useMinigolfStore()
+    Minigolf: useMinigolfStore(),
+    BubbleShooter: useBubbleShooterStore()
   }
 
 const stored = loadProfile()
@@ -51,6 +53,12 @@ const {
 } = useLobbySession(playerName.value, playerColor.value)
 
 const ownRoomId = computed(() => ownRoom.value?.id ?? null)
+
+provide('setRoomHidden', (hidden: boolean) => {
+  if (ownRoom.value && ownRoom.value.isHidden !== hidden) {
+    toggleRoomVisibility()
+  }
+})
 const activeGame = computed(() => route.query.game as GameType | undefined)
 const activeComponent = computed(() =>
   activeGame.value ? GAME_COMPONENTS[activeGame.value] : null

--- a/src/views/Games/Lobby/LobbyChat.vue
+++ b/src/views/Games/Lobby/LobbyChat.vue
@@ -110,7 +110,7 @@ const handleSend = (): void => {
 }
 
 .lb-chat__message--own .lb-chat__text {
-  background: var(--game-ink);
+  background: var(--game-own-msg-bg, var(--game-ink));
   color: #fff;
 }
 

--- a/src/views/Games/Lobby/constants.ts
+++ b/src/views/Games/Lobby/constants.ts
@@ -9,7 +9,8 @@ export const GAME_LABELS: Record<GameType, string> = {
   Pictionary: 'Pictionary',
   SquaresMultiplayer: 'Squares',
   WordleMultiplayer: 'Wordle',
-  Minigolf: 'Minigolf'
+  Minigolf: 'Minigolf',
+  BubbleShooter: 'Bubbles'
 }
 
 export const GAME_COMPONENTS: Record<GameType, ReturnType<typeof defineAsyncComponent>> = {
@@ -20,5 +21,6 @@ export const GAME_COMPONENTS: Record<GameType, ReturnType<typeof defineAsyncComp
   WordleMultiplayer: defineAsyncComponent(
     () => import('@/views/Games/WordleMultiplayer/WordleMultiplayer.vue')
   ),
-  Minigolf: defineAsyncComponent(() => import('@/views/Games/Minigolf/Minigolf.vue'))
+  Minigolf: defineAsyncComponent(() => import('@/views/Games/Minigolf/Minigolf.vue')),
+  BubbleShooter: defineAsyncComponent(() => import('@/views/Games/BubbleShooter/BubbleShooter.vue'))
 }

--- a/src/views/Games/Minigolf/Minigolf.vue
+++ b/src/views/Games/Minigolf/Minigolf.vue
@@ -15,8 +15,9 @@ import {
   PLAYER_COLORS,
   buildRandomGradient
 } from '@/utils/playerProfile'
+import GameHeader from '@/components/GameHeader.vue'
+import LobbyLayout from '@/views/Games/layout/LobbyLayout.vue'
 import MinigolfLobby from './MinigolfLobby.vue'
-import MinigolfHeader from './MinigolfHeader.vue'
 import MinigolfGame from './MinigolfGame.vue'
 import MinigolfSummary from './MinigolfSummary.vue'
 import MultiplayerSidebar, { type MultiplayerPlayer } from '@/components/MultiplayerSidebar.vue'
@@ -169,16 +170,22 @@ onUnmounted(() => cleanup())
 </script>
 
 <template>
-  <main
-    class="mg"
-    :class="[`mg--${phase}`, { 'mg--show-sidebar': showSidebar }]"
-    :style="backgroundStyle"
-  >
-    <MinigolfHeader :room-id="roomId" @copy-link="copyLink" />
+  <LobbyLayout class="mg" :phase="phase" :show-sidebar="showSidebar" :style="backgroundStyle">
+    <template #header>
+      <GameHeader :room-id="roomId" @leave-room="handleLeaveRoom" @copy-link="copyLink" />
+    </template>
+
+    <template #rules>
+      <ul>
+        <li>Each player takes turns shooting their ball toward the hole</li>
+        <li><strong>Drag</strong> on the canvas to aim and set power, then release to shoot</li>
+        <li>Fewest total strokes across all holes wins</li>
+        <li>Maximum 10 strokes per hole — ball is holed automatically after that</li>
+      </ul>
+    </template>
 
     <MinigolfLobby
       v-if="phase === 'lobby'"
-      class="mg__main"
       :player-name="playerName"
       :player-color="playerColor"
       :is-host="isHost"
@@ -198,7 +205,6 @@ onUnmounted(() => cleanup())
     <MinigolfGame
       v-else-if="phase === 'playing'"
       ref="gameReference"
-      class="mg__main"
       :message="message"
       :waiting="waiting"
       :is-aiming="isAiming"
@@ -211,24 +217,26 @@ onUnmounted(() => cleanup())
 
     <MinigolfSummary
       v-else
-      class="mg__main"
       :player-list="playerList"
       :active-holes="activeHoles"
       :is-host="isHost"
       @play-again="handlePlayAgain"
     />
 
-    <MultiplayerSidebar
-      class="mg__sidebar"
-      :players="sidebarPlayers"
-      :local-peer-id="localPeerId"
-      :messages="messages"
-      chat-placeholder="Say something…"
-      @send="session.broadcastChat($event)"
-    />
+    <template #sidebar>
+      <MultiplayerSidebar
+        :players="sidebarPlayers"
+        :local-peer-id="localPeerId"
+        :messages="messages"
+        chat-placeholder="Say something…"
+        @send="session.broadcastChat($event)"
+      />
+    </template>
 
-    <GameTabBar v-model:show-sidebar="showSidebar" :unread-count="unreadCount" />
-  </main>
+    <template #tabbar>
+      <GameTabBar v-model:show-sidebar="showSidebar" :unread-count="unreadCount" />
+    </template>
+  </LobbyLayout>
 </template>
 
 <style scoped>
@@ -237,72 +245,7 @@ onUnmounted(() => cleanup())
   --mg-yellow: #ffd93d;
   --game-accent: var(--mg-green);
 
-  touch-action: manipulation;
-  display: grid;
-  grid-template-columns: 1fr 280px;
-  grid-template-areas: 'header header' 'main sidebar';
-  grid-template-rows: auto minmax(0, 1fr);
-  height: 100dvh;
-  box-sizing: border-box;
-  overflow: hidden;
-  padding: var(--spacing-3);
-  padding-top: calc(var(--nav-height) + var(--spacing-3));
-  gap: var(--spacing-3);
-  font-family: 'Comic Sans MS', 'Chalkboard SE', 'Marker Felt', cursive, system-ui;
   background: var(--mg-bg);
-}
-
-.mg--lobby {
-  height: auto;
-  min-height: 100dvh;
-  overflow: auto;
-}
-
-.mg :deep(.mg-header) {
-  animation: slide-from-right 0.32s ease both;
-}
-
-.mg__main {
-  grid-area: main;
-  min-height: 0;
-  animation: slide-up 0.28s ease both;
-}
-
-.mg__sidebar {
-  grid-area: sidebar;
-  animation: slide-from-right 0.32s ease both;
-}
-
-@media (max-width: 720px) {
-  .mg {
-    grid-template-columns: 1fr;
-    grid-template-areas: 'header' 'main';
-    grid-template-rows: auto 1fr;
-    height: 100dvh;
-    padding: 0 var(--spacing-2);
-    padding-top: var(--nav-height);
-    padding-bottom: 3rem;
-    gap: var(--spacing-2);
-    overflow: hidden;
-  }
-
-  .mg--lobby {
-    height: auto;
-    min-height: 100dvh;
-    overflow: auto;
-  }
-
-  .mg__sidebar {
-    grid-area: main;
-    display: none;
-  }
-
-  .mg--show-sidebar .mg__main {
-    display: none;
-  }
-
-  .mg--show-sidebar .mg__sidebar {
-    display: flex;
-  }
+  font-family: 'Comic Sans MS', 'Chalkboard SE', 'Marker Felt', cursive, system-ui;
 }
 </style>

--- a/src/views/Games/Minigolf/MinigolfLobby.vue
+++ b/src/views/Games/Minigolf/MinigolfLobby.vue
@@ -106,15 +106,6 @@ const toggleHole = (index: number): void => {
         </div>
       </div>
     </template>
-
-    <template #rules>
-      <ul>
-        <li>Each player takes turns shooting their ball toward the hole</li>
-        <li><strong>Drag</strong> on the canvas to aim and set power, then release to shoot</li>
-        <li>Fewest total strokes across all holes wins</li>
-        <li>Maximum {{ 10 }} strokes per hole — ball is holed automatically after that</li>
-      </ul>
-    </template>
   </GameLobbyWizard>
 </template>
 

--- a/src/views/Games/Pictionary/Pictionary.vue
+++ b/src/views/Games/Pictionary/Pictionary.vue
@@ -15,7 +15,8 @@ import {
   NAME_ANIMALS,
   PLAYER_COLORS
 } from './constants'
-import PictionaryHeader from './PictionaryHeader.vue'
+import GameHeader from '@/components/GameHeader.vue'
+import LobbyLayout from '@/views/Games/layout/LobbyLayout.vue'
 import PictionaryLobby from './PictionaryLobby.vue'
 import PictionaryChoosing from './PictionaryChoosing.vue'
 import PictionaryDrawing from './PictionaryDrawing.vue'
@@ -167,12 +168,28 @@ onMounted(() => {
 </script>
 
 <template>
-  <main
+  <LobbyLayout
     class="pictionary"
-    :class="[`pictionary--${phase}`, { 'pictionary--show-sidebar': showSidebar }]"
+    :phase="phase"
+    :show-sidebar="showSidebar"
+    sidebar-width="320px"
+    :hide-header-on-mobile="['drawing', 'choosing'].includes(phase)"
     :style="backgroundStyle"
   >
-    <PictionaryHeader :room-id="roomId" @copy-link="copyLink" />
+    <template #header>
+      <GameHeader :room-id="roomId" @leave-room="handleLeaveRoom" @copy-link="copyLink" />
+    </template>
+
+    <template #rules>
+      <ul>
+        <li>The drawer is given a word and must draw it without speaking</li>
+        <li>Guessers earn points based on speed — faster guesses score more</li>
+        <li>First correct guess gets a bonus</li>
+        <li>The drawer earns points per correct guess, scaled by time remaining</li>
+        <li>Hints reveal extra letters (configurable)</li>
+        <li>Round ends when time runs out or all players guess correctly</li>
+      </ul>
+    </template>
 
     <PictionaryLobby
       v-if="phase === 'lobby'"
@@ -241,18 +258,21 @@ onMounted(() => {
       @restart="session.restartGame()"
     />
 
-    <MultiplayerSidebar
-      class="pictionary__sidebar"
-      :players="sidebarPlayers"
-      :local-peer-id="localPeerId"
-      :messages="messages"
-      :chat-placeholder="isDrawer ? 'Drawer cannot chat' : 'Say something…'"
-      :chat-disabled="isDrawer && phase === 'drawing'"
-      @send="session.broadcastChat($event)"
-    />
+    <template #sidebar>
+      <MultiplayerSidebar
+        :players="sidebarPlayers"
+        :local-peer-id="localPeerId"
+        :messages="messages"
+        :chat-placeholder="isDrawer ? 'Drawer cannot chat' : 'Say something…'"
+        :chat-disabled="isDrawer && phase === 'drawing'"
+        @send="session.broadcastChat($event)"
+      />
+    </template>
 
-    <GameTabBar v-model:show-sidebar="showSidebar" :unread-count="unreadCount" />
-  </main>
+    <template #tabbar>
+      <GameTabBar v-model:show-sidebar="showSidebar" :unread-count="unreadCount" />
+    </template>
+  </LobbyLayout>
 </template>
 
 <style scoped>
@@ -265,80 +285,7 @@ onMounted(() => {
   --pic-purple: #a06cd5;
   --pic-green: #6bcf7f;
 
-  touch-action: manipulation;
-  display: grid;
-  grid-template-columns: 1fr 320px;
-  grid-template-areas: 'header header' 'main sidebar';
-  grid-template-rows: auto minmax(0, 1fr);
-  gap: var(--spacing-3);
-  padding: var(--spacing-3);
-  padding-top: calc(var(--nav-height) + var(--spacing-3));
-  height: 100dvh;
-  box-sizing: border-box;
-  overflow: hidden;
   background: var(--pic-bg);
   font-family: 'Comic Sans MS', 'Chalkboard SE', 'Marker Felt', cursive, system-ui;
-}
-
-.pictionary--lobby {
-  height: auto;
-  min-height: 100dvh;
-  overflow: auto;
-}
-
-.pictionary :deep(.glw),
-.pictionary :deep(.pictionary-choosing),
-.pictionary :deep(.pictionary-drawing),
-.pictionary :deep(.pictionary-intermission),
-.pictionary :deep(.pictionary-summary) {
-  animation: slide-up 0.28s ease both;
-}
-
-.pictionary__sidebar {
-  grid-area: sidebar;
-  animation: slide-from-right 0.32s ease both;
-}
-
-@media (max-width: 720px) {
-  .pictionary {
-    grid-template-columns: 1fr;
-    grid-template-areas: 'header' 'main';
-    grid-template-rows: auto minmax(0, 1fr);
-    height: 100dvh;
-    min-height: 0;
-    padding: 0 var(--spacing-2);
-    padding-top: var(--nav-height);
-    padding-bottom: 3rem;
-    gap: var(--spacing-2);
-    overflow: hidden;
-  }
-
-  .pictionary--lobby {
-    height: auto;
-    min-height: 100dvh;
-    overflow: auto;
-  }
-
-  .pictionary--drawing :deep(.pictionary-header),
-  .pictionary--choosing :deep(.pictionary-header) {
-    display: none;
-  }
-
-  .pictionary__sidebar {
-    grid-area: main;
-    display: none;
-  }
-
-  .pictionary--show-sidebar :deep(.glw),
-  .pictionary--show-sidebar :deep(.pictionary-choosing),
-  .pictionary--show-sidebar :deep(.pictionary-drawing),
-  .pictionary--show-sidebar :deep(.pictionary-intermission),
-  .pictionary--show-sidebar :deep(.pictionary-summary) {
-    display: none;
-  }
-
-  .pictionary--show-sidebar .pictionary__sidebar {
-    display: flex;
-  }
 }
 </style>

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -104,16 +104,5 @@ const handleConfig = (key: string, value: string | number): void => {
     @start-game="emit('startGame')"
     @match-found="emit('matchFound', $event)"
     @leave-room="emit('leaveRoom')"
-  >
-    <template #rules>
-      <ul>
-        <li>The drawer is given a word and must draw it without speaking</li>
-        <li>Guessers earn points based on speed — faster guesses score more</li>
-        <li>First correct guess gets a bonus</li>
-        <li>The drawer earns points per correct guess, scaled by time remaining</li>
-        <li>Hints reveal extra letters (configurable)</li>
-        <li>Round ends when time runs out or all players guess correctly</li>
-      </ul>
-    </template>
-  </GameLobbyWizard>
+  />
 </template>

--- a/src/views/Games/SquaresMultiplayer/SquaresMultiplayer.vue
+++ b/src/views/Games/SquaresMultiplayer/SquaresMultiplayer.vue
@@ -14,7 +14,8 @@ import {
   NAME_ANIMALS,
   PLAYER_COLORS
 } from '@/utils/playerProfile'
-import SquaresMultiplayerHeader from './SquaresMultiplayerHeader.vue'
+import GameHeader from '@/components/GameHeader.vue'
+import LobbyLayout from '@/views/Games/layout/LobbyLayout.vue'
 import SquaresMultiplayerLobby from './SquaresMultiplayerLobby.vue'
 import SquaresMultiplayerGame from './SquaresMultiplayerGame.vue'
 import SquaresMultiplayerIntermission from './SquaresMultiplayerIntermission.vue'
@@ -177,12 +178,23 @@ onMounted(() => {
 </script>
 
 <template>
-  <main
-    class="wm"
-    :class="[`wm--${phase}`, { 'wm--show-sidebar': showSidebar }]"
-    :style="backgroundStyle"
-  >
-    <SquaresMultiplayerHeader :room-id="roomId" @copy-link="copyLink" />
+  <LobbyLayout class="wm" :phase="phase" :show-sidebar="showSidebar" :style="backgroundStyle">
+    <template #header>
+      <GameHeader :room-id="roomId" @leave-room="handleLeaveRoom" @copy-link="copyLink" />
+    </template>
+
+    <template #rules>
+      <ul>
+        <li>A grid of letters hides several target words — grouped by length</li>
+        <li>
+          <strong>Click and drag</strong> through adjacent letters (diagonals OK) to trace a word
+        </li>
+        <li>Release to submit — if the word is in the list, you claim it</li>
+        <li>First to claim a word gets the points</li>
+        <li>3–4 letters = 1 pt · 5 = 2 pt · 6 = 3 pt · 7 = 5 pt · 8+ = 11 pt</li>
+        <li>Round ends when all words are found or time runs out</li>
+      </ul>
+    </template>
 
     <SquaresMultiplayerLobby
       v-if="phase === 'lobby'"
@@ -240,17 +252,20 @@ onMounted(() => {
       @restart="session.restartGame()"
     />
 
-    <MultiplayerSidebar
-      class="wm__sidebar"
-      :players="sidebarPlayers"
-      :local-peer-id="localPeerId"
-      :messages="messages"
-      chat-placeholder="Say something…"
-      @send="session.broadcastChat($event)"
-    />
+    <template #sidebar>
+      <MultiplayerSidebar
+        :players="sidebarPlayers"
+        :local-peer-id="localPeerId"
+        :messages="messages"
+        chat-placeholder="Say something…"
+        @send="session.broadcastChat($event)"
+      />
+    </template>
 
-    <GameTabBar v-model:show-sidebar="showSidebar" :unread-count="unreadCount" />
-  </main>
+    <template #tabbar>
+      <GameTabBar v-model:show-sidebar="showSidebar" :unread-count="unreadCount" />
+    </template>
+  </LobbyLayout>
 </template>
 
 <style scoped>
@@ -259,65 +274,7 @@ onMounted(() => {
   --game-accent: var(--ws-green);
   --ws-yellow: #ffd93d;
 
-  touch-action: manipulation;
-  display: grid;
-  grid-template-columns: 1fr 280px;
-  grid-template-areas: 'header header' 'main sidebar';
-  grid-template-rows: auto minmax(0, 1fr);
-  gap: var(--spacing-3);
-  padding: var(--spacing-3);
-  padding-top: calc(var(--nav-height) + var(--spacing-3));
-  min-height: 100vh;
-  box-sizing: border-box;
   background: var(--wm-bg);
   font-family: 'Segoe UI', system-ui, sans-serif;
-}
-
-.wm :deep(.glw),
-.wm :deep(.wm-game),
-.wm :deep(.wm-intermission),
-.wm :deep(.ws-summary) {
-  animation: slide-up 0.28s ease both;
-}
-
-.wm__sidebar {
-  grid-area: sidebar;
-  animation: slide-from-right 0.32s ease both;
-}
-
-@media (max-width: 720px) {
-  .wm {
-    grid-template-columns: 1fr;
-    grid-template-areas: 'header' 'main';
-    grid-template-rows: auto 1fr;
-    height: 100dvh;
-    padding: 0 var(--spacing-2);
-    padding-top: var(--nav-height);
-    padding-bottom: 3rem;
-    gap: var(--spacing-2);
-    overflow: hidden;
-  }
-
-  .wm--lobby {
-    height: auto;
-    min-height: 100dvh;
-    overflow: auto;
-  }
-
-  .wm__sidebar {
-    grid-area: main;
-    display: none;
-  }
-
-  .wm--show-sidebar :deep(.glw),
-  .wm--show-sidebar :deep(.wm-game),
-  .wm--show-sidebar :deep(.wm-intermission),
-  .wm--show-sidebar :deep(.ws-summary) {
-    display: none;
-  }
-
-  .wm--show-sidebar .wm__sidebar {
-    display: flex;
-  }
 }
 </style>

--- a/src/views/Games/SquaresMultiplayer/SquaresMultiplayerLobby.vue
+++ b/src/views/Games/SquaresMultiplayer/SquaresMultiplayerLobby.vue
@@ -85,18 +85,5 @@ const handleConfig = (key: string, value: string | number): void => {
     @start-game="emit('startGame')"
     @match-found="emit('matchFound', $event)"
     @leave-room="emit('leaveRoom')"
-  >
-    <template #rules>
-      <ul>
-        <li>A grid of letters hides several target words — grouped by length</li>
-        <li>
-          <strong>Click and drag</strong> through adjacent letters (diagonals OK) to trace a word
-        </li>
-        <li>Release to submit — if the word is in the list, you claim it</li>
-        <li>First to claim a word gets the points</li>
-        <li>3–4 letters = 1 pt · 5 = 2 pt · 6 = 3 pt · 7 = 5 pt · 8+ = 11 pt</li>
-        <li>Round ends when all words are found or time runs out</li>
-      </ul>
-    </template>
-  </GameLobbyWizard>
+  />
 </template>

--- a/src/views/Games/WordleMultiplayer/WordleMultiplayer.vue
+++ b/src/views/Games/WordleMultiplayer/WordleMultiplayer.vue
@@ -14,7 +14,8 @@ import {
   NAME_ANIMALS,
   PLAYER_COLORS
 } from '@/utils/playerProfile'
-import WordleMultiplayerHeader from './WordleMultiplayerHeader.vue'
+import GameHeader from '@/components/GameHeader.vue'
+import LobbyLayout from '@/views/Games/layout/LobbyLayout.vue'
 import WordleMultiplayerLobby from './WordleMultiplayerLobby.vue'
 import WordleMultiplayerGame from './WordleMultiplayerGame.vue'
 import WordleMultiplayerIntermission from './WordleMultiplayerIntermission.vue'
@@ -179,12 +180,20 @@ onMounted(() => {
 </script>
 
 <template>
-  <main
-    class="wl"
-    :class="[`wl--${phase}`, { 'wl--show-sidebar': showSidebar }]"
-    :style="backgroundStyle"
-  >
-    <WordleMultiplayerHeader :room-id="roomId" @copy-link="copyLink" />
+  <LobbyLayout class="wl" :phase="phase" :show-sidebar="showSidebar" :style="backgroundStyle">
+    <template #header>
+      <GameHeader :room-id="roomId" @leave-room="handleLeaveRoom" @copy-link="copyLink" />
+    </template>
+
+    <template #rules>
+      <ul>
+        <li>Guess the secret word — all players guess simultaneously</li>
+        <li>Green = correct letter and position · Yellow = letter in word but wrong position</li>
+        <li>Fewer attempts and faster guesses earn more points</li>
+        <li>First to solve gets a bonus</li>
+        <li>Round ends when everyone finishes or time runs out</li>
+      </ul>
+    </template>
 
     <WordleMultiplayerLobby
       v-if="phase === 'lobby'"
@@ -239,17 +248,20 @@ onMounted(() => {
       @restart="session.restartGame()"
     />
 
-    <MultiplayerSidebar
-      class="wl__sidebar"
-      :players="sidebarPlayers"
-      :local-peer-id="localPeerId"
-      :messages="messages"
-      chat-placeholder="Say something…"
-      @send="session.broadcastChat($event)"
-    />
+    <template #sidebar>
+      <MultiplayerSidebar
+        :players="sidebarPlayers"
+        :local-peer-id="localPeerId"
+        :messages="messages"
+        chat-placeholder="Say something…"
+        @send="session.broadcastChat($event)"
+      />
+    </template>
 
-    <GameTabBar v-model:show-sidebar="showSidebar" :unread-count="unreadCount" />
-  </main>
+    <template #tabbar>
+      <GameTabBar v-model:show-sidebar="showSidebar" :unread-count="unreadCount" />
+    </template>
+  </LobbyLayout>
 </template>
 
 <style scoped>
@@ -258,65 +270,7 @@ onMounted(() => {
   --game-accent: var(--wl-green);
   --wl-yellow: #c9b458;
 
-  touch-action: manipulation;
-  display: grid;
-  grid-template-columns: 1fr 280px;
-  grid-template-areas: 'header header' 'main sidebar';
-  grid-template-rows: auto minmax(0, 1fr);
-  gap: var(--spacing-3);
-  padding: var(--spacing-3);
-  padding-top: calc(var(--nav-height) + var(--spacing-3));
-  min-height: 100vh;
-  box-sizing: border-box;
   background: var(--wl-bg);
   font-family: 'Segoe UI', system-ui, sans-serif;
-}
-
-.wl :deep(.glw),
-.wl :deep(.wl-game),
-.wl :deep(.wl-intermission),
-.wl :deep(.wl-summary) {
-  animation: slide-up 0.28s ease both;
-}
-
-.wl__sidebar {
-  grid-area: sidebar;
-  animation: slide-from-right 0.32s ease both;
-}
-
-@media (max-width: 720px) {
-  .wl {
-    grid-template-columns: 1fr;
-    grid-template-areas: 'header' 'main';
-    grid-template-rows: auto 1fr;
-    height: 100dvh;
-    padding: 0 var(--spacing-2);
-    padding-top: var(--nav-height);
-    padding-bottom: 3rem;
-    gap: var(--spacing-2);
-    overflow: hidden;
-  }
-
-  .wl--lobby {
-    height: auto;
-    min-height: 100dvh;
-    overflow: auto;
-  }
-
-  .wl__sidebar {
-    grid-area: main;
-    display: none;
-  }
-
-  .wl--show-sidebar :deep(.glw),
-  .wl--show-sidebar :deep(.wl-game),
-  .wl--show-sidebar :deep(.wl-intermission),
-  .wl--show-sidebar :deep(.wl-summary) {
-    display: none;
-  }
-
-  .wl--show-sidebar .wl__sidebar {
-    display: flex;
-  }
 }
 </style>

--- a/src/views/Games/WordleMultiplayer/WordleMultiplayerLobby.vue
+++ b/src/views/Games/WordleMultiplayer/WordleMultiplayerLobby.vue
@@ -85,15 +85,5 @@ const handleConfig = (key: string, value: string | number): void => {
     @start-game="emit('startGame')"
     @match-found="emit('matchFound', $event)"
     @leave-room="emit('leaveRoom')"
-  >
-    <template #rules>
-      <ul>
-        <li>Guess the secret word — all players guess simultaneously</li>
-        <li>Green = correct letter and position · Yellow = letter in word but wrong position</li>
-        <li>Fewer attempts and faster guesses earn more points</li>
-        <li>First to solve gets a bonus</li>
-        <li>Round ends when everyone finishes or time runs out</li>
-      </ul>
-    </template>
-  </GameLobbyWizard>
+  />
 </template>

--- a/src/views/Games/layout/LobbyLayout.vue
+++ b/src/views/Games/layout/LobbyLayout.vue
@@ -1,0 +1,221 @@
+<script setup lang="ts">
+import { ref, computed, useSlots } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    phase: string
+    showSidebar?: boolean
+    sidebarWidth?: string
+    mainPlacement?: 'fill' | 'center'
+    hideHeaderOnMobile?: boolean
+  }>(),
+  {
+    showSidebar: false,
+    sidebarWidth: '280px',
+    mainPlacement: 'fill',
+    hideHeaderOnMobile: false
+  }
+)
+
+const slots = useSlots()
+const hasSidebar = computed(() => !!slots.sidebar)
+const hasRules = computed(() => !!slots.rules)
+const rulesOpen = ref(false)
+
+const layoutStyle = computed(() => ({
+  '--ll-columns': hasSidebar.value ? `1fr ${props.sidebarWidth}` : '1fr',
+  '--ll-areas': hasSidebar.value ? "'header header' 'main sidebar'" : "'header' 'main'",
+  '--ll-place-items': props.mainPlacement === 'center' ? 'center' : 'stretch'
+}))
+</script>
+
+<template>
+  <main
+    class="lobby-layout"
+    :class="[`lobby-layout--${phase}`, { 'lobby-layout--show-sidebar': showSidebar }]"
+    :style="layoutStyle"
+  >
+    <div
+      class="lobby-layout__header"
+      :class="{ 'lobby-layout__header--hide-mobile': hideHeaderOnMobile }"
+    >
+      <slot name="header" />
+      <button
+        v-if="hasRules"
+        class="lobby-layout__rules-btn"
+        type="button"
+        :aria-expanded="rulesOpen"
+        @click="rulesOpen = !rulesOpen"
+      >
+        ?
+      </button>
+      <Transition name="ll-rules">
+        <div v-if="rulesOpen" class="lobby-layout__rules-panel">
+          <button class="lobby-layout__rules-close" type="button" @click="rulesOpen = false">
+            ×
+          </button>
+          <slot name="rules" />
+        </div>
+      </Transition>
+    </div>
+    <div class="lobby-layout__main">
+      <slot />
+    </div>
+    <div v-if="hasSidebar" class="lobby-layout__sidebar">
+      <slot name="sidebar" />
+    </div>
+    <slot name="tabbar" />
+  </main>
+</template>
+
+<style scoped>
+.lobby-layout {
+  touch-action: manipulation;
+  display: grid;
+  grid-template-columns: var(--ll-columns);
+  grid-template-areas: var(--ll-areas);
+  grid-template-rows: auto minmax(0, 1fr);
+  padding: var(--spacing-3);
+  padding-top: calc(var(--nav-height) + var(--spacing-3));
+  gap: var(--spacing-3);
+  height: 100dvh;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.lobby-layout--lobby {
+  height: auto;
+  min-height: 100dvh;
+  overflow: auto;
+}
+
+.lobby-layout__header {
+  grid-area: header;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  position: relative;
+}
+
+.lobby-layout__rules-btn {
+  padding: var(--spacing-1) var(--spacing-3);
+  border: 2px solid var(--game-border);
+  border-radius: 999px;
+  background: var(--game-surface-subtle);
+  color: var(--game-ink);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 2px 2px 0 var(--game-border);
+  transition: transform 0.1s ease;
+  font-family: inherit;
+  flex-shrink: 0;
+}
+
+.lobby-layout__rules-btn:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 3px 3px 0 var(--game-border);
+}
+
+.lobby-layout__rules-panel {
+  position: absolute;
+  top: calc(100% + var(--spacing-2));
+  left: 0;
+  z-index: var(--z-overlay, 100);
+  background: var(--game-surface-subtle);
+  border: 2px solid var(--game-border);
+  border-radius: var(--radius-md, 0.75rem);
+  box-shadow: 3px 3px 0 var(--game-border);
+  padding: var(--spacing-3);
+  min-width: 18rem;
+  max-width: 24rem;
+}
+
+.lobby-layout__rules-close {
+  position: absolute;
+  top: var(--spacing-2);
+  right: var(--spacing-2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 2px solid var(--game-border);
+  border-radius: 50%;
+  background: var(--game-surface-dim, var(--game-surface-subtle));
+  color: var(--game-ink);
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  font-family: inherit;
+  flex-shrink: 0;
+}
+
+.lobby-layout__rules-close:hover {
+  background: var(--game-border);
+}
+
+.lobby-layout__main {
+  grid-area: main;
+  min-height: 0;
+  display: grid;
+  place-items: var(--ll-place-items);
+  animation: slide-up 0.28s ease both;
+}
+
+.lobby-layout__sidebar {
+  grid-area: sidebar;
+  animation: slide-from-right 0.32s ease both;
+}
+
+.ll-rules-enter-active,
+.ll-rules-leave-active {
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
+}
+
+.ll-rules-enter-from,
+.ll-rules-leave-to {
+  opacity: 0;
+  transform: translateY(-0.25rem);
+}
+
+@media (max-width: 720px) {
+  .lobby-layout {
+    grid-template-columns: 1fr;
+    grid-template-areas: 'header' 'main';
+    grid-template-rows: auto 1fr;
+    height: 100dvh;
+    padding: 0 var(--spacing-2);
+    padding-top: var(--nav-height);
+    padding-bottom: 3rem;
+    gap: var(--spacing-2);
+    overflow: hidden;
+  }
+
+  .lobby-layout--lobby {
+    height: auto;
+    min-height: 100dvh;
+    overflow: auto;
+  }
+
+  .lobby-layout__header--hide-mobile {
+    display: none;
+  }
+
+  .lobby-layout__sidebar {
+    grid-area: main;
+    display: none;
+  }
+
+  .lobby-layout--show-sidebar .lobby-layout__main {
+    display: none;
+  }
+
+  .lobby-layout--show-sidebar .lobby-layout__sidebar {
+    display: flex;
+  }
+}
+</style>


### PR DESCRIPTION
Closes #144

## Summary

- Adds a full Bust-a-Move / Puzzle Bobble style **Bubble Shooter** game (solo + multiplayer) with hex grid, trajectory preview, match-3 popping, dangling detection, garbage rows, difficulty settings (color count + drop speed), and pop particle effects
- Extracts shared multiplayer infrastructure used across all 5 games: `LobbyLayout`, `GameHeader`, `useRoomId`, `useMultiplayerLobbyHandlers`
- Moves the rules button from inside `GameLobbyWizard` into `LobbyLayout`'s header area (next to ← Lobby)

## Key Changes

**New: BubbleShooter game**
- `src/views/Games/BubbleShooter/` — full game suite: root view, lobby, game canvas (Three.js), summary, session (P2P), game loop, utilities, config, types
- `src/stores/bubbleShooter.ts` — Pinia store for phase, players, scores, messages
- `src/views/Games/BubbleShooter/bubbleShooterUtilities.test.ts` — 31 unit tests for grid/match/trajectory logic

**New: Shared layout infrastructure**
- `src/views/Games/layout/LobbyLayout.vue` — two-column grid (header/main/sidebar) with `--ll-columns`, `--ll-areas`, `--ll-place-items` CSS custom properties; `mainPlacement`, `hideHeaderOnMobile`, `#rules` slot support
- `src/components/GameHeader.vue` — shared "← Lobby" + room ID/copy-link header replacing 5 game-specific headers
- `src/composables/useRoomId.ts` — resolves/creates stable room UUID from route query
- `src/composables/useMultiplayerLobbyHandlers.ts` — shared name change, color change, matchFound, leaveRoom handlers

**Refactored: All 5 existing games**
- Pictionary, SquaresMultiplayer, WordleMultiplayer, Minigolf, BubbleShooter now use `LobbyLayout` + `GameHeader`
- Rules content moved from `GameLobbyWizard` `#rules` slot (inside lobby wrappers) to `LobbyLayout` `#rules` slot (in game views) — rules button now appears in the header bar
- Removed all `:deep()` usage introduced during this work (replaced with `hideHeaderOnMobile` prop + CSS class)
- `BubbleShooterLobby` difficulty → separate `colorCount` (3/4/5) and `speed` (slow/medium/fast) options

**Misc**
- Added `--game-own-msg-bg: #3a3020` dark theme token for chat own-message bubble
- Added "Lobby Game Development" section to `.github/rules/code-style.md`

## Test Plan

- [ ] BubbleShooter solo: open `/games/BubbleShooter`, play solo — wizard centers, game fills, summary centers, no sidebar
- [ ] BubbleShooter multiplayer: open two tabs, matchmake, verify garbage rows sync, game-over detection
- [ ] All 5 games: lobby wizard is vertically centered; rules "?" button appears next to ← Lobby in header
- [ ] Pictionary: header hides on mobile during drawing/choosing phases
- [ ] `pnpm test:unit` — 1000 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)