### PR TITLE
fix: prettier format game-ui.scss

### DIFF
--- a/src/assets/styles/game-ui.scss
+++ b/src/assets/styles/game-ui.scss
@@ -8,24 +8,10 @@
   // one or two em-based drop shadows that scale proportionally.
   // Keep em values small: at large font sizes even 0.1em is several pixels.
   --shadow-text-game:
-    -1px -1px 0 #fff,
-    1px -1px 0 #fff,
-    -1px 1px 0 #fff,
-    1px 1px 0 #fff,
-    -1px 0 0 #fff,
-    1px 0 0 #fff,
-    0 -1px 0 #fff,
-    0 1px 0 #fff,
-    0.06em 0.08em 0 #000;
+    -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff, -1px 0 0 #fff, 1px 0 0 #fff,
+    0 -1px 0 #fff, 0 1px 0 #fff, 0.06em 0.08em 0 #000;
   --shadow-text-game-large:
-    -1px -1px 0 #fff,
-    1px -1px 0 #fff,
-    -1px 1px 0 #fff,
-    1px 1px 0 #fff,
-    -1px 0 0 #fff,
-    1px 0 0 #fff,
-    0 -1px 0 #fff,
-    0 1px 0 #fff,
-    0.06em 0.1em 0.12em rgb(0 0 0 / 0.6),
+    -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff, -1px 0 0 #fff, 1px 0 0 #fff,
+    0 -1px 0 #fff, 0 1px 0 #fff, 0.06em 0.1em 0.12em rgb(0 0 0 / 0.6),
     0.1em 0.18em 0.28em rgb(0 0 0 / 0.35);
 }


### PR DESCRIPTION
Closes #166

## Summary

- Run `prettier --write` on `src/assets/styles/game-ui.scss`
- Collapses multi-line shadow value lists to the format Prettier expects

## Key Changes

- `src/assets/styles/game-ui.scss`: reformatted `--shadow-text-game` and `--shadow-text-game-large` from one-value-per-line to Prettier's preferred compact style — no functional change

## Test Plan

- [ ] `pnpm run format:check` passes
- [ ] CI `format:check` job green on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)