### PR TITLE
feat: client-side image converter and compressor

### DIFF
--- a/.github/rules/code-style.md
+++ b/.github/rules/code-style.md
@@ -1,5 +1,9 @@
 # Code Style Guidelines
 
+## Tone and Content
+
+- **No emoji**: Never use emoji in code, comments, UI text, commit messages, documentation, or any other output unless the user explicitly requests it. Use plain SVG icons or text instead of emoji in UI.
+
 ## Uncertainty & Debugging
 
 - **Ask before assuming**: If uncertain about expected behavior, physics interactions, or edge cases, ask for clarification before implementing

--- a/documentation/docs/journey/image-converter.md
+++ b/documentation/docs/journey/image-converter.md
@@ -1,0 +1,82 @@
+---
+sidebar_position: 99
+---
+
+# Image Converter: Client-Side Conversion via Web Worker
+
+This documents the design decisions behind the image converter tool (issue #37).
+
+## The constraint: everything must stay in the browser
+
+The goal was to convert and compress images — PNG to WebP, resize on the fly, adjust quality — without sending files to a server. Two reasons drove this: privacy (users should not need to upload personal images to a third party) and simplicity (no backend, no storage, no auth).
+
+The browser has had the building blocks for years: `FileReader`, `Canvas`, and `toBlob`. The missing piece was keeping the main thread free during conversion of large files or batches.
+
+## Why a Web Worker?
+
+Decoding a 10 MB PNG, scaling it, and re-encoding it to WebP can take hundreds of milliseconds. Running that on the main thread freezes the UI — the file list stops updating, animations stutter, and the browser may show a "page unresponsive" warning on slower devices.
+
+A dedicated Worker runs on a separate OS thread. The main thread posts a message and continues rendering; the Worker does the heavy lifting and posts the result back when done.
+
+```mermaid
+sequenceDiagram
+    participant Main as Main Thread
+    participant Worker as Image Worker
+
+    Main->>Worker: postMessage({ id, buffer, format, quality, ... })
+    Note over Worker: createImageBitmap(blob)
+    Note over Worker: OffscreenCanvas → drawImage → convertToBlob
+    Worker-->>Main: postMessage({ id, buffer }, [buffer])
+    Note over Main: new Blob([buffer]) → createObjectURL → download link
+```
+
+Each file gets its own message round-trip. The Worker processes them sequentially (one active job at a time) and signals completion via the result's `id`, which the main thread uses to match the result back to the correct file entry.
+
+## OffscreenCanvas as the conversion engine
+
+`HTMLCanvasElement.toBlob()` is the classic approach to re-encode an image in a browser. But `HTMLCanvasElement` is a DOM object and cannot be used inside a Worker.
+
+`OffscreenCanvas` is the Worker-compatible equivalent. It has the same 2D drawing API and — crucially — a `convertToBlob()` method that returns a Promise with the encoded result in whatever format and quality you request.
+
+```mermaid
+flowchart LR
+    A[ArrayBuffer] --> B["new Blob([buffer])"]
+    B --> C[createImageBitmap]
+    C --> D["OffscreenCanvas\n.getContext('2d')\n.drawImage"]
+    D --> E["canvas.convertToBlob\n({ type, quality })"]
+    E --> F[ArrayBuffer via .arrayBuffer()]
+    F --> G[transferred to main thread]
+```
+
+`createImageBitmap` handles decoding — it accepts a `Blob` directly, respects EXIF orientation, and returns a hardware-accelerated `ImageBitmap` that can be drawn to canvas in one call. The bitmap is then closed to free GPU memory.
+
+## Transferable ArrayBuffers: zero-copy across threads
+
+Blobs cannot be transferred between threads — they can only be structured-cloned, which copies the underlying bytes. A large image file copied twice (once to the Worker, once back) would double the peak memory usage.
+
+The output is instead read into an `ArrayBuffer` (`outputBlob.arrayBuffer()`) which is transferred using the second argument to `postMessage`:
+
+```typescript
+self.postMessage(result, [outputBuffer])
+```
+
+Transferring an `ArrayBuffer` hands ownership to the receiving thread without copying — the Worker's reference becomes detached (zero bytes) the moment the transfer completes. The main thread reconstructs a `Blob` from the received buffer for the download link.
+
+The input buffer is not transferred to the Worker — it is structured-cloned. This is intentional: the original buffer stays valid on the main thread so "Re-convert all" can resend it with new settings without re-reading the file from disk.
+
+## Format support and AVIF detection
+
+`convertToBlob` accepts any MIME type the browser supports for encoding. WebP and JPEG are universally supported in modern browsers. AVIF encoding requires Chrome 94+ or Firefox 113+.
+
+Rather than silently producing a PNG fallback when AVIF is unavailable, the Worker lets the `convertToBlob` call reject. The error propagates back to the main thread as a `ConvertError` message, and the file entry shows the browser's own error text. This makes the limitation explicit rather than surprising the user with an unexpected output format.
+
+## Object URL lifecycle
+
+Each converted file gets a temporary object URL (`URL.createObjectURL`) pointing to its output Blob. These URLs are revoked:
+
+- When the user removes a file from the list
+- When "Clear all" is clicked
+- When "Re-convert all" replaces them with fresh results
+- On `onUnmounted`, which also terminates the Worker
+
+Without explicit revocation, object URLs persist for the lifetime of the document and the underlying Blobs are never garbage-collected — a steady memory leak for users processing many images in one session.

--- a/src/views/Tools/ImageConverter/DropZone.vue
+++ b/src/views/Tools/ImageConverter/DropZone.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+defineProps<{
+  accept?: string
+  multiple?: boolean
+}>()
+
+const emit = defineEmits<{
+  change: [files: FileList]
+}>()
+
+const isDragging = ref(false)
+
+const onDrop = (event: DragEvent): void => {
+  isDragging.value = false
+  if (event.dataTransfer?.files?.length) emit('change', event.dataTransfer.files)
+}
+
+const onInputChange = (event: Event): void => {
+  const files = (event.target as HTMLInputElement).files
+  if (files?.length) emit('change', files)
+}
+</script>
+
+<template>
+  <label
+    class="drop-zone"
+    :class="{ 'drop-zone--dragging': isDragging }"
+    @dragover.prevent="isDragging = true"
+    @dragleave.prevent="isDragging = false"
+    @drop.prevent="onDrop"
+  >
+    <svg
+      class="drop-zone__icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.5"
+      aria-hidden="true"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
+      />
+    </svg>
+    <span class="drop-zone__text">Drop images here or click to browse</span>
+    <input
+      type="file"
+      :multiple="multiple"
+      :accept="accept"
+      class="drop-zone__input"
+      @change="onInputChange"
+    />
+  </label>
+</template>
+
+<style scoped>
+.drop-zone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-10);
+  border: 2px dashed var(--color-muted-foreground);
+  border-radius: var(--radius-lg);
+  background: var(--color-secondary);
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+}
+
+.drop-zone:hover,
+.drop-zone--dragging {
+  border-color: var(--color-primary);
+  background: var(--color-muted);
+}
+
+.drop-zone__icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  color: var(--color-muted-foreground);
+}
+
+.drop-zone__text {
+  color: var(--color-muted-foreground);
+  font-size: var(--font-size-md);
+}
+
+.drop-zone__input {
+  display: none;
+}
+</style>

