### PR TITLE
feat: marble madness polish — fog, ball shading, faux-pad, ghost sync

### DIFF
--- a/documentation/docs/journey/marble-madness.md
+++ b/documentation/docs/journey/marble-madness.md
@@ -81,6 +81,54 @@ flowchart LR
 
 The shadow token value matches the GoombaRunner pattern: eight 1 px text-shadows form a full white outline, followed by a stack of progressively offset black drops that create the layered 3-D effect. Two sizes are defined — standard and large — for body text and titles respectively.
 
+## Scene polish: fog, ball shading, and mobile controls
+
+### Exponential fog with matched background
+
+Adding `THREE.FogExp2` to the scene gives the ground sphere a natural fade at a distance, preventing the hard visual cut where the sphere edge meets the sky. The fog colour (`FOG_COLOR`) is assigned to both `scene.fog` and `scene.background` so the Three.js clear colour matches the fog — without this, the background renders as a distinct band behind the faded geometry.
+
+Exponential fog (`FogExp2`) was preferred over linear fog because the density increase is perceptually smoother: distant objects fade quickly while nearby geometry stays crisp.
+
+```mermaid
+flowchart LR
+    A[scene.fog = FogExp2] --> B[fragments blended toward fog colour by distance]
+    A --> C[scene.background = same colour]
+    B --> D[ground sphere fades naturally]
+    C --> D
+```
+
+### Ball shading via MeshPhysicalMaterial properties
+
+The player marble uses `MeshPhysicalMaterial` (the default for `getBall`). Passing `roughness` and `metalness` through `ModelOptions` into the material constructor gives specular highlights without any external texture file. Low roughness concentrates the specular lobe; moderate metalness tints the reflection toward the diffuse colour.
+
+The same marble texture is reused as the `displacementMap`. This pushes vertices outward along their normals proportional to the texture's brightness, adding subtle surface relief to the sphere. The sphere segment count was raised to 48 to give the displacement enough geometry to work with.
+
+```mermaid
+flowchart TD
+    A[ModelOptions: roughness, metalness, displacementScale] --> B[buildPhysicalMaterial]
+    B --> C[MeshPhysicalMaterial with props]
+    D[applyTextureToMesh] --> E[mat.map = tex]
+    D --> F[mat.displacementMap = tex\nwhen displacementScale > 0]
+```
+
+### Mobile faux-pad via existing TouchControl
+
+The `@webgamekit/controls` package already ships `createFauxPadController`, and the app already has a `TouchControl.vue` component wrapping it. Wiring the faux-pad to the marble game required exposing the controls' `currentActions` object from `useMarbleMadnessGame` — it is created inside `buildGame` (async), so a `ref` initialised to `{}` is assigned the live object after `createControls` resolves.
+
+`TouchControl` receives this ref's value as a prop and mutates it directly when directions change. Because the game loop reads `state.controls.currentActions` every frame, the same object reference means touch input is picked up with no extra glue.
+
+```mermaid
+sequenceDiagram
+    participant T as TouchControl
+    participant R as currentActionsReference (ref)
+    participant L as game loop
+
+    T->>R: currentActions['forward'] = …
+    L->>R: read currentActions each frame
+    L->>L: computeImpulse → apply force
+    T->>R: delete currentActions['forward']
+```
+
 ## Winner name overflow: viewport-relative sizing
 
 The multiplayer summary screen shows the winning player's name above a "Wins!" heading. Long player names broke the layout in two ways: the text wrapped to a second line, or it overflowed the container on narrow viewports.

--- a/packages/threejs/src/models.ts
+++ b/packages/threejs/src/models.ts
@@ -64,6 +64,7 @@ const buildPhysicalMaterial = (
   if (options.ior !== undefined) props.ior = options.ior
   if (options.thickness !== undefined) props.thickness = options.thickness
   if (options.envMapIntensity !== undefined) props.envMapIntensity = options.envMapIntensity
+  if (options.displacementScale !== undefined) props.displacementScale = options.displacementScale
   return new THREE.MeshPhysicalMaterial(props)
 }
 
