### PR TITLE
chore: add stylelint, ban :deep(), forbid unmaintained packages

### DIFF
--- a/.github/rules/code-style.md
+++ b/.github/rules/code-style.md
@@ -119,6 +119,10 @@
 - **Header with "← Lobby" navigation**: Every game view must include a header component that navigates back to the Lobby. Follow the pattern established by `PictionaryHeader.vue` and `BubbleShooterHeader.vue` — a dedicated `<GameName>Header.vue` component that emits `leave-room`.
 - **Game-specific session composable**: Each game's P2P session logic must live in its own `use<GameName>Session.ts` composable co-located with the view. Use `useBubbleShooterSession` or `useMinigolfSession` as the reference pattern.
 
+## Dependencies
+
+- **No discontinued or unmaintained libraries**: Before adding any npm package, verify it is actively maintained. Check the repository's last commit date, open issues, and whether the maintainer responds to bug reports. Never use a library that has been archived, deprecated by its author, or has had no releases in over a year without a clear reason. If a well-maintained alternative exists, prefer it.
+
 ## Modular Architecture
 
 - **Reuse existing components**: Check and use existing components/libraries before creating new ones. Check `src/components/ui/` for shadcn UI components and other reusables in `src/components/`. Never reinvent the wheel.

--- a/.github/rules/code-style.md
+++ b/.github/rules/code-style.md
@@ -76,7 +76,9 @@
 
 ## CSS Conventions
 
-- **Never use `:deep()`**: The `:deep()` combinator is absolutely forbidden. No exceptions unless the user explicitly writes permission for a specific case in the codebase. If a parent needs to style a child component's internals, the child must expose CSS custom properties that the parent sets on its own element — CSS variables cascade naturally without piercing scoped styles. Stylelint enforces this automatically via `selector-pseudo-class-disallowed-list`.
+- **Never use `:deep()`**: The `:deep()` combinator is absolutely forbidden. No exceptions unless the user explicitly writes permission for a specific case in the codebase. Stylelint enforces this automatically via `selector-pseudo-class-disallowed-list`.
+
+- **No cross-component CSS**: Never use CSS custom properties to pass style information from a parent component into a child's internals. Setting `--some-var` on a parent element so a child reads it is the same violation as `:deep()` — it couples the parent to the child's implementation details. If a child component needs different styling in different contexts, add a `variant` prop to the child and apply BEM modifier classes (`.component--variant`) internally. The parent simply passes `:variant="..."` — it has no knowledge of the child's CSS.
 
 - **BEM methodology**: Use Block\_\_Element--Modifier naming for all CSS classes
 - **Scoped styles**: Use `<style scoped>` in Vue components

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,9 @@ jobs:
     - name: Run Linter
       run: pnpm run lint
 
+    - name: Run Stylelint
+      run: pnpm run lint:css
+
   format:
     runs-on: ubuntu-latest
     needs: check-rebase

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4742,7 +4742,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.19.17)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@24.1.3)(less@4.5.1)(lightningcss@1.30.2)(sass@1.97.3)(stylus@0.62.0)(terser@5.46.1)(yaml@2.8.2)
+      vitest: 4.0.18(@types/node@20.19.25)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@24.1.3)(less@4.5.1)(lightningcss@1.30.2)(sass@1.97.3)(stylus@0.62.0)(terser@5.46.1)(yaml@2.8.2)
 
   '@vitest/utils@4.0.18':
     dependencies:

--- a/src/components/Chat/Chat.vue
+++ b/src/components/Chat/Chat.vue
@@ -83,6 +83,7 @@ watch(() => props.messages.length, scrollToBottom)
         v-for="(message, index) in messages"
         :key="message.id"
         :message="message"
+        :variant="variant"
         :is-own="message.senderId === localPeerId"
         :grouped-with-previous="index > 0 && isSameUser(messages[index - 1], message)"
         :grouped-with-next="index < messages.length - 1 && isSameUser(messages[index + 1], message)"