--- a/src/views/Tools/ImageConverter/ImageConverter.vue
+++ b/src/views/Tools/ImageConverter/ImageConverter.vue
@@ -1,0 +1,562 @@
+<script setup lang="ts">
+import { ref, computed, onUnmounted } from 'vue'
+import ConverterWorker from './imageConverter.worker?worker'
+import {
+  FORMAT_OPTIONS,
+  DEFAULT_FORMAT,
+  DEFAULT_QUALITY,
+  DEFAULT_MAX_DIMENSION,
+  ACCEPTED_TYPES,
+  type ImageFormat,
+  type ConvertRequest,
+  type ConvertResult,
+  type ConvertError
+} from './config'
+
+type FileEntry = {
+  id: string
+  name: string
+  originalSize: number
+  mimeType: string
+  buffer: ArrayBuffer
+  previewUrl: string
+  status: 'pending' | 'processing' | 'done' | 'error'
+  convertedBlob?: Blob
+  convertedSize?: number
+  downloadUrl?: string
+  error?: string
+}
+
+const format = ref<ImageFormat>(DEFAULT_FORMAT)
+const quality = ref(DEFAULT_QUALITY)
+const maxWidth = ref(DEFAULT_MAX_DIMENSION)
+const maxHeight = ref(DEFAULT_MAX_DIMENSION)
+const isDragging = ref(false)
+const files = ref<FileEntry[]>([])
+
+const selectedFormatOption = computed(() => FORMAT_OPTIONS.find((f) => f.value === format.value)!)
+const isLossy = computed(() => selectedFormatOption.value.lossy)
+
+const worker = new ConverterWorker()
+
+const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+}
+
+const savings = (entry: FileEntry): string => {
+  if (!entry.convertedSize) return ''
+  const pct = ((1 - entry.convertedSize / entry.originalSize) * 100).toFixed(1)
+  return Number(pct) > 0 ? `-${pct}%` : `+${Math.abs(Number(pct))}%`
+}
+
+const resultExtension = computed(() => selectedFormatOption.value.extension)
+
+const downloadName = (entry: FileEntry): string => {
+  const base = entry.name.replace(/\.[^.]+$/, '')
+  return `${base}.${resultExtension.value}`
+}
+
+worker.onmessage = (event: MessageEvent<ConvertResult | ConvertError>) => {
+  const data = event.data
+  const entry = files.value.find((f) => f.id === data.id)
+  if (!entry) return
+
+  if ('error' in data) {
+    entry.status = 'error'
+    entry.error = data.error
+    return
+  }
+
+  const result = data as ConvertResult
+  const blob = new Blob([result.buffer], { type: result.format })
+  entry.convertedBlob = blob
+  entry.convertedSize = result.convertedSize
+  entry.downloadUrl = URL.createObjectURL(blob)
+  entry.status = 'done'
+}
+
+const processEntry = (entry: FileEntry): void => {
+  entry.status = 'processing'
+  const request: ConvertRequest = {
+    id: entry.id,
+    buffer: entry.buffer,
+    mimeType: entry.mimeType,
+    format: format.value,
+    quality: quality.value,
+    maxWidth: maxWidth.value,
+    maxHeight: maxHeight.value
+  }
+  worker.postMessage(request)
+}
+
+const readFile = (file: File): Promise<FileEntry> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      const buffer = e.target?.result as ArrayBuffer
+      const previewUrl = URL.createObjectURL(file)
+      resolve({
+        id: `${Date.now()}-${Math.random()}`,
+        name: file.name,
+        originalSize: file.size,
+        mimeType: file.type,
+        buffer,
+        previewUrl,
+        status: 'pending'
+      })
+    }
+    reader.onerror = () => reject(reader.error)
+    reader.readAsArrayBuffer(file)
+  })
+
+const addFiles = async (fileList: FileList | null): Promise<void> => {
+  if (!fileList) return
+  const entries = await Promise.all([...fileList].map(readFile))
+  files.value = [...files.value, ...entries]
+  entries.forEach(processEntry)
+}
+
+const onDrop = (event: DragEvent): void => {
+  isDragging.value = false
+  addFiles(event.dataTransfer?.files ?? null)
+}
+
+const onInputChange = (event: Event): void => {
+  addFiles((event.target as HTMLInputElement).files)
+}
+
+const reconvertAll = (): void => {
+  files.value.forEach((entry) => {
+    if (entry.downloadUrl) URL.revokeObjectURL(entry.downloadUrl)
+    entry.downloadUrl = undefined
+    entry.convertedBlob = undefined
+    entry.convertedSize = undefined
+    entry.error = undefined
+    processEntry(entry)
+  })
+}
+
+const removeEntry = (id: string): void => {
+  const entry = files.value.find((f) => f.id === id)
+  if (entry) {
+    URL.revokeObjectURL(entry.previewUrl)
+    if (entry.downloadUrl) URL.revokeObjectURL(entry.downloadUrl)
+  }
+  files.value = files.value.filter((f) => f.id !== id)
+}
+
+const clearAll = (): void => {
+  files.value.forEach((entry) => {
+    URL.revokeObjectURL(entry.previewUrl)
+    if (entry.downloadUrl) URL.revokeObjectURL(entry.downloadUrl)
+  })
+  files.value = []
+}
+
+onUnmounted(() => {
+  worker.terminate()
+  clearAll()
+})
+</script>
+
+<template>
+  <div class="image-converter">
+    <div class="image-converter__controls">
+      <div class="image-converter__control-group">
+        <label class="image-converter__label">Format</label>
+        <div class="image-converter__format-options">
+          <label
+            v-for="opt in FORMAT_OPTIONS"
+            :key="opt.value"
+            class="image-converter__format-option"
+            :class="{ 'image-converter__format-option--active': format === opt.value }"
+          >
+            <input
+              v-model="format"
+              type="radio"
+              :value="opt.value"
+              class="image-converter__radio"
+            />
+            {{ opt.label }}
+          </label>
+        </div>
+      </div>
+
+      <div v-if="isLossy" class="image-converter__control-group">
+        <label class="image-converter__label">Quality — {{ quality }}%</label>
+        <input
+          v-model.number="quality"
+          type="range"
+          min="1"
+          max="100"
+          class="image-converter__range"
+        />
+      </div>
+
+      <div class="image-converter__control-group image-converter__control-group--row">
+        <div class="image-converter__control-group">
+          <label class="image-converter__label">Max width (px)</label>
+          <input
+            v-model.number="maxWidth"
+            type="number"
+            min="0"
+            placeholder="0 = no limit"
+            class="image-converter__input"
+          />
+        </div>
+        <div class="image-converter__control-group">
+          <label class="image-converter__label">Max height (px)</label>
+          <input
+            v-model.number="maxHeight"
+            type="number"
+            min="0"
+            placeholder="0 = no limit"
+            class="image-converter__input"
+          />
+        </div>
+      </div>
+
+      <div v-if="files.length > 0" class="image-converter__actions">
+        <button class="image-converter__btn" type="button" @click="reconvertAll">
+          Re-convert all
+        </button>
+        <button
+          class="image-converter__btn image-converter__btn--ghost"
+          type="button"
+          @click="clearAll"
+        >
+          Clear all
+        </button>
+      </div>
+    </div>
+
+    <div
+      class="image-converter__dropzone"
+      :class="{ 'image-converter__dropzone--dragging': isDragging }"
+      @dragover.prevent="isDragging = true"
+      @dragleave.prevent="isDragging = false"
+      @drop.prevent="onDrop"
+    >
+      <span class="image-converter__dropzone-icon">🖼</span>
+      <span class="image-converter__dropzone-text">Drop images here or</span>
+      <label class="image-converter__btn image-converter__btn--primary">
+        Browse
+        <input
+          type="file"
+          multiple
+          :accept="ACCEPTED_TYPES"
+          class="image-converter__file-input"
+          @change="onInputChange"
+        />
+      </label>
+    </div>
+
+    <ul v-if="files.length > 0" class="image-converter__file-list">
+      <li v-for="entry in files" :key="entry.id" class="image-converter__file-item">
+        <img :src="entry.previewUrl" :alt="entry.name" class="image-converter__thumb" />
+
+        <div class="image-converter__file-info">
+          <span class="image-converter__file-name" :title="entry.name">{{ entry.name }}</span>
+          <div class="image-converter__file-sizes">
+            <span>{{ formatBytes(entry.originalSize) }}</span>
+            <template v-if="entry.status === 'done' && entry.convertedSize !== undefined">
+              <span class="image-converter__arrow">→</span>
+              <span>{{ formatBytes(entry.convertedSize) }}</span>
+              <span
+                class="image-converter__savings"
+                :class="
+                  entry.convertedSize < entry.originalSize
+                    ? 'image-converter__savings--positive'
+                    : 'image-converter__savings--negative'
+                "
+              >
+                {{ savings(entry) }}
+              </span>
+            </template>
+          </div>
+          <span v-if="entry.status === 'processing'" class="image-converter__status">
+            Converting…
+          </span>
+          <span
+            v-if="entry.status === 'error'"
+            class="image-converter__status image-converter__status--error"
+          >
+            {{ entry.error }}
+          </span>
+        </div>
+
+        <div class="image-converter__file-actions">
+          <a
+            v-if="entry.downloadUrl"
+            :href="entry.downloadUrl"
+            :download="downloadName(entry)"
+            class="image-converter__btn image-converter__btn--primary"
+          >
+            Download
+          </a>
+          <button
+            class="image-converter__btn image-converter__btn--ghost"
+            type="button"
+            @click="removeEntry(entry.id)"
+          >
+            ✕
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.image-converter {
+  padding-top: var(--nav-height);
+  min-height: 100vh;
+  max-width: 56rem;
+  margin: 0 auto;
+  padding-inline: var(--spacing-4);
+  padding-bottom: var(--spacing-10);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-6);
+}
+
+.image-converter__controls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  padding: var(--spacing-4);
+  background: var(--color-secondary);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+}
+
+.image-converter__control-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.image-converter__control-group--row {
+  flex-direction: row;
+  gap: var(--spacing-4);
+}
+
+.image-converter__control-group--row > * {
+  flex: 1;
+}
+
+.image-converter__label {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-muted-foreground);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.image-converter__format-options {
+  display: flex;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+.image-converter__format-option {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-1-5) var(--spacing-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: var(--font-size-md);
+  background: var(--color-background);
+  transition: border-color 0.15s;
+}
+
+.image-converter__format-option--active {
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+  color: var(--color-primary-foreground);
+}
+
+.image-converter__radio {
+  display: none;
+}
+
+.image-converter__range {
+  width: 100%;
+  accent-color: var(--color-primary);
+}
+
+.image-converter__input {
+  width: 100%;
+  padding: var(--spacing-1-5) var(--spacing-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background);
+  color: var(--color-foreground);
+  font-size: var(--font-size-md);
+  box-sizing: border-box;
+}
+
+.image-converter__actions {
+  display: flex;
+  gap: var(--spacing-2);
+}
+
+.image-converter__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-1-5) var(--spacing-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-md);
+  cursor: pointer;
+  background: var(--color-background);
+  color: var(--color-foreground);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.image-converter__btn--primary {
+  background: var(--color-primary);
+  color: var(--color-primary-foreground);
+  border-color: var(--color-primary);
+}
+
+.image-converter__btn--ghost {
+  background: transparent;
+  border-color: transparent;
+}
+
+.image-converter__file-input {
+  display: none;
+}
+
+.image-converter__dropzone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-10);
+  border: 2px dashed var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-secondary);
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+  cursor: default;
+}
+
+.image-converter__dropzone--dragging {
+  border-color: var(--color-primary);
+  background: var(--color-muted);
+}
+
+.image-converter__dropzone-icon {
+  font-size: 2.5rem;
+  line-height: 1;
+}
+
+.image-converter__dropzone-text {
+  color: var(--color-muted-foreground);
+  font-size: var(--font-size-md);
+}
+
+.image-converter__file-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.image-converter__file-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-secondary);
+}
+
+.image-converter__thumb {
+  width: 3.5rem;
+  height: 3.5rem;
+  object-fit: cover;
+  border-radius: var(--radius-md);
+  flex-shrink: 0;
+  border: 1px solid var(--color-border);
+}
+
+.image-converter__file-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.image-converter__file-name {
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.image-converter__file-sizes {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-muted-foreground);
+}
+
+.image-converter__arrow {
+  opacity: 0.5;
+}
+
+.image-converter__savings {
+  font-weight: 700;
+}
+
+.image-converter__savings--positive {
+  color: #16a34a;
+}
+
+.image-converter__savings--negative {
+  color: #dc2626;
+}
+
+.image-converter__status {
+  font-size: var(--font-size-sm);
+  color: var(--color-muted-foreground);
+}
+
+.image-converter__status--error {
+  color: #dc2626;
+}
+
+.image-converter__file-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  flex-shrink: 0;
+}
+
+@media (width <= 480px) {
+  .image-converter__control-group--row {
+    flex-direction: column;
+  }
+
+  .image-converter__file-item {
+    flex-wrap: wrap;
+  }
+}
+</style>

