### PR TITLE
feat(#162): Marble Madness visual polish — stroke outlines, cloud fix, text shadow

### DIFF
--- a/documentation/docs/journey/toon-stroke-outline.md
+++ b/documentation/docs/journey/toon-stroke-outline.md
@@ -1,0 +1,84 @@
+---
+sidebar_position: 100
+tags: [three-js, shaders, games, visual-style]
+---
+
+# Toon Stroke Outlines in Three.js
+
+Adding black outlines to 3D objects to create a toon/sketch aesthetic. Two techniques are needed because they solve different problems.
+
+## Why two techniques
+
+No single approach works for every mesh:
+
+- **Inverted hull** — perfect for convex shapes (spheres, capsules). Adds a stroke by rendering a slightly scaled-up copy of the mesh with back faces only and a flat dark material. Zero GPU cost, no shader needed.
+- **EdgesGeometry + LineSegments2** — correct for flat-faced objects (boxes, platforms, obstacles). Traces silhouette and crease edges at a configurable angle threshold.
+
+`LineBasicMaterial` ignores `linewidth` in WebGL (browser limitation). Use `LineMaterial` + `LineSegments2` from `three/examples/jsm/lines/` for any line thicker than 1px.
+
+```mermaid
+flowchart TD
+    A[Object added to scene] --> B{Convex / sphere?}
+    B -->|Yes| C[Inverted Hull\nscale 1.05, BackSide]
+    B -->|No| D[EdgesGeometry\nLineSegments2 + LineMaterial]
+```
+
+## Inverted hull
+
+```typescript
+const STROKE_MATERIAL = new THREE.MeshBasicMaterial({ color: 0x333333, side: THREE.BackSide })
+
+const attachBallStroke = (mesh: THREE.Mesh): void => {
+  const hull = new THREE.Mesh(mesh.geometry, STROKE_MATERIAL)
+  hull.scale.setScalar(1.05)
+  hull.userData.skipEdgeLines = true // prevent double-processing
+  mesh.add(hull)
+}
+```
+
+The hull shares the same geometry but renders only back faces. When the camera sees the inside of the hull through the outer mesh, the hull peeks out as a uniform outline ring. Scale 1.05 gives a stroke about 5% of the object radius — adjust to taste.
+
+## EdgesGeometry + LineSegments2
+
+```typescript
+const attachEdgeLines = async (mesh: THREE.Mesh): Promise<void> => {
+  const [{ LineMaterial }, { LineSegments2 }, { LineSegmentsGeometry }] = await Promise.all([
+    import('three/examples/jsm/lines/LineMaterial.js'),
+    import('three/examples/jsm/lines/LineSegments2.js'),
+    import('three/examples/jsm/lines/LineSegmentsGeometry.js')
+  ])
+  const edges = new THREE.EdgesGeometry(mesh.geometry, 15) // 15° crease threshold
+  const geometry = new LineSegmentsGeometry().fromEdgesGeometry(edges)
+  const material = new LineMaterial({
+    color: 0x333333,
+    linewidth: 2,
+    resolution: new THREE.Vector2(window.innerWidth, window.innerHeight)
+  })
+  mesh.add(new LineSegments2(geometry, material))
+}
+```
+
+`LineMaterial` requires a `resolution` uniform matching the canvas size. The crease threshold (15°) controls how many interior edges are drawn — lower values show more edges.
+
+## Scene traversal
+
+Apply edge lines after all objects are built, then skip objects that already have strokes or should be excluded:
+
+```typescript
+const isSolidMesh = (object: THREE.Object3D): object is THREE.Mesh => {
+  if (!(object instanceof THREE.Mesh)) return false
+  if (object.userData.skipEdgeLines) return false
+  const mat = Array.isArray(object.material) ? object.material[0] : object.material
+  return !(mat instanceof THREE.Material && mat.transparent)
+}
+
+scene.traverse((object) => {
+  if (isSolidMesh(object)) attachEdgeLines(object)
+})
+```
+
+Mark objects to skip with `mesh.userData.skipEdgeLines = true` — useful for the hull child meshes themselves, underground/background objects too large to draw edges on, and transparent meshes (clouds, glass).
+
+## What didn't work
+
+**OutlinePass** (post-processing): renders the outline in screen space after the scene is drawn. Looks correct for isolated objects but haloes bleed across object boundaries and the result is soft, not sketch-like. No easy way to vary thickness per object. Dropped in favour of the mesh-level approach above.

--- a/packages/threejs/src/core.ts
+++ b/packages/threejs/src/core.ts
@@ -156,7 +156,7 @@ const createResizeHandler =
     } else {
       ;(camera as THREE.PerspectiveCamera).aspect = window.innerWidth / window.innerHeight
     }