@@ -266,12 +267,19 @@ const applyModelMaterial = (
 const getCubeSizeArray = (size: number | CoordinateTuple): CoordinateTuple =>
   typeof size === 'number' ? [size, size, size] : size
 
-const applyTextureToMesh = (mesh: THREE.Mesh, texture: string | undefined): void => {
+const applyTextureToMesh = (
+  mesh: THREE.Mesh,
+  texture: string | undefined,
+  options: ModelOptions = {}
+): void => {
   if (!texture) return
-  if (Array.isArray(mesh.material)) {
-    ;(mesh.material[0] as THREE.MeshStandardMaterial).map = textureLoader.load(texture)
-  } else {
-    ;(mesh.material as THREE.MeshStandardMaterial).map = textureLoader.load(texture)
+  const tex = textureLoader.load(texture)
+  const mat = Array.isArray(mesh.material)
+    ? (mesh.material[0] as THREE.MeshPhysicalMaterial)
+    : (mesh.material as THREE.MeshPhysicalMaterial)
+  mat.map = tex
+  if (options.displacementScale !== undefined && options.displacementScale > 0) {
+    mat.displacementMap = tex
   }
 }
 
@@ -598,7 +606,7 @@ export const getBall = (
   if (setUV2) geometry.setAttribute('uv2', geometry.attributes['uv'])
   const mesh = applyModelMaterial(new THREE.Mesh(geometry), options)
 
-  applyTextureToMesh(mesh, texture)
+  applyTextureToMesh(mesh, texture, options)
 
   if (name) mesh.name = name
   mesh.position.set(...position)

--- a/packages/threejs/src/types.ts
+++ b/packages/threejs/src/types.ts
@@ -30,6 +30,7 @@ export interface ModelOptions extends CommonOptions {
   reflectivity?: number
   roughness?: number
   metalness?: number
+  displacementScale?: number
   transmission?: number
   transparent?: boolean
   material?: THREE.Material | typeof THREE.Material | string | boolean

--- a/src/components/ui/coordinate-input/CoordinateInput.vue
+++ b/src/components/ui/coordinate-input/CoordinateInput.vue
@@ -192,7 +192,7 @@ const handleInputZ = (event: Event) => {
   color: inherit;
   font: inherit;
   text-align: center;
-  width: 4em;
+  width: 5.5em;
   padding: 2px 4px;
   outline: none;
   border-radius: 2px;

--- a/src/style.css
+++ b/src/style.css
@@ -27,3 +27,9 @@ a:hover {
 body {
   margin: 0;
 }
+
+html,
+body {
+  overflow: hidden;
+  max-height: 100vh;
+}

--- a/src/utils/textureAreaProperties.ts
+++ b/src/utils/textureAreaProperties.ts
@@ -1,4 +1,5 @@
 import type { Ref } from 'vue'
+import { toRaw } from 'vue'
 import * as THREE from 'three'
 import { useElementPropertiesStore } from '@/stores/elementProperties'
 import { useDebugSceneStore } from '@/stores/debugScene'
@@ -87,24 +88,21 @@ export const registerTextureAreaProperties = ({
   const debugSceneStore = useDebugSceneStore()
   debugSceneStore.addSceneElement({ name: areaName, type: 'TextureArea', hidden: false })
 
-  // Initialize config for this area if not already present
   if (!areaConfigs.value[areaName]) {
-    areaConfigs.value = {
-      ...areaConfigs.value,
-      [areaName]: buildTextureAreaConfig(layers)
-    }
+    toRaw(areaConfigs.value)[areaName] = buildTextureAreaConfig(layers)
   }
 
   elementPropertiesStore.registerElementProperties(areaName, {
     title: areaName.charAt(0).toUpperCase() + areaName.slice(1),
     type: 'TextureArea',
     schema,
-    getValue: (path: string) => getNestedValue(areaConfigs.value[areaName], path),
+    getValue: (path: string) => {
+      const raw = toRaw(areaConfigs.value)
+      return getNestedValue(raw[areaName], path)
+    },
     updateValue: (path: string, value: unknown) => {
-      areaConfigs.value = {
-        ...areaConfigs.value,
-        [areaName]: setNestedValueImmutable(areaConfigs.value[areaName], path, value)
-      }
+      const raw = toRaw(areaConfigs.value)
+      raw[areaName] = setNestedValueImmutable(raw[areaName], path, value)
       onUpdate?.(areaName, path, value)
     }
   })

--- a/src/views/Games/MarbleMadness/MarbleMadness.vue
+++ b/src/views/Games/MarbleMadness/MarbleMadness.vue
@@ -71,6 +71,9 @@ const session = useMarbleMadnessSession(
     if (!player) return
     const marbleOption = MARBLE_OPTIONS.find((m) => m.id === player.marble)
     game.updateGhostPosition(peerId, new THREE.Color(player.color).getHex(), pos, marbleOption?.url)
+  },
+  (receivedTrackIndex) => {
+    trackIndex.value = receivedTrackIndex
   }
 )
 const { isHost, localPeerId } = session
@@ -197,7 +200,7 @@ const handleStartGame = (): void => {
     store.raceStartTime = Date.now()
     store.phase = 'playing'
   } else {
-    session.startGame()
+    session.startGame(trackIndex.value)
   }
 }
 
@@ -277,6 +280,7 @@ onUnmounted(() => {
         :finished="game.finished.value"
         :penalty-count="game.penaltyCount.value"
         :track-name="track.name"
+        :current-actions="game.currentActions.value"
         @escape="store.phase = 'lobby'"
       />
       <MarbleMadnessSummary

--- a/src/views/Games/MarbleMadness/MarbleMadnessGame.vue
+++ b/src/views/Games/MarbleMadness/MarbleMadnessGame.vue
@@ -1,12 +1,17 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { isMobile } from '@webgamekit/controls'
+import TouchControl from '@/components/TouchControl.vue'
 import { TIME_PENALTY_FALL } from './config'
+
+const isMobileDevice = isMobile()
 
 const props = defineProps<{
   elapsed: number
   finished: boolean
   penaltyCount: number
   trackName: string
+  currentActions?: Record<string, unknown>
 }>()
 
 const emit = defineEmits<{ escape: [] }>()
@@ -101,6 +106,15 @@ onUnmounted(() => {
     </Transition>
 
     <canvas ref="canvas" class="mm-game__canvas" />
+
+    <TouchControl
+      v-if="isMobileDevice && currentActions"
+      class="mm-game__fauxpad"
+      :mapping="{ up: 'forward', down: 'backward', left: 'left', right: 'right' }"
+      :options="{ deadzone: 0.15 }"
+      :current-actions="currentActions"
+      :on-action="() => {}"
+    />
   </div>
 </template>
 
@@ -119,6 +133,12 @@ onUnmounted(() => {
   flex: 1;
   width: 100%;
   display: block;
+}
+
+.mm-game__fauxpad {
+  position: absolute;
+  left: var(--spacing-6);
+  bottom: var(--spacing-6);
 }
 
 .mm-game__time {

--- a/src/views/Games/MarbleMadness/config.ts
+++ b/src/views/Games/MarbleMadness/config.ts
@@ -116,8 +116,8 @@ const LONG_ROAD_TRACK: TrackConfig = {
 const SLOPES_TRACK: TrackConfig = {
   name: 'Slopes',
   spawnPosition: [0, 1.5, 4],
-  finishPosition: [0, -4, -170],
-  finishCheckZ: -157,
+  finishPosition: [0, -4, -163],
+  finishCheckZ: -155,
   finishCheckRadius: 8,
   platforms: [
     { size: [18, 1, 14], position: [0, 0, 0], color: PLATFORM_COLOR },
@@ -135,7 +135,7 @@ const SLOPES_TRACK: TrackConfig = {
     // Diagonal: combines forward slope and side tilt
     { size: [7, 1, 20], position: [0, -2, -137], color: BRIDGE_COLOR, rotation: [-0.2, 0, 0.2] },
     { size: [8, 1, 8], position: [0, -4.5, -153], color: BRIDGE_COLOR },
-    { size: [16, 1, 16], position: [0, -4.5, -170], color: FINISH_COLOR, isFinish: true }
+    { size: [16, 1, 16], position: [0, -4.5, -163], color: FINISH_COLOR, isFinish: true }
   ],
   obstacles: [
     { size: [2.5, 2, 2.5], position: [-2, -5.5, -48] },

--- a/src/views/Games/MarbleMadness/types.ts
+++ b/src/views/Games/MarbleMadness/types.ts
@@ -5,8 +5,16 @@ import type { useMarbleMadnessStore } from '@/stores/marbleMadness'
 
 export type HelloPayload = { name: string; color: string; marble: string }
 export type AvatarPayload = { name: string; color: string; marble: string }
-export type StartPayload = { timestamp: number }
-export type BallPosPayload = { x: number; y: number; z: number }
+export type StartPayload = { timestamp: number; trackIndex: number }
+export type BallPosPayload = {
+  x: number
+  y: number
+  z: number
+  rx: number
+  ry: number
+  rz: number
+  rw: number
+}
 export type FinishPayload = { playerId: string; time: number }
 
 export type UseMarbleMadnessSessionOptions = {
@@ -23,6 +31,7 @@ export type MmContext = {
   localPeerId: Ref<string>
   isHost: ComputedRef<boolean>
   onBallPos: (peerId: string, pos: BallPosPayload) => void
+  onStart: (trackIndex: number) => void
 }
 
 export type GameDeps = {

--- a/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
+++ b/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
@@ -1,5 +1,5 @@
 import cloudUrl from '@/assets/images/goomba/cloud.png'
-import { ref, watch, onUnmounted } from 'vue'
+import { ref, reactive, watch, onUnmounted } from 'vue'
 import type { Ref } from 'vue'
 import * as THREE from 'three'
 import type { OrbitControls } from 'three/addons/controls/OrbitControls.js'
@@ -23,7 +23,6 @@ import type { ControlsExtras, ControlsCurrents } from '@webgamekit/controls'
 import { createTimelineManager, type CoordinateTuple } from '@webgamekit/animation'
 import { registerCameraProperties } from '@/utils/cameraProperties'
 import { registerTextureAreaProperties } from '@/utils/textureAreaProperties'
-import { registerObjectProperties } from '@/utils/objectProperties'
 import { useDebugSceneStore } from '@/stores/debugScene'
 import { useElementPropertiesStore } from '@/stores/elementProperties'
 import {
@@ -92,8 +91,11 @@ const CLOUD_AREA_CENTER: CoordinateTuple = [0, CLOUD_Y, CLOUD_AREA_CENTER_Z]
 const CLOUD_AREA_SIZE: CoordinateTuple = [CLOUD_AREA_WIDTH, 0, CLOUD_AREA_DEPTH]
 const CLOUD_BASE_SIZE: CoordinateTuple = [CLOUD_BASE_WIDTH, CLOUD_BASE_HEIGHT, CLOUD_BASE_DEPTH]
 
-const GROUND_SPHERE_RADIUS = 600
-const GROUND_SPHERE_Y = -700
+const FOG_COLOR = 0xb0d8f0
+const FOG_DENSITY = 0.0015
+
+const GROUND_SPHERE_RADIUS = 1500
+const GROUND_SPHERE_Y = -1700
 const GROUND_SPHERE_Z = -120
 const GROUND_SPHERE_CENTER: CoordinateTuple = [0, GROUND_SPHERE_Y, GROUND_SPHERE_Z]
 const GROUND_SPHERE_COLOR = 0x4a7a3a
@@ -152,7 +154,7 @@ const buildCloudObjects = (
       material: 'MeshBasicMaterial',
       transparent: true,
       opacity,
-      alphaTest: 0.1,
+      alphaTest: 0.4,
       type: 'fixed',
       castShadow: false,
       receiveShadow: false
@@ -242,6 +244,32 @@ const makeGhostMarble = (scene: THREE.Scene, colorHex: number, texture?: string)
     segments: 16
   })
 
+type GhostRegistry = { meshes: Map<string, THREE.Mesh>; scene: THREE.Scene | null }
+
+const placeGhost = (
+  registry: GhostRegistry,
+  peerId: string,
+  colorHex: number,
+  pos: BallPosPayload,
+  texture?: string
+): void => {
+  if (!registry.scene) return
+  const ghost = registry.meshes.get(peerId) ?? makeGhostMarble(registry.scene, colorHex, texture)
+  registry.meshes.set(peerId, ghost)
+  ghost.position.set(pos.x, pos.y + PLATFORM_HALF_HEIGHT, pos.z)
+  ghost.quaternion.set(pos.rx, pos.ry, pos.rz, pos.rw)
+}
+
+const disposeGhost = (registry: GhostRegistry, peerId: string): void => {
+  const ghost = registry.meshes.get(peerId)
+  if (ghost && registry.scene) {
+    registry.scene.remove(ghost)
+    ghost.geometry.dispose()
+    if (ghost.material instanceof THREE.Material) ghost.material.dispose()
+  }
+  registry.meshes.delete(peerId)
+}
+
 const buildTimeline = (
   camera: THREE.Camera,
   getDelta: () => number,
@@ -315,7 +343,16 @@ const buildTimeline = (
       state.posAccumulator += getDelta() * 1000
       if (state.posAccumulator >= POS_BROADCAST_MS) {
         const pos = state.marbleMesh.userData.body.translation()
-        deps.onPositionUpdate({ x: pos.x, y: pos.y, z: pos.z })
+        const rot = state.marbleMesh.userData.body.rotation()
+        deps.onPositionUpdate({
+          x: pos.x,
+          y: pos.y,
+          z: pos.z,
+          rx: rot.x,
+          ry: rot.y,
+          rz: rot.z,
+          rw: rot.w
+        })
         state.posAccumulator = 0
       }
     }
@@ -428,6 +465,52 @@ const buildSceneSetupConfig = (track: TrackConfig) => ({
   }
 })
 
+const registerGroundSphereProperties = (groundMesh: THREE.Mesh): void => {
+  const state = reactive({
+    position: { x: groundMesh.position.x, y: groundMesh.position.y, z: groundMesh.position.z },
+    radius: groundMesh.scale.x * GROUND_SPHERE_RADIUS,
+    color: (groundMesh.material as THREE.MeshStandardMaterial).color.getHex()
+  })
+
+  useDebugSceneStore().addSceneElement({ name: 'Ground', type: 'Mesh', hidden: false })
+  useElementPropertiesStore().registerElementProperties('Ground', {
+    title: 'Ground',
+    type: 'Mesh',
+    schema: {
+      position: {
+        label: 'Position',
+        component: 'CoordinateInput',
+        min: { x: -2000, y: -2000, z: -2000 },
+        max: { x: 2000, y: 2000, z: 2000 },
+        step: { x: 10, y: 10, z: 10 }
+      },
+      radius: { label: 'Radius', min: 100, max: 2000, step: 10 },
+      color: { label: 'Color', color: true }
+    },
+    getValue: (path: string) => {
+      if (path === 'position')
+        return { x: state.position.x, y: state.position.y, z: state.position.z }
+      if (path === 'radius') return state.radius
+      if (path === 'color') return state.color
+      return undefined
+    },
+    updateValue: (path: string, value: unknown) => {
+      if (path === 'position') {
+        const v = value as { x: number; y: number; z: number }
+        state.position = { x: v.x, y: v.y, z: v.z }
+        groundMesh.position.set(v.x, v.y, v.z)
+      } else if (path === 'radius') {
+        state.radius = value as number
+        const scale = (value as number) / GROUND_SPHERE_RADIUS
+        groundMesh.scale.set(scale, scale, scale)
+      } else if (path === 'color') {
+        state.color = value as number
+        ;(groundMesh.material as THREE.MeshStandardMaterial).color.setHex(value as number)
+      }
+    }
+  })
+}
+
 /**
  * Set up and manage the MarbleMadness Three.js scene, physics, and game loop.
  * @param deps - Canvas ref, solo flag, track config, win/position callbacks.
@@ -445,16 +528,20 @@ export const useMarbleMadnessGame = (deps: GameDeps) => {
     directionalLight: null
   }
   let cleanupTools: (() => void) | null = null
-  const ghostMeshes = new Map<string, THREE.Mesh>()
+  const ghostRegistry: GhostRegistry = { meshes: new Map(), scene: null }
   let sceneReference: THREE.Scene | null = null
   let worldReference: NonNullable<GetToolsResult['world']> | null = null
   let cloudObjects: ComplexModel[] = []
+  const currentActionsReference = ref<Record<string, unknown>>({})
   const areaConfigs = ref<Record<string, Record<string, unknown>>>({})
 
   const buildGame = async ({ scene, world, camera, getDelta, animate, orbit }: SceneContext) => {
     if (!world) return
     sceneReference = scene
+    ghostRegistry.scene = scene
     worldReference = world
+    scene.fog = new THREE.FogExp2(FOG_COLOR, FOG_DENSITY)
+    scene.background = new THREE.Color(FOG_COLOR)
     state.directionalLight =
       (scene.children.find((c) => c instanceof THREE.DirectionalLight) as THREE.DirectionalLight) ??
       null
@@ -473,8 +560,7 @@ export const useMarbleMadnessGame = (deps: GameDeps) => {
       castShadow: false,
       receiveShadow: false
     })
-    useDebugSceneStore().addSceneElement({ name: 'Ground', type: 'Mesh', hidden: false })
-    registerObjectProperties({ object: state.groundSphereMesh, name: 'Ground', title: 'Ground' })
+    registerGroundSphereProperties(state.groundSphereMesh)
     state.marbleMesh = getBall(scene, world, {
       size: MARBLE_RADIUS,
       position: track.spawnPosition,
@@ -482,22 +568,19 @@ export const useMarbleMadnessGame = (deps: GameDeps) => {
       friction: MARBLE_FRICTION,
       weight: MARBLE_WEIGHT,
       texture: deps.marble.value,
-      segments: 32,
+      roughness: 0.08,
+      metalness: 0.2,
+      displacementScale: 0.08,
+      segments: 48,
       type: 'dynamic'
     }) as unknown as ComplexModel
     applyDamping(state.marbleMesh)
     animate({ timeline: buildTimeline(camera, getDelta, state, deps, orbit) })
   }
 
-  const init = async (): Promise<void> => {
-    if (!deps.canvas.value) return
-    state.finished.value = false
-    state.elapsed.value = 0
-    state.penaltyCount.value = 0
-    state.posAccumulator = 0
-    state.controls = createControls({ mapping: KEYBOARD_MAPPING })
+  const initScene = async (canvas: HTMLCanvasElement): Promise<void> => {
     const track = deps.track.value
-    const tools = await getTools({ canvas: deps.canvas.value })
+    const tools = await getTools({ canvas })
     cleanupTools = tools.cleanup
     await tools.setup({
       config: buildSceneSetupConfig(track),
@@ -515,12 +598,27 @@ export const useMarbleMadnessGame = (deps: GameDeps) => {
     })
   }
 
+  const init = async (): Promise<void> => {
+    if (!deps.canvas.value) return
+    state.finished.value = false
+    state.elapsed.value = 0
+    state.penaltyCount.value = 0
+    state.posAccumulator = 0
+    state.controls = createControls({ mapping: KEYBOARD_MAPPING })
+    currentActionsReference.value = state.controls.currentActions as unknown as Record<
+      string,
+      unknown
+    >
+    await initScene(deps.canvas.value)
+  }
+
   const destroy = (): void => {
     state.controls?.destroyControls()
     state.marbleMesh = null
     state.controls = null
     state.directionalLight = null
-    ghostMeshes.clear()
+    ghostRegistry.meshes.clear()
+    ghostRegistry.scene = null
     sceneReference = null
     worldReference = null
     cloudObjects = []
@@ -540,22 +638,9 @@ export const useMarbleMadnessGame = (deps: GameDeps) => {
     colorHex: number,
     pos: BallPosPayload,
     texture?: string
-  ): void => {
-    if (!sceneReference) return
-    const ghost = ghostMeshes.get(peerId) ?? makeGhostMarble(sceneReference, colorHex, texture)
-    ghostMeshes.set(peerId, ghost)
-    ghost.position.set(pos.x, pos.y, pos.z)
-  }
+  ): void => placeGhost(ghostRegistry, peerId, colorHex, pos, texture)
 
-  const removeGhost = (peerId: string): void => {
-    const ghost = ghostMeshes.get(peerId)
-    if (ghost && sceneReference) {
-      sceneReference.remove(ghost)
-      ghost.geometry.dispose()
-      if (ghost.material instanceof THREE.Material) ghost.material.dispose()
-    }
-    ghostMeshes.delete(peerId)
-  }
+  const removeGhost = (peerId: string): void => disposeGhost(ghostRegistry, peerId)
 
   watch(
     () => deps.canvas.value,
@@ -569,6 +654,7 @@ export const useMarbleMadnessGame = (deps: GameDeps) => {
     elapsed: state.elapsed,
     finished: state.finished,
     penaltyCount: state.penaltyCount,
+    currentActions: currentActionsReference,
     init,
     destroy,
     updateGhostPosition,

--- a/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
+++ b/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
@@ -155,6 +155,7 @@ const buildCloudObjects = (
       transparent: true,
       opacity,
       alphaTest: 0.4,
+      depthWrite: false,
       type: 'fixed',
       castShadow: false,
       receiveShadow: false

--- a/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
+++ b/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
@@ -165,6 +165,7 @@ const buildCloudObjects = (
     cloudMesh.geometry.dispose()
     cloudMesh.geometry = new THREE.PlaneGeometry(instanceSize[0], instanceSize[2])
     if (cloudMesh.material instanceof THREE.Material) cloudMesh.material.side = THREE.DoubleSide
+    cloudMesh.rotation.set(0, instanceRotation[1], instanceRotation[2])
     return cloud
   })
 }

--- a/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
+++ b/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
@@ -146,7 +146,7 @@ const buildCloudObjects = (
       rotation[1] + applyVariation(0, rotationVariation[1]),
       rotation[2] + applyVariation(0, rotationVariation[2])
     ]
-    return getCube(scene, world, {
+    const cloud = getCube(scene, world, {
       size: instanceSize,
       position,
       rotation: instanceRotation,
@@ -154,12 +154,18 @@ const buildCloudObjects = (
       material: 'MeshBasicMaterial',
       transparent: true,
       opacity,
-      alphaTest: 0.4,
+      alphaTest: 0.5,
       depthWrite: false,
+      renderOrder: 1,
       type: 'fixed',
       castShadow: false,
       receiveShadow: false
     })
+    const cloudMesh = cloud as unknown as THREE.Mesh
+    cloudMesh.geometry.dispose()
+    cloudMesh.geometry = new THREE.PlaneGeometry(instanceSize[0], instanceSize[2])
+    if (cloudMesh.material instanceof THREE.Material) cloudMesh.material.side = THREE.DoubleSide
+    return cloud
   })
 }
 

--- a/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
+++ b/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
@@ -146,7 +146,7 @@ const buildCloudObjects = (
       rotation[1] + applyVariation(0, rotationVariation[1]),
       rotation[2] + applyVariation(0, rotationVariation[2])
     ]
-    const cloud = getCube(scene, world, {
+    return getCube(scene, world, {
       size: instanceSize,
       position,
       rotation: instanceRotation,
@@ -154,18 +154,12 @@ const buildCloudObjects = (
       material: 'MeshBasicMaterial',
       transparent: true,
       opacity,
-      alphaTest: 0.5,
+      alphaTest: 0.4,
       depthWrite: false,
-      renderOrder: 1,
       type: 'fixed',
       castShadow: false,
       receiveShadow: false
     })
-    const cloudMesh = cloud as unknown as THREE.Mesh
-    cloudMesh.geometry.dispose()
-    cloudMesh.geometry = new THREE.PlaneGeometry(instanceSize[0], instanceSize[2])
-    if (cloudMesh.material instanceof THREE.Material) cloudMesh.material.side = THREE.DoubleSide
-    return cloud
   })
 }
 

--- a/src/views/Games/MarbleMadness/useMarbleMadnessSession.ts
+++ b/src/views/Games/MarbleMadness/useMarbleMadnessSession.ts
@@ -145,6 +145,7 @@ const bindGameEvents = (ctx: MmContext, joined: P2PSession): void => {
   p2pOnData<ChatMessage>(joined, CHAT_CHANNEL, (message) => ctx.store.appendMessage(message))
 
   p2pOnData<StartPayload>(joined, START_CHANNEL, (payload) => {
+    ctx.onStart(payload.trackIndex)
     ctx.store.raceStartTime = payload.timestamp
     ctx.store.phase = 'playing'
   })
@@ -193,18 +194,19 @@ const initSessionForContext = (ctx: MmContext, roomId: string): void => {
  */
 export const useMarbleMadnessSession = (
   options: UseMarbleMadnessSessionOptions,
-  onBallPos: (peerId: string, pos: BallPosPayload) => void = () => {}
+  onBallPos: (peerId: string, pos: BallPosPayload) => void = () => {},
+  onStart: (trackIndex: number) => void = () => {}
 ) => {
   const store = useMarbleMadnessStore()
   const session = ref<P2PSession | null>(null)
   const localPeerId = ref<string>('')
   const isHost = computed(() => store.hostId === localPeerId.value && localPeerId.value !== '')
 
-  const ctx: MmContext = { options, store, session, localPeerId, isHost, onBallPos }
+  const ctx: MmContext = { options, store, session, localPeerId, isHost, onBallPos, onStart }
 
-  const startGame = (): void => {
+  const startGame = (trackIndex: number): void => {
     if (!session.value || !isHost.value) return
-    const payload: StartPayload = { timestamp: Date.now() }
+    const payload: StartPayload = { timestamp: Date.now(), trackIndex }
     p2pSendData(session.value, START_CHANNEL, payload)
     store.raceStartTime = payload.timestamp
     store.phase = 'playing'


### PR DESCRIPTION
Closes #162

## Summary

Post-merge polish and multiplayer correctness fixes for the Marble Madness game.

## Key Changes

- **Track sync**: host's selected track index is now included in `StartPayload` so all players load the same map on race start
- **Ghost rotation**: `BallPosPayload` extended with quaternion (`rx/ry/rz/rw`); opponent ghost marbles now rotate as they roll
- **Ghost ground alignment**: apply `PLATFORM_HALF_HEIGHT` offset to ghost Y so opponents sit on surfaces correctly
- **Fog**: `THREE.FogExp2` added with matched `scene.background` colour for a natural horizon fade
- **Ball shading**: `MeshPhysicalMaterial` `roughness`/`metalness` + `displacementMap` reusing the marble texture for surface relief; `segments` raised to 48
- **`displacementScale` option**: added to `ModelOptions` and `buildPhysicalMaterial` in `@webgamekit/threejs`
- **Faux-pad**: `TouchControl` wired for mobile via `currentActionsReference` ref exposed from `useMarbleMadnessGame`
- **Cloud edge fix**: `alphaTest` raised from 0.1 to 0.4 to remove stroke artefact on cloud PNG edges
- **Ground sphere**: radius 1500, Y −1700; element panel registration via reactive mirror state
- **CoordinateInput**: number input widened to 5.5 em to fit negative values like −1700
- **`GhostRegistry` refactor**: `placeGhost`/`disposeGhost` extracted as module-level helpers to stay within the 150-line function limit
- **Journey doc**: new section covering fog, ball shading, and faux-pad implementation

## Test Plan

- [ ] Solo play: marble has shading and surface texture relief, fog visible at distance
- [ ] Mobile: faux-pad appears and controls the marble
- [ ] Multiplayer: both players load the same track after host starts
- [ ] Multiplayer: opponent ghost marbles rotate and sit on surfaces correctly
- [ ] CI passes (lint, type-check, unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)