--- a/src/views/Tools/ImageConverter/ImageConverter.vue
+++ b/src/views/Tools/ImageConverter/ImageConverter.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { ref, computed, onUnmounted } from 'vue'
 import ConverterWorker from './imageConverter.worker?worker'
+import DropZone from './DropZone.vue'
 import {
   FORMAT_OPTIONS,
   DEFAULT_FORMAT,
   DEFAULT_QUALITY,
   DEFAULT_MAX_DIMENSION,
+  DEFAULT_SCALE_PCT,
   ACCEPTED_TYPES,
   type ImageFormat,
   type ConvertRequest,
@@ -31,7 +33,7 @@ const format = ref<ImageFormat>(DEFAULT_FORMAT)
 const quality = ref(DEFAULT_QUALITY)
 const maxWidth = ref(DEFAULT_MAX_DIMENSION)
 const maxHeight = ref(DEFAULT_MAX_DIMENSION)
-const isDragging = ref(false)
+const scalePct = ref(DEFAULT_SCALE_PCT)
 const files = ref<FileEntry[]>([])
 
 const selectedFormatOption = computed(() => FORMAT_OPTIONS.find((f) => f.value === format.value)!)
@@ -86,7 +88,8 @@ const processEntry = (entry: FileEntry): void => {
     format: format.value,
     quality: quality.value,
     maxWidth: maxWidth.value,
-    maxHeight: maxHeight.value
+    maxHeight: maxHeight.value,
+    scalePct: scalePct.value
   }
   worker.postMessage(request)
 }
