### PR TITLE
fix: games cannot start in solo mode; Pictionary requires 2+ players

### DIFF
--- a/src/components/GameLobbyWizard.test.ts
+++ b/src/components/GameLobbyWizard.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { ref } from 'vue'
+import GameLobbyWizard from './GameLobbyWizard.vue'
+import type { LobbyPlayer } from '@/types/lobbyWizard'
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {} })
+}))
+
+vi.mock('@/composables/useGameLobby', () => ({
+  useGameLobby: () => ({
+    isSearching: ref(false),
+    pendingRequests: ref([]),
+    startSearching: vi.fn(),
+    stopSearching: vi.fn(),
+    acceptRequest: vi.fn(() => null),
+    ignoreRequest: vi.fn(),
+    displayName: vi.fn((id: string) => id)
+  })
+}))
+
+const STUBS = {
+  GameCard: { template: '<div class="game-card"><slot /></div>' },
+  Check: { template: '<span class="check-icon" />' }
+}
+
+const SOLO_PLAYER: LobbyPlayer = { id: 'peer-1', name: 'Solo', color: '#ff0000' }
+
+const buildWrapper = (overrides: Record<string, unknown> = {}): VueWrapper => {
+  return mount(GameLobbyWizard, {
+    props: {
+      playerName: 'Solo',
+      playerColor: '#ff0000',
+      isHost: true,
+      playerList: [SOLO_PLAYER],
+      roomId: 'room-abc',
+      matchmakerRoom: 'test-matchmaker',
+      configFields: [],
+      accentColor: '#4caf50',
+      ...overrides
+    },
+    global: { stubs: STUBS }
+  })
+}
+
+describe('GameLobbyWizard — host single player', () => {
+  it('starts on step 1 (profile) and shows no Start button yet', () => {
+    const wrapper = buildWrapper()
+    expect(wrapper.find('.glw__start-btn').exists()).toBe(false)
+    expect(wrapper.find('.glw__step-title').text()).toBe('Your profile')
+  })
+
+  it('shows Next button on step 1 when there are 2 steps', () => {
+    const wrapper = buildWrapper()
+    const nextButton = wrapper.findAll('button').find((b) => b.text().includes('Next'))
+    expect(nextButton).toBeDefined()
+  })
+
+  it('advances to step 2 (settings) when Next is clicked', async () => {
+    const wrapper = buildWrapper()
+    const nextButton = wrapper.findAll('button').find((b) => b.text().includes('Next'))
+    await nextButton!.trigger('click')
+    expect(wrapper.find('.glw__step-title').text()).toBe('Game settings')
+  })
+
+  it('shows enabled Start button on step 2 by default', async () => {
+    const wrapper = buildWrapper()
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Next'))!
+      .trigger('click')
+    const startButton = wrapper.find('.glw__start-btn')
+    expect(startButton.exists()).toBe(true)
+    expect((startButton.element as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('emits startGame when Start is clicked', async () => {
+    const wrapper = buildWrapper()
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Next'))!
+      .trigger('click')
+    const startButton = wrapper.find('.glw__start-btn')
+    expect((startButton.element as HTMLButtonElement).disabled).toBe(false)
+    await startButton.trigger('click')
+    expect(wrapper.emitted('startGame')).toHaveLength(1)
+  })
+})
+
+describe('GameLobbyWizard — canStart prop', () => {
+  it('disables Start button when canStart is false', async () => {
+    const wrapper = buildWrapper({ canStart: false })
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Next'))!
+      .trigger('click')
+    const startButton = wrapper.find('.glw__start-btn')
+    expect(startButton.attributes('disabled')).toBeDefined()
+  })
+
+  it('enables Start button when canStart is true', async () => {
+    const wrapper = buildWrapper({ canStart: true })
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Next'))!
+      .trigger('click')
+    const startButton = wrapper.find('.glw__start-btn')
+    expect((startButton.element as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('enables Start button when canStart is undefined (not passed)', async () => {
+    const wrapper = buildWrapper()
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Next'))!
+      .trigger('click')
+    const startButton = wrapper.find('.glw__start-btn')
+    expect((startButton.element as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('does not emit startGame when Start is disabled', async () => {
+    const wrapper = buildWrapper({ canStart: false })
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Next'))!
+      .trigger('click')
+    await wrapper.find('.glw__start-btn').trigger('click')
+    expect(wrapper.emitted('startGame')).toBeFalsy()
+  })
+})
+
+describe('GameLobbyWizard — guest player (isHost=false)', () => {
+  it('has only 1 step for a guest', () => {
+    const wrapper = buildWrapper({ isHost: false })
+    expect(wrapper.findAll('.glw__step-dot')).toHaveLength(1)
+  })
+
+  it('shows no Next button for a guest on the only step', () => {
+    const wrapper = buildWrapper({ isHost: false })
+    const nextButton = wrapper.findAll('button').find((b) => b.text().includes('Next'))
+    expect(nextButton).toBeUndefined()
+  })
+
+  it('shows no Start button for a guest', () => {
+    const wrapper = buildWrapper({ isHost: false })
+    expect(wrapper.find('.glw__start-btn').exists()).toBe(false)
+  })
+})
+
+describe('GameLobbyWizard — step navigation', () => {
+  it('Back button appears on step 2', async () => {
+    const wrapper = buildWrapper()
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Next'))!
+      .trigger('click')
+    const backButton = wrapper.findAll('button').find((b) => b.text().includes('Back'))
+    expect(backButton).toBeDefined()
+  })
+
+  it('Back returns to step 1', async () => {
+    const wrapper = buildWrapper()
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Next'))!
+      .trigger('click')
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Back'))!
+      .trigger('click')
+    expect(wrapper.find('.glw__step-title').text()).toBe('Your profile')
+  })
+
+  it('step dots reflect current step', async () => {
+    const wrapper = buildWrapper()
+    const dotsStep1 = wrapper.findAll('.glw__step-dot--active')
+    expect(dotsStep1).toHaveLength(1)
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Next'))!
+      .trigger('click')
+    const dotsStep2 = wrapper.findAll('.glw__step-dot--active')
+    expect(dotsStep2).toHaveLength(1)
+  })
+})
+
+describe('GameLobbyWizard — profile step', () => {
+  it('renders the player name input', () => {
+    const wrapper = buildWrapper()
+    const input = wrapper.find('input[type="text"]')
+    expect(input.exists()).toBe(true)
+    expect((input.element as HTMLInputElement).value).toBe('Solo')
+  })
+
+  it('emits update:playerName when input changes', async () => {
+    const wrapper = buildWrapper()
+    const input = wrapper.find('input[type="text"]')
+    await input.setValue('NewName')
+    expect(wrapper.emitted('update:playerName')).toBeTruthy()
+  })
+
+  it('renders color swatch buttons', () => {
+    const wrapper = buildWrapper()
+    const swatches = wrapper.findAll('.glw__swatch-btn')
+    expect(swatches.length).toBeGreaterThan(0)
+  })
+
+  it('emits update:playerColor when a swatch is clicked', async () => {
+    const wrapper = buildWrapper()
+    const swatches = wrapper.findAll('.glw__swatch-btn')
+    await swatches[0].trigger('click')
+    expect(wrapper.emitted('update:playerColor')).toBeTruthy()
+  })
+})
+
+describe('GameLobbyWizard — player count display', () => {
+  it('shows player count on step 2', async () => {
+    const wrapper = buildWrapper({
+      playerList: [SOLO_PLAYER, { id: 'peer-2', name: 'Other', color: '#0000ff' }]
+    })
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Next'))!
+      .trigger('click')
+    expect(wrapper.find('.glw__player-count').text()).toContain('2')
+  })
+})
+
+describe('GameLobbyWizard — results / play-again mode', () => {
+  it('shows Play Again button when showResults is true', () => {
+    const wrapper = buildWrapper({ showResults: true })
+    const playAgainButton = wrapper.find('.glw__start-btn')
+    expect(playAgainButton.exists()).toBe(true)
+    expect(playAgainButton.text()).toBe('Play Again')
+  })
+
+  it('emits playAgain when Play Again is clicked', async () => {
+    const wrapper = buildWrapper({ showResults: true })
+    await wrapper.find('.glw__start-btn').trigger('click')
+    expect(wrapper.emitted('playAgain')).toHaveLength(1)
+  })
+
+  it('shows summary slot content in results mode', () => {
+    const wrapper = mount(GameLobbyWizard, {
+      props: {
+        playerName: 'Solo',
+        playerColor: '#ff0000',
+        isHost: true,
+        playerList: [SOLO_PLAYER],
+        roomId: 'room-abc',
+        matchmakerRoom: 'test-matchmaker',
+        configFields: [],
+        accentColor: '#4caf50',
+        showResults: true
+      },
+      slots: { summary: '<div class="test-summary">Results</div>' },
+      global: { stubs: STUBS }
+    })
+    expect(wrapper.find('.test-summary').exists()).toBe(true)
+  })
+})

--- a/src/components/GameLobbyWizard.vue
+++ b/src/components/GameLobbyWizard.vue
@@ -11,18 +11,21 @@ import { useGameLobby } from '@/composables/useGameLobby'
 import { PLAYER_COLORS } from '@/utils/playerProfile'
 import type { LobbyConfigField, LobbyPlayer } from '@/types/lobbyWizard'
 
-const props = defineProps<{
-  playerName: string
-  playerColor: string
-  isHost: boolean
-  playerList: LobbyPlayer[]
-  roomId: string
-  matchmakerRoom: string
-  configFields: LobbyConfigField[]
-  accentColor: string
-  showResults?: boolean
-  canStart?: boolean
-}>()
+const props = withDefaults(
+  defineProps<{
+    playerName: string
+    playerColor: string
+    isHost: boolean
+    playerList: LobbyPlayer[]
+    roomId: string
+    matchmakerRoom: string
+    configFields: LobbyConfigField[]
+    accentColor: string
+    showResults?: boolean
+    canStart?: boolean
+  }>(),
+  { canStart: true }
+)
 
 const emit = defineEmits<{
   'update:playerName': [value: string]

--- a/src/views/Games/Minigolf/useMinigolfSession.ts
+++ b/src/views/Games/Minigolf/useMinigolfSession.ts
@@ -179,7 +179,16 @@ const bindDataEvents = (ctx: MgContext, joined: P2PSession): void => {
 }
 
 const initSessionForContext = (ctx: MgContext, roomId: string): void => {
-  if (!p2pIsSupported()) return
+  if (!p2pIsSupported()) {
+    ctx.localPeerId.value = crypto.randomUUID()
+    ctx.store.upsertPlayer({
+      id: ctx.localPeerId.value,
+      name: ctx.options.name,
+      color: ctx.options.color,
+      scores: []
+    })
+    return
+  }
   const joined = p2pJoin(roomId)
   ctx.session.value = joined
   ctx.localPeerId.value = joined.peerId
@@ -229,25 +238,26 @@ export const useMinigolfSession = (options: UseMinigolfSessionOptions) => {
    * @param selectedHoles - Indices of the selected holes to play.
    */
   const broadcastConfig = (holeCount: number, selectedHoles: number[]): void => {
-    if (!session.value) return
     store.holeCount = holeCount
     store.selectedHoles = selectedHoles
-    const payload: ConfigPayload = { holeCount, selectedHoles }
-    p2pSendData(session.value, CONFIG_CHANNEL, payload)
+    if (session.value) {
+      const payload: ConfigPayload = { holeCount, selectedHoles }
+      p2pSendData(session.value, CONFIG_CHANNEL, payload)
+    }
   }
 
   /**
    * Broadcast the game start signal to all peers (host only).
    */
   const broadcastStart = (): void => {
-    if (!session.value || !isHost.value) return
+    if (!isHost.value) return
     const payload: StartPayload = {
       holeCount: store.holeCount,
       selectedHoles: store.selectedHoles
     }
     store.currentHole = 0
     store.phase = 'playing'
-    p2pSendData(session.value, START_CHANNEL, payload)
+    if (session.value) p2pSendData(session.value, START_CHANNEL, payload)
   }
 
   /**
@@ -256,10 +266,11 @@ export const useMinigolfSession = (options: UseMinigolfSessionOptions) => {
    * @param strokes - Number of strokes taken.
    */
   const broadcastScore = (holeIndex: number, strokes: number): void => {
-    if (!session.value) return
     store.recordScore(localPeerId.value, holeIndex, strokes)
-    const payload: ScorePayload = { id: localPeerId.value, holeIndex, strokes }
-    p2pSendData(session.value, SCORE_CHANNEL, payload)
+    if (session.value) {
+      const payload: ScorePayload = { id: localPeerId.value, holeIndex, strokes }
+      p2pSendData(session.value, SCORE_CHANNEL, payload)
+    }
   }
 
   /**
@@ -267,8 +278,7 @@ export const useMinigolfSession = (options: UseMinigolfSessionOptions) => {
    * @param holeIndex - Next hole index, or -1 for summary.
    */
   const broadcastAdvanceHole = (holeIndex: number): void => {
-    if (!session.value) return
-    p2pSendData(session.value, ADVANCE_CHANNEL, { holeIndex })
+    if (session.value) p2pSendData(session.value, ADVANCE_CHANNEL, { holeIndex })
   }
 
   /**
@@ -278,9 +288,10 @@ export const useMinigolfSession = (options: UseMinigolfSessionOptions) => {
    * @param z - Ball Z position.
    */
   const broadcastBallPosition = (x: number, y: number, z: number): void => {
-    if (!session.value) return
-    const payload: BallPosPayload = { id: localPeerId.value, x, y, z }
-    p2pSendData(session.value, BALL_POS_CHANNEL, payload)
+    if (session.value) {
+      const payload: BallPosPayload = { id: localPeerId.value, x, y, z }
+      p2pSendData(session.value, BALL_POS_CHANNEL, payload)
+    }
   }
 
   /**

--- a/src/views/Games/Pictionary/PictionaryLobby.vue
+++ b/src/views/Games/Pictionary/PictionaryLobby.vue
@@ -4,7 +4,12 @@ import GameLobbyWizard from '@/components/GameLobbyWizard.vue'
 import type { LobbyConfigField } from '@/types/lobbyWizard'
 import type { DictionaryDifficulty } from '@webgamekit/dictionary'
 import type { PictionaryPlayer } from '@/stores/pictionary'
-import { ROUND_DURATION_OPTIONS, WORD_COUNT_OPTIONS, HINT_COUNT_OPTIONS } from './constants'
+import {
+  ROUND_DURATION_OPTIONS,
+  WORD_COUNT_OPTIONS,
+  HINT_COUNT_OPTIONS,
+  MIN_PLAYERS
+} from './constants'
 
 const MATCHMAKER_ROOM = 'pictionary-matchmaker'
 
@@ -96,6 +101,7 @@ const handleConfig = (key: string, value: string | number): void => {
     :room-id="roomId"
     :matchmaker-room="MATCHMAKER_ROOM"
     accent-color="var(--pic-orange)"
+    :can-start="playerList.length >= MIN_PLAYERS"
     :config-fields="configFields"
     @update:player-name="emit('update:playerName', $event)"
     @update:player-color="emit('update:playerColor', $event)"

--- a/src/views/Games/Pictionary/constants.ts
+++ b/src/views/Games/Pictionary/constants.ts
@@ -12,6 +12,8 @@ export const ROUND_DURATION_OPTIONS = [30, 60, 90, 120, 150]
 export const WORD_COUNT_OPTIONS = [1, 2, 3]
 export const HINT_COUNT_OPTIONS = [0, 1, 2, 3, 4, 5]
 
+export const MIN_PLAYERS = 2
+
 export const POINTS_BASE = 100
 export const POINTS_FIRST_BONUS = 50
 export const POINTS_DRAWER_PER_GUESS = 25

--- a/src/views/Games/Pictionary/usePictionarySession.ts
+++ b/src/views/Games/Pictionary/usePictionarySession.ts
@@ -148,10 +148,9 @@ const scheduleHints = (ctx: PictionaryContext): void => {
 }
 
 const startRoundForContext = (ctx: PictionaryContext): void => {
-  if (!ctx.session.value) return
+  if (!ctx.isHost.value) return
   const ids = Object.keys(ctx.store.players).sort()
-  if (ids.length < 2) return
-  broadcastConfig(ctx, ctx.session.value)
+  if (ctx.session.value) broadcastConfig(ctx, ctx.session.value)
   const nextNumber = ctx.store.round.number + 1
   const drawerId = ids[(nextNumber - 1) % ids.length]
   const buildChoice = (): string =>
@@ -169,11 +168,10 @@ const startRoundForContext = (ctx: PictionaryContext): void => {
     endsAt: Date.now() + CHOICE_DURATION_MS
   }
   ctx.applyChoices(payload)
-  p2pSendData(ctx.session.value, ROUND_CHOICES_CHANNEL, payload)
+  if (ctx.session.value) p2pSendData(ctx.session.value, ROUND_CHOICES_CHANNEL, payload)
 }
 
 const pickWordForContext = (ctx: PictionaryContext, word: string): void => {
-  if (!ctx.session.value) return
   if (!ctx.store.round.choices.includes(word)) return
   const payload: PictionaryRoundPayload = {
     number: ctx.store.round.number,
@@ -182,12 +180,11 @@ const pickWordForContext = (ctx: PictionaryContext, word: string): void => {
     endsAt: Date.now() + ctx.store.roundDuration * 1000
   }
   ctx.applyRound(payload)
-  p2pSendData(ctx.session.value, ROUND_CHANNEL, payload)
+  if (ctx.session.value) p2pSendData(ctx.session.value, ROUND_CHANNEL, payload)
 }
 
 const restartGameForContext = (ctx: PictionaryContext): void => {
-  if (!ctx.session.value) return
-  p2pSendData(ctx.session.value, RESTART_CHANNEL, { ts: Date.now() })
+  if (ctx.session.value) p2pSendData(ctx.session.value, RESTART_CHANNEL, { ts: Date.now() })
   ctx.applyRestart()
 }
 
@@ -359,13 +356,15 @@ const bindDrawingEvents = (ctx: PictionaryContext, joined: P2PSession): void => 
 }
 
 const endRoundForContext = (ctx: PictionaryContext, startRound: () => void): void => {
-  if (!ctx.session.value || !ctx.isHost.value) return
+  if (!ctx.isHost.value) return
   clearHintTimers(ctx)
   const intermissionEndsAt = Date.now() + INTERMISSION_MS
-  p2pSendData(ctx.session.value, ROUND_END_CHANNEL, {
-    number: ctx.store.round.number,
-    intermissionEndsAt
-  })
+  if (ctx.session.value) {
+    p2pSendData(ctx.session.value, ROUND_END_CHANNEL, {
+      number: ctx.store.round.number,
+      intermissionEndsAt
+    })
+  }
   ctx.applyRoundEnd(intermissionEndsAt)
   if (ctx.store.phase === 'intermission') {
     setTimeout(() => {
@@ -375,7 +374,16 @@ const endRoundForContext = (ctx: PictionaryContext, startRound: () => void): voi
 }
 
 const initSessionForContext = (ctx: PictionaryContext, roomId: string): void => {
-  if (!p2pIsSupported()) return
+  if (!p2pIsSupported()) {
+    ctx.localPeerId.value = crypto.randomUUID()
+    ctx.store.upsertPlayer({
+      id: ctx.localPeerId.value,
+      name: ctx.options.name,
+      color: ctx.options.color,
+      score: 0
+    })
+    return
+  }
   const joined = p2pJoin(roomId)
   ctx.session.value = joined
   ctx.localPeerId.value = joined.peerId

--- a/src/views/Games/SquaresMultiplayer/useSquaresMultiplayerSession.ts
+++ b/src/views/Games/SquaresMultiplayer/useSquaresMultiplayerSession.ts
@@ -110,12 +110,14 @@ const announceSelf = (ctx: WmContext, joined: P2PSession): void => {
 }
 
 const endRoundForContext = (ctx: WmContext, startRound: () => void): void => {
-  if (!ctx.session.value || !ctx.isHost.value) return
+  if (!ctx.isHost.value) return
   const intermissionEndsAt = Date.now() + INTERMISSION_MS
-  p2pSendData(ctx.session.value, ROUND_END_CHANNEL, {
-    number: ctx.store.round.number,
-    intermissionEndsAt
-  })
+  if (ctx.session.value) {
+    p2pSendData(ctx.session.value, ROUND_END_CHANNEL, {
+      number: ctx.store.round.number,
+      intermissionEndsAt
+    })
+  }
   applyRoundEnd(ctx, intermissionEndsAt)
   if (ctx.store.phase === 'intermission') {
     setTimeout(() => {
@@ -233,7 +235,16 @@ const bindGameEvents = (ctx: WmContext, joined: P2PSession): void => {
 }
 
 const initSessionForContext = (ctx: WmContext, roomId: string): void => {
-  if (!p2pIsSupported()) return
+  if (!p2pIsSupported()) {
+    ctx.localPeerId.value = crypto.randomUUID()
+    ctx.store.upsertPlayer({
+      id: ctx.localPeerId.value,
+      name: ctx.options.name,
+      color: ctx.options.color,
+      score: 0
+    })
+    return
+  }
   const joined = p2pJoin(roomId)
   ctx.session.value = joined
   ctx.localPeerId.value = joined.peerId
@@ -272,8 +283,8 @@ export const useSquaresMultiplayerSession = (options: UseSquaresMultiplayerSessi
   const isHost = computed(() => store.hostId === localPeerId.value && localPeerId.value !== '')
 
   const startRound = (): void => {
-    if (!isHost.value || !session.value) return
-    broadcastConfig(ctx, session.value)
+    if (!isHost.value) return
+    if (session.value) broadcastConfig(ctx, session.value)
 
     const eligible = buildEligibleWords(store.difficulty)
     const candidates = shuffleArray(eligible)
@@ -300,7 +311,7 @@ export const useSquaresMultiplayerSession = (options: UseSquaresMultiplayerSessi
     store.round = { number: nextNumber, grid, validWords, endsAt }
     store.phase = 'playing'
     store.resetRound()
-    p2pSendData(session.value, ROUND_CHANNEL, payload)
+    if (session.value) p2pSendData(session.value, ROUND_CHANNEL, payload)
   }
 
   const endRound = (): void => endRoundForContext(ctx, startRound)
@@ -316,7 +327,6 @@ export const useSquaresMultiplayerSession = (options: UseSquaresMultiplayerSessi
   }
 
   const submitWord = (word: string): void => {
-    if (!session.value) return
     const upperWord = word.toUpperCase()
     const isValid = store.round.validWords.some((w) => w.toUpperCase() === upperWord)
     if (!isValid) return
@@ -327,7 +337,7 @@ export const useSquaresMultiplayerSession = (options: UseSquaresMultiplayerSessi
     const claim: WmClaimedWord = { word: upperWord, playerId: localPeerId.value, points }
     store.addClaim(claim)
     store.addScore(localPeerId.value, points)
-    p2pSendData(session.value, WORD_CLAIM_CHANNEL, claim)
+    if (session.value) p2pSendData(session.value, WORD_CLAIM_CHANNEL, claim)
 
     const allClaimed = store.claimedWords.length >= store.round.validWords.length
     if (allClaimed && isHost.value) endRound()
@@ -350,8 +360,8 @@ export const useSquaresMultiplayerSession = (options: UseSquaresMultiplayerSessi
   }
 
   const restartGame = (): void => {
-    if (!isHost.value || !session.value) return
-    p2pSendData(session.value, RESTART_CHANNEL, { ts: Date.now() })
+    if (!isHost.value) return
+    if (session.value) p2pSendData(session.value, RESTART_CHANNEL, { ts: Date.now() })
     const preserved = Object.fromEntries(
       Object.entries(store.players).map(([id, p]) => [id, { ...p, score: 0 }])
     )


### PR DESCRIPTION
Closes #151

## Summary

- Games (Minigolf, Pictionary, SquaresMultiplayer) failed to show the Start button for a single player because `p2pIsSupported()` returns `false` without HTTPS/WebCrypto, leaving `localPeerId` unset and `isHost` permanently `false`
- Pictionary now enforces a minimum of 2 players via `MIN_PLAYERS` constant and `canStart` prop

## Key Changes

- **Session composables** (Minigolf, Pictionary, SquaresMultiplayer): add `p2pIsSupported()` fallback — generate local peer ID with `crypto.randomUUID()` and upsert player into store, skipping P2P entirely for solo play
- **Broadcast functions**: separate local state mutations from `p2pSendData` calls; broadcasts are guarded by `if (session.value)`, state changes always run
- **`GameLobbyWizard`**: use `withDefaults({ canStart: true })` to prevent Vue's boolean prop casting from treating absent `canStart` as `false` and disabling the Start button
- **`PictionaryLobby`**: pass `:can-start="playerList.length >= MIN_PLAYERS"` — requires 2 players
- **`GameLobbyWizard.test.ts`**: 23 new unit tests covering step navigation, `canStart` prop states, host vs guest view, profile inputs, player count display, and results/play-again mode

## Test Plan

- [ ] Open Minigolf solo — Start button visible and functional
- [ ] Open SquaresMultiplayer solo — Start button visible and functional
- [ ] Open Pictionary solo — Start button disabled; invite second player → button enables
- [ ] All 23 `GameLobbyWizard` unit tests pass (`pnpm test:unit`)
- [ ] Multiplayer still works: two tabs, matchmake, game starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)