### PR TITLE
fix: use BASE_URL for GLB/FBX asset paths

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -3,8 +3,6 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -60,7 +58,6 @@ jobs:
           path: dist
 
   deploy:
-    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -3,6 +3,8 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -58,6 +60,7 @@ jobs:
           path: dist
 
   deploy:
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/packages/threejs/src/models.ts
+++ b/packages/threejs/src/models.ts
@@ -422,7 +422,7 @@ export const loadAnimation = (
   index: number = 0
 ): Promise<THREE.AnimationMixer> => {
   return new Promise((resolve) => {
-    fbxLoader.load(`/${fileName}`, (animation) => {
+    fbxLoader.load(`${import.meta.env.BASE_URL}${fileName}`, (animation) => {
       const mixer = new THREE.AnimationMixer(model)
       const action = mixer.clipAction(
         (model?.animations?.length ? model : animation).animations[index]
@@ -450,7 +450,7 @@ export const loadFBX = (fileName: string, options: ModelOptions = {}): Promise<M
 
   return new Promise((resolve, reject) => {
     fbxLoader.load(
-      `/${fileName}`,
+      `${import.meta.env.BASE_URL}${fileName}`,
       (model) => {
         model.position.set(...position)
         model.scale.set(...scale)
@@ -493,7 +493,7 @@ export const loadGLTF = (
 
   return new Promise((resolve, reject) => {
     gltfLoader.load(
-      `/${fileName}`,
+      `${import.meta.env.BASE_URL}${fileName}`,
       (gltf) => {
         const model = gltf.scene
         model.castShadow = castShadow

--- a/packages/threejs/tsconfig.json
+++ b/packages/threejs/tsconfig.json
@@ -4,6 +4,7 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": ["ESNext", "DOM"],
+    "types": ["vite/client"],
     "moduleResolution": "bundler",
     "strict": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
Closes #156

## Summary

- Replace hardcoded `/${fileName}` with `${import.meta.env.BASE_URL}${fileName}` in all three model loaders (`loadGLTF`, `loadFBX`, `loadAnimation`)
- Vite sets `BASE_URL` to `/generative-art/` for the GitHub Pages build and `/` in dev, so paths resolve correctly in both environments

## Test Plan

- [ ] LandingPage and VisualizerMain load `cnotv.glb` without 404 on GitHub Pages
- [ ] Models still load correctly in local dev (`/cnotv.glb` → `http://localhost:5173/cnotv.glb`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)