@@ -111,20 +114,10 @@ const readFile = (file: File): Promise<FileEntry> =>
     reader.readAsArrayBuffer(file)
   })
 
-const addFiles = async (fileList: FileList | null): Promise<void> => {
-  if (!fileList) return
+const addFiles = async (fileList: FileList): Promise<void> => {
   const entries = await Promise.all([...fileList].map(readFile))
   files.value = [...files.value, ...entries]
   entries.forEach(processEntry)
-}
-
-const onDrop = (event: DragEvent): void => {
-  isDragging.value = false
-  addFiles(event.dataTransfer?.files ?? null)
-}
-
-const onInputChange = (event: Event): void => {
-  addFiles((event.target as HTMLInputElement).files)
 }
 
 const reconvertAll = (): void => {
@@ -218,6 +211,17 @@ onUnmounted(() => {
         </div>
       </div>
 
+      <div class="image-converter__control-group">
+        <label class="image-converter__label">Scale — {{ scalePct }}%</label>
+        <input
+          v-model.number="scalePct"
+          type="range"
+          min="1"
+          max="100"
+          class="image-converter__range"
+        />
+      </div>
+
       <div v-if="files.length > 0" class="image-converter__actions">
         <button class="image-converter__btn" type="button" @click="reconvertAll">
           Re-convert all
@@ -232,39 +236,7 @@ onUnmounted(() => {
       </div>
     </div>
 
-    <div
-      class="image-converter__dropzone"
-      :class="{ 'image-converter__dropzone--dragging': isDragging }"
-      @dragover.prevent="isDragging = true"
-      @dragleave.prevent="isDragging = false"
-      @drop.prevent="onDrop"
-    >
-      <svg
-        class="image-converter__dropzone-icon"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="1.5"
-        aria-hidden="true"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
-        />
-      </svg>
-      <span class="image-converter__dropzone-text">Drop images here or</span>
-      <label class="image-converter__btn image-converter__btn--primary">
-        Browse
-        <input
-          type="file"
-          multiple
-          :accept="ACCEPTED_TYPES"
-          class="image-converter__file-input"
-          @change="onInputChange"
-        />
-      </label>
-    </div>
+    <DropZone multiple :accept="ACCEPTED_TYPES" @change="addFiles" />
 
     <ul v-if="files.length > 0" class="image-converter__file-list">
       <li v-for="entry in files" :key="entry.id" class="image-converter__file-item">
@@ -442,42 +414,6 @@ onUnmounted(() => {
 .image-converter__btn--ghost {
   background: transparent;
   border-color: transparent;
-}
-
-.image-converter__file-input {
-  display: none;
-}
-
-.image-converter__dropzone {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: var(--spacing-3);
-  padding: var(--spacing-10);
-  border: 2px dashed var(--color-muted-foreground);
-  border-radius: var(--radius-lg);
-  background: var(--color-secondary);
-  transition:
-    border-color 0.15s,
-    background 0.15s;
-  cursor: default;
-}
-
-.image-converter__dropzone--dragging {
-  border-color: var(--color-primary);
-  background: var(--color-muted);
-}
-
-.image-converter__dropzone-icon {
-  width: 2.5rem;
-  height: 2.5rem;
-  color: var(--color-muted-foreground);
-}
-
-.image-converter__dropzone-text {
-  color: var(--color-muted-foreground);
-  font-size: var(--font-size-md);
 }
 
 .image-converter__file-list {

--- a/src/views/Tools/ImageConverter/ImageConverter.vue
+++ b/src/views/Tools/ImageConverter/ImageConverter.vue
@@ -455,7 +455,7 @@ onUnmounted(() => {
   justify-content: center;
   gap: var(--spacing-3);
   padding: var(--spacing-10);
-  border: 2px dashed var(--color-border);
+  border: 2px dashed var(--color-muted-foreground);
   border-radius: var(--radius-lg);
   background: var(--color-secondary);
   transition:

--- a/src/views/Tools/ImageConverter/ImageConverter.vue
+++ b/src/views/Tools/ImageConverter/ImageConverter.vue
@@ -239,7 +239,20 @@ onUnmounted(() => {
       @dragleave.prevent="isDragging = false"
       @drop.prevent="onDrop"
     >
-      <span class="image-converter__dropzone-icon">🖼</span>
+      <svg
+        class="image-converter__dropzone-icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        aria-hidden="true"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
+        />
+      </svg>
       <span class="image-converter__dropzone-text">Drop images here or</span>
       <label class="image-converter__btn image-converter__btn--primary">
         Browse
@@ -457,8 +470,9 @@ onUnmounted(() => {
 }
 
 .image-converter__dropzone-icon {
-  font-size: 2.5rem;
-  line-height: 1;
+  width: 2.5rem;
+  height: 2.5rem;
+  color: var(--color-muted-foreground);
 }
 
 .image-converter__dropzone-text {

--- a/src/views/Tools/ImageConverter/config.ts
+++ b/src/views/Tools/ImageConverter/config.ts
@@ -1,0 +1,43 @@
+export type ImageFormat = 'image/webp' | 'image/jpeg' | 'image/png' | 'image/avif'
+
+export type ConvertRequest = {
+  id: string
+  buffer: ArrayBuffer
+  mimeType: string
+  format: ImageFormat
+  quality: number
+  maxWidth: number
+  maxHeight: number
+}
+
+export type ConvertResult = {
+  id: string
+  buffer: ArrayBuffer
+  format: ImageFormat
+  originalSize: number
+  convertedSize: number
+}
+
+export type ConvertError = {
+  id: string
+  error: string
+}
+
+export type FormatOption = {
+  value: ImageFormat
+  label: string
+  lossy: boolean
+  extension: string
+}
+
+export const FORMAT_OPTIONS: FormatOption[] = [
+  { value: 'image/webp', label: 'WebP', lossy: true, extension: 'webp' },
+  { value: 'image/jpeg', label: 'JPEG', lossy: true, extension: 'jpg' },
+  { value: 'image/avif', label: 'AVIF', lossy: true, extension: 'avif' },
+  { value: 'image/png', label: 'PNG', lossy: false, extension: 'png' }
+]
+
+export const DEFAULT_FORMAT: ImageFormat = 'image/webp'
+export const DEFAULT_QUALITY = 85
+export const DEFAULT_MAX_DIMENSION = 0
+export const ACCEPTED_TYPES = 'image/*'

--- a/src/views/Tools/ImageConverter/config.ts
+++ b/src/views/Tools/ImageConverter/config.ts
@@ -8,6 +8,7 @@ export type ConvertRequest = {
   quality: number
   maxWidth: number
   maxHeight: number
+  scalePct: number
 }
 
 export type ConvertResult = {
@@ -40,4 +41,5 @@ export const FORMAT_OPTIONS: FormatOption[] = [
 export const DEFAULT_FORMAT: ImageFormat = 'image/webp'
 export const DEFAULT_QUALITY = 85
 export const DEFAULT_MAX_DIMENSION = 0
+export const DEFAULT_SCALE_PCT = 100
 export const ACCEPTED_TYPES = 'image/*'

--- a/src/views/Tools/ImageConverter/imageConverter.worker.ts
+++ b/src/views/Tools/ImageConverter/imageConverter.worker.ts
@@ -1,12 +1,13 @@
 import type { ConvertRequest, ConvertResult, ConvertError } from './config'
 
 const convertImage = async (request: ConvertRequest): Promise<void> => {
-  const { id, buffer, mimeType, format, quality, maxWidth, maxHeight } = request
+  const { id, buffer, mimeType, format, quality, maxWidth, maxHeight, scalePct } = request
 
   const blob = new Blob([buffer], { type: mimeType })
   const bitmap = await createImageBitmap(blob)
 
-  const scale =
+  const pctScale = scalePct > 0 ? scalePct / 100 : 1
+  const dimScale =
     maxWidth > 0 || maxHeight > 0
       ? Math.min(
           maxWidth > 0 ? maxWidth / bitmap.width : 1,
@@ -14,6 +15,7 @@ const convertImage = async (request: ConvertRequest): Promise<void> => {
           1
         )
       : 1
+  const scale = pctScale * dimScale
 
   const width = Math.round(bitmap.width * scale)
   const height = Math.round(bitmap.height * scale)

--- a/src/views/Tools/ImageConverter/imageConverter.worker.ts
+++ b/src/views/Tools/ImageConverter/imageConverter.worker.ts
@@ -1,0 +1,56 @@
+import type { ConvertRequest, ConvertResult, ConvertError } from './config'
+
+const convertImage = async (request: ConvertRequest): Promise<void> => {
+  const { id, buffer, mimeType, format, quality, maxWidth, maxHeight } = request
+
+  const blob = new Blob([buffer], { type: mimeType })
+  const bitmap = await createImageBitmap(blob)
+
+  const scale =
+    maxWidth > 0 || maxHeight > 0
+      ? Math.min(
+          maxWidth > 0 ? maxWidth / bitmap.width : 1,
+          maxHeight > 0 ? maxHeight / bitmap.height : 1,
+          1
+        )
+      : 1
+
+  const width = Math.round(bitmap.width * scale)
+  const height = Math.round(bitmap.height * scale)
+
+  const canvas = new OffscreenCanvas(width, height)
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Failed to get 2D context')
+
+  ctx.drawImage(bitmap, 0, 0, width, height)
+  bitmap.close()
+
+  const outputBlob = await canvas.convertToBlob({
+    type: format,
+    quality: quality / 100
+  })
+
+  const outputBuffer = await outputBlob.arrayBuffer()
+
+  const result: ConvertResult = {
+    id,
+    buffer: outputBuffer,
+    format,
+    originalSize: buffer.byteLength,
+    convertedSize: outputBuffer.byteLength
+  }
+
+  self.postMessage(result, [outputBuffer])
+}
+
+self.onmessage = async (event: MessageEvent<ConvertRequest>) => {
+  try {
+    await convertImage(event.data)
+  } catch (error_) {
+    const error: ConvertError = {
+      id: event.data.id,
+      error: error_ instanceof Error ? error_.message : String(error_)
+    }
+    self.postMessage(error)
+  }
+}


### PR DESCRIPTION
Closes #37

## Summary

- Drop or browse any image(s) → pick output format, quality, and optional max dimensions → converted file downloads immediately, all in the browser with no server round-trip
- Heavy work (decode → scale → encode) runs in a Web Worker via `OffscreenCanvas.convertToBlob()` so the main thread stays responsive during batch conversion
- Output `ArrayBuffer` is transferred (zero-copy) from the worker back to the main thread

## Key Changes

- [config.ts](src/views/Tools/ImageConverter/config.ts) — `ConvertRequest/Result/Error` types, `FORMAT_OPTIONS` (WebP/JPEG/AVIF/PNG), default constants
- [imageConverter.worker.ts](src/views/Tools/ImageConverter/imageConverter.worker.ts) — `createImageBitmap` → scale with `OffscreenCanvas` → `convertToBlob` → transfer `ArrayBuffer` back
- [ImageConverter.vue](src/views/Tools/ImageConverter/ImageConverter.vue) — drag-and-drop + file picker, format radio buttons, quality slider (hidden for PNG), max-dimension inputs, per-file thumbnail / size comparison / savings % / download link; worker terminated and object URLs revoked on unmount
- Route auto-registered as `/tools/ImageConverter` by the existing glob router

## Test Plan

- [ ] Navigate to `/tools/ImageConverter`
- [ ] Drop a PNG → default WebP, size visibly drops, savings % shown
- [ ] Switch to JPEG, adjust quality slider, click "Re-convert all" → sizes update
- [ ] Set max width/height → output dimensions are capped
- [ ] Select PNG → quality slider hidden, lossless round-trip
- [ ] AVIF: available in Chrome 94+ / Firefox 113+; gracefully shows error on unsupported browsers
- [ ] Remove a file → object URLs revoked, entry disappears
- [ ] Navigate away → worker terminated, no memory leak