@@ -111,26 +112,7 @@ watch(() => props.messages.length, scrollToBottom)
 <style scoped>
 .chat {
   --chat-font-scale: 1;
-  --chat-flex: initial;
-  --chat-bg: transparent;
-  --chat-border: none;
-  --chat-radius: 0;
-  --chat-shadow: none;
-  --chat-padding: 0;
-  --chat-box-sizing: content-box;
-  --chat-control-radius: var(--radius-sm);
-  --chat-control-border: 1px solid var(--color-border);
-  --chat-list-radius: var(--radius-sm);
-  --chat-list-border: 1px solid var(--color-border);
-  --chat-list-bg: var(--color-background);
 
-  flex: var(--chat-flex);
-  background: var(--chat-bg);
-  border: var(--chat-border);
-  border-radius: var(--chat-radius);
-  box-shadow: var(--chat-shadow);
-  padding: var(--chat-padding);
-  box-sizing: var(--chat-box-sizing);
   display: flex;
   flex-direction: column;
   gap: var(--spacing-2);
@@ -147,10 +129,6 @@ watch(() => props.messages.length, scrollToBottom)
   box-shadow: 3px 3px 0 var(--game-border);
   padding: var(--spacing-2);
   box-sizing: border-box;
-
-  --chat-message-radius: var(--radius-xl);
-  --chat-message-radius-adjacent: 4px;
-  --chat-message-bg: #d7d8d9;
 }
 
 .chat__zoom {
@@ -164,8 +142,8 @@ watch(() => props.messages.length, scrollToBottom)
   align-items: center;
   justify-content: center;
   padding: var(--spacing-1);
-  border: var(--chat-control-border);
-  border-radius: var(--chat-control-radius);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
   background: var(--color-secondary);
   color: var(--color-foreground);
   cursor: pointer;
@@ -194,9 +172,9 @@ watch(() => props.messages.length, scrollToBottom)
   flex-direction: column;
   gap: var(--spacing-1);
   padding: var(--spacing-1);
-  background: var(--chat-list-bg);
-  border: var(--chat-list-border);
-  border-radius: var(--chat-list-radius);
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
 }
 
 .chat--game .chat__list {
@@ -213,8 +191,8 @@ watch(() => props.messages.length, scrollToBottom)
 .chat__input {
   flex: 1;
   padding: var(--spacing-1) var(--spacing-2);
-  border: var(--chat-control-border);
-  border-radius: var(--chat-control-radius);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
   background: var(--color-background);
   color: var(--color-foreground);
   font-size: var(--font-size-md, 1rem);
@@ -235,8 +213,8 @@ watch(() => props.messages.length, scrollToBottom)
   align-items: center;
   justify-content: center;
   padding: var(--spacing-1) var(--spacing-2);
-  border: var(--chat-control-border);
-  border-radius: var(--chat-control-radius);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
   background: var(--color-primary);
   color: var(--color-primary-foreground);
   cursor: pointer;

--- a/src/components/Chat/Chat.vue
+++ b/src/components/Chat/Chat.vue
@@ -111,7 +111,26 @@ watch(() => props.messages.length, scrollToBottom)
 <style scoped>
 .chat {
   --chat-font-scale: 1;
+  --chat-flex: initial;
+  --chat-bg: transparent;
+  --chat-border: none;
+  --chat-radius: 0;
+  --chat-shadow: none;
+  --chat-padding: 0;
+  --chat-box-sizing: content-box;
+  --chat-control-radius: var(--radius-sm);
+  --chat-control-border: 1px solid var(--color-border);
+  --chat-list-radius: var(--radius-sm);
+  --chat-list-border: 1px solid var(--color-border);
+  --chat-list-bg: var(--color-background);
 
+  flex: var(--chat-flex);
+  background: var(--chat-bg);
+  border: var(--chat-border);
+  border-radius: var(--chat-radius);
+  box-shadow: var(--chat-shadow);
+  padding: var(--chat-padding);
+  box-sizing: var(--chat-box-sizing);
   display: flex;
   flex-direction: column;
   gap: var(--spacing-2);
@@ -145,8 +164,8 @@ watch(() => props.messages.length, scrollToBottom)
   align-items: center;
   justify-content: center;
   padding: var(--spacing-1);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
+  border: var(--chat-control-border);
+  border-radius: var(--chat-control-radius);
   background: var(--color-secondary);
   color: var(--color-foreground);
   cursor: pointer;
@@ -175,9 +194,9 @@ watch(() => props.messages.length, scrollToBottom)
   flex-direction: column;
   gap: var(--spacing-1);
   padding: var(--spacing-1);
-  background: var(--color-background);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
+  background: var(--chat-list-bg);
+  border: var(--chat-list-border);
+  border-radius: var(--chat-list-radius);
 }
 
 .chat--game .chat__list {
@@ -194,8 +213,8 @@ watch(() => props.messages.length, scrollToBottom)
 .chat__input {
   flex: 1;
   padding: var(--spacing-1) var(--spacing-2);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
+  border: var(--chat-control-border);
+  border-radius: var(--chat-control-radius);
   background: var(--color-background);
   color: var(--color-foreground);
   font-size: var(--font-size-md, 1rem);
@@ -216,8 +235,8 @@ watch(() => props.messages.length, scrollToBottom)
   align-items: center;
   justify-content: center;
   padding: var(--spacing-1) var(--spacing-2);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
+  border: var(--chat-control-border);
+  border-radius: var(--chat-control-radius);
   background: var(--color-primary);
   color: var(--color-primary-foreground);
   cursor: pointer;

--- a/src/components/Chat/ChatMessage.vue
+++ b/src/components/Chat/ChatMessage.vue
@@ -29,6 +29,10 @@ defineProps<{
 
 <style scoped>
 .chat-message {
+  --chat-message-radius: var(--radius-sm);
+  --chat-message-radius-adjacent: var(--radius-sm);
+  --chat-message-bg: var(--color-secondary);
+
   display: flex;
   flex-direction: column;
   gap: var(--spacing-0);

--- a/src/components/Chat/ChatMessage.vue
+++ b/src/components/Chat/ChatMessage.vue
@@ -6,6 +6,7 @@ defineProps<{
   isOwn: boolean
   groupedWithPrevious?: boolean
   groupedWithNext?: boolean
+  variant?: 'game'
 }>()
 </script>
 
@@ -13,6 +14,7 @@ defineProps<{
   <div
     class="chat-message"
     :class="{
+      'chat-message--game': variant === 'game',
       'chat-message--own': isOwn,
       'chat-message--system': message.kind === 'system',
       'chat-message--success': message.kind === 'success',
@@ -29,19 +31,20 @@ defineProps<{
 
 <style scoped>
 .chat-message {
-  --chat-message-radius: var(--radius-sm);
-  --chat-message-radius-adjacent: var(--radius-sm);
-  --chat-message-bg: var(--color-secondary);
-
   display: flex;
   flex-direction: column;
   gap: var(--spacing-0);
   padding: var(--spacing-1) var(--spacing-2);
-  border-radius: var(--chat-message-radius, var(--radius-sm));
-  background: var(--chat-message-bg, var(--color-secondary));
+  border-radius: var(--radius-sm);
+  background: var(--color-secondary);
   font-size: inherit;
   color: #111;
   overflow-wrap: break-word;
+}
+
+.chat-message--game {
+  border-radius: var(--radius-xl);
+  background: #d7d8d9;
 }
 
 .chat-message--own {
@@ -55,17 +58,31 @@ defineProps<{
 }
 
 .chat-message--group-top {
-  border-bottom-left-radius: var(--chat-message-radius-adjacent, var(--radius-sm));
-  border-bottom-right-radius: var(--chat-message-radius-adjacent, var(--radius-sm));
+  border-bottom-left-radius: var(--radius-sm);
+  border-bottom-right-radius: var(--radius-sm);
+}
+
+.chat-message--game.chat-message--group-top {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
 }
 
 .chat-message--group-middle {
-  border-radius: var(--chat-message-radius-adjacent, var(--radius-sm));
+  border-radius: var(--radius-sm);
+}
+
+.chat-message--game.chat-message--group-middle {
+  border-radius: 4px;
 }
 
 .chat-message--group-bottom {
-  border-top-left-radius: var(--chat-message-radius-adjacent, var(--radius-sm));
-  border-top-right-radius: var(--chat-message-radius-adjacent, var(--radius-sm));
+  border-top-left-radius: var(--radius-sm);
+  border-top-right-radius: var(--radius-sm);
+}
+
+.chat-message--game.chat-message--group-bottom {
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
 }
 
 .chat-message--system {

--- a/src/components/MultiplayerSidebar.vue
+++ b/src/components/MultiplayerSidebar.vue
@@ -161,21 +161,5 @@ const emit = defineEmits<{
   display: flex;
   flex-direction: column;
   overflow: hidden;
-
-  --chat-flex: 1;
-  --chat-bg: var(--game-surface-subtle);
-  --chat-border: 3px solid var(--game-border);
-  --chat-radius: 1.25rem;
-  --chat-shadow: 3px 3px 0 var(--game-border);
-  --chat-padding: var(--spacing-2);
-  --chat-box-sizing: border-box;
-  --chat-control-radius: 999px;
-  --chat-control-border: 2px solid var(--game-border);
-  --chat-list-radius: 1rem;
-  --chat-list-border: 2px solid var(--game-border);
-  --chat-list-bg: var(--game-surface-subtle);
-  --chat-message-radius: var(--radius-xl);
-  --chat-message-radius-adjacent: 4px;
-  --chat-message-bg: #d7d8d9;
 }
 </style>

--- a/src/components/MultiplayerSidebar.vue
+++ b/src/components/MultiplayerSidebar.vue
@@ -161,5 +161,21 @@ const emit = defineEmits<{
   display: flex;
   flex-direction: column;
   overflow: hidden;
+
+  --chat-flex: 1;
+  --chat-bg: var(--game-surface-subtle);
+  --chat-border: 3px solid var(--game-border);
+  --chat-radius: 1.25rem;
+  --chat-shadow: 3px 3px 0 var(--game-border);
+  --chat-padding: var(--spacing-2);
+  --chat-box-sizing: border-box;
+  --chat-control-radius: 999px;
+  --chat-control-border: 2px solid var(--game-border);
+  --chat-list-radius: 1rem;
+  --chat-list-border: 2px solid var(--game-border);
+  --chat-list-bg: var(--game-surface-subtle);
+  --chat-message-radius: var(--radius-xl);
+  --chat-message-radius-adjacent: 4px;
+  --chat-message-bg: #d7d8d9;
 }
 </style>

--- a/src/style.css
+++ b/src/style.css
@@ -30,7 +30,6 @@ body {
 
 html,
 body {
-  user-select: none;
   overflow: hidden;
   max-height: 100vh;
 }


### PR DESCRIPTION
Closes #147

## Summary

- Add stylelint with `stylelint-config-standard-scss` and `stylelint-config-recommended-vue/scss`; integrate with lint-staged
- Enforce `selector-pseudo-class-disallowed-list: ["deep"]` — permanently bans `:deep()` at commit time
- Remove remaining `:deep()` usages across the codebase; expose CSS custom properties where needed (CanvasEditor, PictionaryDrawing)
- Add `variant` prop to `ChatMessage` + `.chat-message--game` BEM modifier — Chat component owns all its own styles, no CSS variables crossing component boundaries
- Add code-style rules: never use `:deep()`, never use CSS custom properties to pass style between components (use `variant` prop instead), never use discontinued/unmaintained npm packages

## Key Changes

- `.stylelintrc.json` — stylelint config with `:deep()` ban enforced at lint time
- `Chat.vue` — passes `:variant="variant"` to each `ChatMessageItem`; direct values in all selectors, no `--chat-*` indirection
- `ChatMessage.vue` — `variant?: 'game'` prop; `.chat-message--game` modifier with all game-specific styles self-contained
- `MultiplayerSidebar.vue` — no CSS variable overrides; passes `variant="game"` via Chat's prop
- `.github/rules/code-style.md` — updated `:deep()` rule; new cross-component CSS rule

## Test Plan

- [ ] `pnpm lint:css` passes with no violations
- [ ] Attempting to use `:deep()` fails lint-staged on commit
- [ ] Chat renders correctly in default context (no variant)
- [ ] Chat renders correctly with `variant="game"` inside `MultiplayerSidebar`