-    camera.updateProjectionMatrix()
+    ;(camera as THREE.PerspectiveCamera | THREE.OrthographicCamera).updateProjectionMatrix()
   }
 
 export const getTools = async ({

--- a/packages/threejs/src/core.ts
+++ b/packages/threejs/src/core.ts
@@ -144,6 +144,21 @@ const emitProgress = (
   callback?.({ stage, detail, done })
 }
 
+const createResizeHandler =
+  (renderer: THREE.WebGLRenderer, camera: THREE.Camera): (() => void) =>
+  () => {
+    renderer.setSize(window.innerWidth, window.innerHeight)
+    if (camera instanceof THREE.OrthographicCamera) {
+      const halfH = camera.top
+      const newHalfW = halfH * (window.innerWidth / window.innerHeight)
+      camera.left = -newHalfW
+      camera.right = newHalfW
+    } else {
+      ;(camera as THREE.PerspectiveCamera).aspect = window.innerWidth / window.innerHeight
+    }
+    camera.updateProjectionMatrix()
+  }
+
 export const getTools = async ({
   stats,
   route,
@@ -159,6 +174,7 @@ export const getTools = async ({
   const { renderer, scene, camera, world } = await getEnvironment(canvas)
   activeRendererReference.current = renderer
   let composer: EffectComposer | null = null
+  let populateOutline: ((sceneReference: THREE.Scene) => void) | null = null
   if (video && route) video.record(canvas, route)
   const getDelta = () => delta
   let orbit: OrbitControls | null = null
@@ -183,14 +199,20 @@ export const getTools = async ({
     frameRate = resolved?.global?.frameRate || frameRate
     if (resolved.orbit !== false) orbit = createOrbitControls(camera, renderer, resolved.orbit)
     const ground = applySceneConfig(scene, camera, world, resolved)
-    if (config.postprocessing)
-      composer = await setupPostprocessing({
+    if (config.postprocessing) {
+      const pp = await setupPostprocessing({
         renderer,
         scene,
         camera,
         config: config.postprocessing
       })
+      if (pp) {
+        composer = pp.composer
+        populateOutline = pp.populateOutline
+      }
+    }
     if (defineSetup) await defineSetup({ ground, orbit })
+    if (populateOutline) populateOutline(scene)
     emitProgress(onProgress, 'Ready', undefined, true)
     const elements = scene.children.slice(childrenCountBefore)
     return { orbit, ground, elements }
@@ -257,18 +279,7 @@ export const getTools = async ({
     runAnimation()
   }
 
-  const handleResize = () => {
-    renderer.setSize(window.innerWidth, window.innerHeight)
-    if (camera instanceof THREE.OrthographicCamera) {
-      const halfH = camera.top
-      const newHalfW = halfH * (window.innerWidth / window.innerHeight)
-      camera.left = -newHalfW
-      camera.right = newHalfW
-    } else {
-      ;(camera as THREE.PerspectiveCamera).aspect = window.innerWidth / window.innerHeight
-    }
-    camera.updateProjectionMatrix()
-  }
+  const handleResize = createResizeHandler(renderer, camera)
 
   if (resize !== false) {
     window.addEventListener('resize', handleResize)

--- a/packages/threejs/src/postprocessing.ts
+++ b/packages/threejs/src/postprocessing.ts
@@ -136,13 +136,40 @@ const applyColorCorrection = async (composer: EffectComposer, config: PostProces
   })
 }
 
+const applyOutline = async (
+  composer: EffectComposer,
+  scene: THREE.Scene,
+  camera: THREE.Camera,
+  config: PostProcessingConfig
+): Promise<((sceneReference: THREE.Scene) => void) | null> => {
+  if (!config?.outline) return null
+  const { OutlinePass } = await import('three/examples/jsm/postprocessing/OutlinePass.js')
+  const { color = 0x333333, strength = 3, thickness = 1 } = config.outline
+  const pass = new OutlinePass(
+    new THREE.Vector2(window.innerWidth, window.innerHeight),
+    scene,
+    camera
+  )
+  pass.visibleEdgeColor.set(color)
+  pass.hiddenEdgeColor.set(color)
+  pass.edgeStrength = strength
+  pass.edgeThickness = thickness
+  pass.edgeGlow = 0
+  composer.addPass(pass)
+  return (sceneReference: THREE.Scene) => {
+    sceneReference.traverse((object) => {
+      if (object instanceof THREE.Mesh) pass.selectedObjects.push(object)
+    })
+  }
+}
+
 /**
  * Abstracted postprocessing setup function
  * @param renderer
  * @param scene
  * @param camera
  * @param config
- * @returns EffectComposer|null
+ * @returns composer and optional populateOutline callback to call after scene is built
  */
 const setupPostprocessing = async ({
   renderer,
@@ -154,7 +181,10 @@ const setupPostprocessing = async ({
   scene: THREE.Scene
   camera: THREE.Camera
   config: PostProcessingConfig
-}) => {
+}): Promise<{
+  composer: EffectComposer
+  populateOutline: ((sceneReference: THREE.Scene) => void) | null
+} | null> => {
   const hasEffects =
     config && Object.keys(config).some((key) => !!(config as Record<string, unknown>)[key])
   if (!hasEffects) return null
@@ -176,8 +206,9 @@ const setupPostprocessing = async ({
   await applySimplePasses(composer, scene, camera, config)
   await applyVignette(composer, config)
   await applyColorCorrection(composer, config)
+  const populateOutline = await applyOutline(composer, scene, camera, config)
 
-  return composer
+  return { composer, populateOutline }
 }
 
 export { setupPostprocessing, addShaderPass, EffectComposer, RenderPass, ShaderPass }

--- a/packages/threejs/src/types.ts
+++ b/packages/threejs/src/types.ts
@@ -161,6 +161,11 @@ export interface PostProcessingConfig {
     saturation?: number
     brightness?: number
   }
+  outline?: {
+    color?: number
+    strength?: number
+    thickness?: number
+  }
 }
 
 export interface CameraConfig {

--- a/src/assets/styles/game-ui.scss
+++ b/src/assets/styles/game-ui.scss
@@ -8,8 +8,9 @@
   // one or two em-based drop shadows that scale proportionally.
   // Keep em values small: at large font sizes even 0.1em is several pixels.
   --shadow-text-game:
-    -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff, -1px 0 0 #fff, 1px 0 0 #fff,
-    0 -1px 0 #fff, 0 1px 0 #fff, 0.06em 0.08em 0 #000;
+    -1.5px -1.5px 0 #333, 1.5px -1.5px 0 #333, -1.5px 1.5px 0 #333, 1.5px 1.5px 0 #333,
+    -1px 0 0 #fff, 1px 0 0 #fff, 0 -1px 0 #fff, 0 1px 0 #fff,
+    clamp(2px, 0.16em, 3px) clamp(2px, 0.2em, 4px) 0 #000;
   --shadow-text-game-large:
     -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff, -1px 0 0 #fff, 1px 0 0 #fff,
     0 -1px 0 #fff, 0 1px 0 #fff, 0.06em 0.1em 0.12em rgb(0 0 0 / 0.6),

--- a/src/assets/styles/game-ui.scss
+++ b/src/assets/styles/game-ui.scss
@@ -13,6 +13,5 @@
     clamp(2px, 0.16em, 3px) clamp(2px, 0.2em, 4px) 0 #000;
   --shadow-text-game-large:
     -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff, -1px 0 0 #fff, 1px 0 0 #fff,
-    0 -1px 0 #fff, 0 1px 0 #fff, 0.06em 0.1em 0.12em rgb(0 0 0 / 0.6),
-    0.1em 0.18em 0.28em rgb(0 0 0 / 0.35);
+    0 -1px 0 #fff, 0 1px 0 #fff, clamp(2px, 0.16em, 4px) clamp(2px, 0.2em, 6px) 0 #333;
 }

--- a/src/views/Games/MarbleMadness/MarbleMadnessGame.vue
+++ b/src/views/Games/MarbleMadness/MarbleMadnessGame.vue
@@ -182,7 +182,7 @@ onUnmounted(() => {
   font-weight: 900;
   font-family: var(--font-playful);
   color: #fff;
-  text-shadow: var(--shadow-text-game-large);
+  text-shadow: var(--shadow-text-game);
   text-transform: uppercase;
   white-space: nowrap;
   pointer-events: none;

--- a/src/views/Games/MarbleMadness/MarbleMadnessLobby.vue
+++ b/src/views/Games/MarbleMadness/MarbleMadnessLobby.vue
@@ -142,6 +142,7 @@ const isAvailable = (marbleId: string): boolean =>
 
 .mml__marble-btn--active {
   transform: scale(1.3);
+  border: 2px solid #333;
 }
 
 .mml__marble-btn--taken {

--- a/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
+++ b/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
@@ -578,7 +578,6 @@ export const useMarbleMadnessGame = (deps: GameDeps) => {
       texture: deps.marble.value,
       roughness: 0.08,
       metalness: 0.2,
-      displacementScale: 0.08,
       segments: 48,
       type: 'dynamic'
     }) as unknown as ComplexModel

--- a/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
+++ b/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
@@ -78,6 +78,50 @@ type MarbleState = {
 
 const CAMERA_OFFSET: CoordinateTuple = [0, CAMERA_HEIGHT, CAMERA_BACK]
 const PLATFORM_HALF_HEIGHT = 0.5
+const STROKE_COLOR = 0x333333
+const STROKE_SCALE = 1.05
+const STROKE_MATERIAL = new THREE.MeshBasicMaterial({ color: STROKE_COLOR, side: THREE.BackSide })
+const EDGE_THRESHOLD_ANGLE = 15
+const EDGE_LINE_WIDTH = 2
+
+const attachBallStroke = (mesh: THREE.Mesh): void => {
+  const hull = new THREE.Mesh(mesh.geometry, STROKE_MATERIAL)
+  hull.scale.setScalar(STROKE_SCALE)
+  hull.userData.skipEdgeLines = true
+  mesh.add(hull)
+}
+
+const isSolidMesh = (object: THREE.Object3D): object is THREE.Mesh => {
+  if (!(object instanceof THREE.Mesh)) return false
+  if (object.userData.skipEdgeLines) return false
+  const mat = Array.isArray(object.material) ? object.material[0] : object.material
+  return !(mat instanceof THREE.Material && mat.transparent)
+}
+
+const attachEdgeLines = async (mesh: THREE.Mesh): Promise<void> => {
+  const [{ LineMaterial }, { LineSegments2 }, { LineSegmentsGeometry }] = await Promise.all([
+    import('three/examples/jsm/lines/LineMaterial.js'),
+    import('three/examples/jsm/lines/LineSegments2.js'),
+    import('three/examples/jsm/lines/LineSegmentsGeometry.js')
+  ])
+  const edges = new THREE.EdgesGeometry(mesh.geometry, EDGE_THRESHOLD_ANGLE)
+  const geometry = new LineSegmentsGeometry().fromEdgesGeometry(edges)
+  const material = new LineMaterial({
+    color: STROKE_COLOR,
+    linewidth: EDGE_LINE_WIDTH,
+    resolution: new THREE.Vector2(window.innerWidth, window.innerHeight)
+  })
+  const lines = new LineSegments2(geometry, material)
+  lines.userData.skipEdgeLines = true
+  mesh.add(lines)
+}
+
+const addEdgeLinesToScene = (scene: THREE.Scene): void => {
+  scene.traverse((object) => {
+    if (isSolidMesh(object)) attachEdgeLines(object)
+  })
+}
+
 const CLOUD_Y = -100
 const CLOUD_AREA_CENTER_Z = 50
 const CLOUD_ROTATION: CoordinateTuple = [Math.PI / 2, 0, 0]
@@ -568,6 +612,7 @@ export const useMarbleMadnessGame = (deps: GameDeps) => {
       castShadow: false,
       receiveShadow: false
     })
+    state.groundSphereMesh.userData.skipEdgeLines = true
     registerGroundSphereProperties(state.groundSphereMesh)
     state.marbleMesh = getBall(scene, world, {
       size: MARBLE_RADIUS,
@@ -581,7 +626,9 @@ export const useMarbleMadnessGame = (deps: GameDeps) => {
       segments: 48,
       type: 'dynamic'
     }) as unknown as ComplexModel
+    attachBallStroke(state.marbleMesh as unknown as THREE.Mesh)
     applyDamping(state.marbleMesh)
+    addEdgeLinesToScene(scene)
     animate({ timeline: buildTimeline(camera, getDelta, state, deps, orbit) })
   }
 


### PR DESCRIPTION
Closes #162
Closes #170

## Summary

- Toon stroke outlines on all 3D models: inverted hull for the marble ball, EdgesGeometry + LineSegments2 for platforms and obstacles
- Cloud edge glitch fixed: replaced BoxGeometry with PlaneGeometry + corrected rotation + alphaTest/depthWrite settings
- `--shadow-text-game` drop shadow increased with `clamp()` min/max bounds for proportional scaling
- Active marble selection button in lobby now has a `2px solid #333` border
- OutlinePass infrastructure added to `@webgamekit/threejs` postprocessing (available but not used by Marble Madness)
- `createResizeHandler` extracted to module level in `core.ts` to satisfy `max-lines-per-function` rule

## Key Changes

- [useMarbleMadnessGame.ts](src/views/Games/MarbleMadness/useMarbleMadnessGame.ts) — stroke helpers + buildGame wiring
- [MarbleMadnessLobby.vue](src/views/Games/MarbleMadness/MarbleMadnessLobby.vue) — active marble border
- [game-ui.scss](src/assets/styles/game-ui.scss) — shadow token update
- [packages/threejs/src/postprocessing.ts](packages/threejs/src/postprocessing.ts) — OutlinePass support
- [toon-stroke-outline.md](documentation/docs/journey/toon-stroke-outline.md) — journey doc

## Test Plan

- [ ] Launch Marble Madness, verify marble has a black silhouette stroke
- [ ] Verify platform and obstacle edges have visible black lines
- [ ] Verify clouds render without white edge artifacts
- [ ] Verify "Esc - Settings" text shadow is more prominent
- [ ] Open lobby, verify selected marble has a visible border
- [ ] All 1182 unit tests pass