### PR TITLE
fix: MinigolfGame width varies on click

### DIFF
--- a/src/views/Games/Minigolf/MinigolfGame.vue
+++ b/src/views/Games/Minigolf/MinigolfGame.vue
@@ -48,6 +48,7 @@ defineExpose({ canvas })
   border-radius: 1.25rem;
   border: 3px solid var(--game-border);
   box-shadow: 4px 4px 0 var(--game-border);
+  width: 100%;
 }
 
 .mg-game__bar {


### PR DESCRIPTION
## Summary

- Set `width: 100%` on `.mg-game` in `MinigolfGame.vue` to prevent the game container from resizing when HUD content changes (message, hint, power bar) on each click

🤖 Generated with [Claude Code](https://claude.com/claude-code)