### PR TITLE
feat: Marble Rush — endless mode inside Marble Madness

### DIFF
--- a/documentation/docs/journey/marble-rush-track-generation.md
+++ b/documentation/docs/journey/marble-rush-track-generation.md
@@ -1,0 +1,107 @@
+---
+sidebar_position: 99
+---
+
+# Marble Rush: Track Generation and Gap Physics
+
+Non-obvious decisions made while building the Rush endless mode (PR #172–173): procedural chunk streaming, physics-derived gap sizing, and lateral drift.
+
+## Chunk streaming instead of a fixed track
+
+The Race mode loads a static `TrackConfig` — a hand-authored list of platform positions baked into `config.ts`. Rush must run forever, so a fixed list is impossible.
+
+The solution is a cursor-based chunk streamer. A `ChunkCursor` records the current spawn head `{ z, x }`. Each frame the game checks whether the lookahead window ahead of the marble is full; if not, it calls `spawnNextChunk` until the window is satisfied.
+
+```mermaid
+flowchart TD
+    A[animate frame] --> B{cursor.z > marble.z - LOOKAHEAD?}
+    B -- yes --> C[spawnNextChunk]
+    C --> D[cursor advances]
+    D --> B
+    B -- no --> E[prune old chunks behind marble]
+```
+
+The lookahead distance (`RUSH_LOOKAHEAD_Z = 120`) keeps several chunks pre-rendered so the player never sees platforms pop into view. Chunks that have fallen more than `RUSH_DISPOSE_BEHIND = 80` units behind the marble are removed from the scene and their Rapier colliders destroyed.
+
+Recursion replaces the `while` loop that would otherwise violate the functional/no-loop-statements ESLint rule. Each recursive call spawns one chunk and re-enters only if the lookahead window is still under-full.
+
+## Chunk types and difficulty scaling
+
+Four chunk shapes are available. A weighted random selector picks among them based on a `difficulty` value in `[0, 1]` that grows linearly with distance up to `RUSH_MAX_DIFFICULTY_DISTANCE = 400`.
+
+| Type   | Platform width                 | Drift allowed   |
+| ------ | ------------------------------ | --------------- |
+| Wide   | 14 u                           | ±4 u            |
+| Medium | 10 u                           | ±2.5 u          |
+| Narrow | 3–7 u (scales with difficulty) | ±1.5 u          |
+| Gap    | 6–12 u landing                 | ±4 u (airborne) |
+
+At low difficulty the selector heavily favours wide and medium chunks. At full difficulty gaps and narrow bridges dominate.
+
+```mermaid
+flowchart LR
+    D0["difficulty 0"] --> W["wide 65 % · medium 35 %"]
+    D50["difficulty 0.5"] --> M["medium 35 % · narrow 35 % · gap 30 %"]
+    D100["difficulty 1"] --> N["narrow 30 % · gap 70 %"]
+```
+
+## Physics-derived gap sizes
+
+The gap width is not an arbitrary number. It is derived from the ball's physical constants so that it scales automatically if the ball radius or speed cap changes.
+
+When the ball rolls off a platform edge its centre sits exactly `MARBLE_RADIUS` above the platform top face. Under gravity `g` the ball can travel horizontally at most:
+
+```
+RUSH_JUMP_RANGE = MAX_LINEAR_SPEED × √(2 × MARBLE_RADIUS / g)
+```
+
+With the current values (`MAX_LINEAR_SPEED = 20`, `MARBLE_RADIUS = 0.8`, `g = 9.81`) this evaluates to roughly **8.1 m**.
+
+Two derived constants bound the gap at each difficulty extreme:
+
+- `RUSH_GAP_MIN = 2 × MARBLE_RADIUS` — the smallest gap the ball cannot straddle; it must genuinely jump.
+- `RUSH_GAP_MAX = RUSH_JUMP_RANGE × 0.35` — 35 % of the theoretical maximum, keeping full-difficulty gaps demanding but clearable.
+
+```mermaid
+flowchart LR
+    A["MARBLE_RADIUS (0.8)"] --> B["RUSH_GAP_MIN = 2r ≈ 1.6 m"]
+    A --> C["RUSH_JUMP_RANGE ≈ 8.1 m"]
+    D["MAX_LINEAR_SPEED (20)"] --> C
+    C --> E["RUSH_GAP_MAX = 0.35 × range ≈ 2.8 m"]
+    B --> F["gap = MIN + difficulty × (MAX − MIN)"]
+    E --> F
+```
+
+The landing platform width narrows with difficulty through the same linear interpolation, from 12 u down to 6 u.
+
+## Lateral drift
+
+The first implementation kept `cursor.x = 0` throughout, producing a corridor that ran perfectly straight. That is boring and removes any steering challenge.
+
+Each chunk builder returns a `maxXDrift` value appropriate for its width. Wide platforms tolerate larger shifts because the ball has room to realign; narrow bridges allow very little lateral change to stay reachable from the previous platform.
+
+After every chunk spawn a helper computes the next cursor X:
+
+```
+nextX = clamp(currentX + random(−maxDrift, +maxDrift), −MAX_X_OFFSET, +MAX_X_OFFSET)
+```
+
+When the drift would push past the boundary it reflects back rather than clamping flat, which prevents the path from hugging a wall for long stretches.
+
+Gap chunks allow the same drift as wide platforms because the ball is airborne during the void and has time to move laterally.
+
+```mermaid
+flowchart LR
+    CX["cursor.x"] --> D["random drift within maxXDrift"]
+    D --> R{"exceeds ±MAX_X_OFFSET?"}
+    R -- no --> NX["nextX = currentX + drift"]
+    R -- yes --> RF["reflect: nextX = boundary − overshoot"]
+    NX --> NC["next chunk spawns at nextX"]
+    RF --> NC
+```
+
+## Pickup bonuses and penalty feedback
+
+Time pickups (glowing yellow orbs) grant `RUSH_TIME_BONUS = 3` extra seconds and increment a `pickupCount` counter. The counter triggers a floating green `+3s` text in the HUD, mirroring the existing red penalty animation. Both animations share the same float-and-fade keyframe; the pickup label is pinned to the right edge so it does not collide with the red penalty text at the centre.
+
+A `lastSafePosition` tracks the most recent spot where the ball was above the fall threshold and not descending quickly. On a fall the ball teleports there instead of back to spawn, keeping the player near their progress distance.

--- a/src/components/GameLobbyWizard.test.ts
+++ b/src/components/GameLobbyWizard.test.ts
@@ -45,31 +45,20 @@ const buildWrapper = (overrides: Record<string, unknown> = {}): VueWrapper => {
 }
 
 describe('GameLobbyWizard — host single player', () => {
-  it('starts on step 1 (profile) and shows no Start button yet', () => {
+  it('shows profile step with a Start button', () => {
     const wrapper = buildWrapper()
-    expect(wrapper.find('.glw__start-btn').exists()).toBe(false)
     expect(wrapper.find('.glw__step-title').text()).toBe('Your profile')
+    expect(wrapper.find('.glw__start-btn').exists()).toBe(true)
   })
 
-  it('shows Next button on step 1 when there are 2 steps', () => {
+  it('shows no Next button', () => {
     const wrapper = buildWrapper()
     const nextButton = wrapper.findAll('button').find((b) => b.text().includes('Next'))
-    expect(nextButton).toBeDefined()
+    expect(nextButton).toBeUndefined()
   })
 
-  it('advances to step 2 (settings) when Next is clicked', async () => {
+  it('shows enabled Start button by default', () => {
     const wrapper = buildWrapper()
-    const nextButton = wrapper.findAll('button').find((b) => b.text().includes('Next'))
-    await nextButton!.trigger('click')
-    expect(wrapper.find('.glw__step-title').text()).toBe('Game settings')
-  })
-
-  it('shows enabled Start button on step 2 by default', async () => {
-    const wrapper = buildWrapper()
-    await wrapper
-      .findAll('button')
-      .find((b) => b.text().includes('Next'))!
-      .trigger('click')
     const startButton = wrapper.find('.glw__start-btn')
     expect(startButton.exists()).toBe(true)
     expect((startButton.element as HTMLButtonElement).disabled).toBe(false)
@@ -77,66 +66,39 @@ describe('GameLobbyWizard — host single player', () => {
 
   it('emits startGame when Start is clicked', async () => {
     const wrapper = buildWrapper()
-    await wrapper
-      .findAll('button')
-      .find((b) => b.text().includes('Next'))!
-      .trigger('click')
-    const startButton = wrapper.find('.glw__start-btn')
-    expect((startButton.element as HTMLButtonElement).disabled).toBe(false)
-    await startButton.trigger('click')
+    await wrapper.find('.glw__start-btn').trigger('click')
     expect(wrapper.emitted('startGame')).toHaveLength(1)
   })
 })
 
 describe('GameLobbyWizard — canStart prop', () => {
-  it('disables Start button when canStart is false', async () => {
+  it('disables Start button when canStart is false', () => {
     const wrapper = buildWrapper({ canStart: false })
-    await wrapper
-      .findAll('button')
-      .find((b) => b.text().includes('Next'))!
-      .trigger('click')
     const startButton = wrapper.find('.glw__start-btn')
     expect(startButton.attributes('disabled')).toBeDefined()
   })
 
-  it('enables Start button when canStart is true', async () => {
+  it('enables Start button when canStart is true', () => {
     const wrapper = buildWrapper({ canStart: true })
-    await wrapper
-      .findAll('button')
-      .find((b) => b.text().includes('Next'))!
-      .trigger('click')
     const startButton = wrapper.find('.glw__start-btn')
     expect((startButton.element as HTMLButtonElement).disabled).toBe(false)
   })
 
-  it('enables Start button when canStart is undefined (not passed)', async () => {
+  it('enables Start button when canStart is undefined (not passed)', () => {
     const wrapper = buildWrapper()
-    await wrapper
-      .findAll('button')
-      .find((b) => b.text().includes('Next'))!
-      .trigger('click')
     const startButton = wrapper.find('.glw__start-btn')
     expect((startButton.element as HTMLButtonElement).disabled).toBe(false)
   })
 
   it('does not emit startGame when Start is disabled', async () => {
     const wrapper = buildWrapper({ canStart: false })
-    await wrapper
-      .findAll('button')
-      .find((b) => b.text().includes('Next'))!
-      .trigger('click')
     await wrapper.find('.glw__start-btn').trigger('click')
     expect(wrapper.emitted('startGame')).toBeFalsy()
   })
 })
 
 describe('GameLobbyWizard — guest player (isHost=false)', () => {
-  it('has only 1 step for a guest', () => {
-    const wrapper = buildWrapper({ isHost: false })
-    expect(wrapper.findAll('.glw__step-dot')).toHaveLength(1)
-  })
-
-  it('shows no Next button for a guest on the only step', () => {
+  it('shows no Next button for a guest', () => {
     const wrapper = buildWrapper({ isHost: false })
     const nextButton = wrapper.findAll('button').find((b) => b.text().includes('Next'))
     expect(nextButton).toBeUndefined()
@@ -145,43 +107,6 @@ describe('GameLobbyWizard — guest player (isHost=false)', () => {
   it('shows no Start button for a guest', () => {
     const wrapper = buildWrapper({ isHost: false })
     expect(wrapper.find('.glw__start-btn').exists()).toBe(false)
-  })
-})
-
-describe('GameLobbyWizard — step navigation', () => {
-  it('Back button appears on step 2', async () => {
-    const wrapper = buildWrapper()
-    await wrapper
-      .findAll('button')
-      .find((b) => b.text().includes('Next'))!
-      .trigger('click')
-    const backButton = wrapper.findAll('button').find((b) => b.text().includes('Back'))
-    expect(backButton).toBeDefined()
-  })
-
-  it('Back returns to step 1', async () => {
-    const wrapper = buildWrapper()
-    await wrapper
-      .findAll('button')
-      .find((b) => b.text().includes('Next'))!
-      .trigger('click')
-    await wrapper
-      .findAll('button')
-      .find((b) => b.text().includes('Back'))!
-      .trigger('click')
-    expect(wrapper.find('.glw__step-title').text()).toBe('Your profile')
-  })
-
-  it('step dots reflect current step', async () => {
-    const wrapper = buildWrapper()
-    const dotsStep1 = wrapper.findAll('.glw__step-dot--active')
-    expect(dotsStep1).toHaveLength(1)
-    await wrapper
-      .findAll('button')
-      .find((b) => b.text().includes('Next'))!
-      .trigger('click')
-    const dotsStep2 = wrapper.findAll('.glw__step-dot--active')
-    expect(dotsStep2).toHaveLength(1)
   })
 })
 
@@ -215,14 +140,10 @@ describe('GameLobbyWizard — profile step', () => {
 })
 
 describe('GameLobbyWizard — player count display', () => {
-  it('shows player count on step 2', async () => {
+  it('shows player count when multiple players are present', () => {
     const wrapper = buildWrapper({
       playerList: [SOLO_PLAYER, { id: 'peer-2', name: 'Other', color: '#0000ff' }]
     })
-    await wrapper
-      .findAll('button')
-      .find((b) => b.text().includes('Next'))!
-      .trigger('click')
     expect(wrapper.find('.glw__player-count').text()).toContain('2')
   })
 })

--- a/src/components/GameLobbyWizard.vue
+++ b/src/components/GameLobbyWizard.vue
@@ -1,9 +1,5 @@
-<script lang="ts">
-const rememberedSteps = new Map<string, number>()
-</script>
-
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, useSlots, inject } from 'vue'
+import { ref, computed, watch, onMounted, inject } from 'vue'
 import { useRoute } from 'vue-router'
 import { Check } from 'lucide-vue-next'
 import GameCard from '@/components/GameCard.vue'
@@ -41,10 +37,6 @@ const emit = defineEmits<{
 const route = useRoute()
 const fromLobby = computed(() => !!route.query.game)
 
-const step = ref(1)
-// Host: profile (1) + settings (2). Guest: profile only (1).
-const totalSteps = computed(() => (props.isHost ? 2 : 1))
-
 const isPrivate = ref(false)
 
 const {
@@ -67,28 +59,14 @@ const handleAccept = (entry: Parameters<typeof acceptRequest>[0]): void => {
   if (gameRoomId) emit('matchFound', gameRoomId)
 }
 
-const canGoNext = computed(() => step.value < totalSteps.value)
-
 const handleStartGame = (): void => {
-  rememberedSteps.set(props.matchmakerRoom, totalSteps.value)
   emit('startGame')
-}
-
-const goNext = (): void => {
-  if (step.value < totalSteps.value) step.value++
-}
-
-const goBack = (): void => {
-  if (step.value > 1) step.value--
 }
 
 const handleFieldChange = (field: LobbyConfigField, event: Event): void => {
   const raw = (event.target as HTMLInputElement | HTMLSelectElement).value
   emit('configChange', field.key, field.type === 'number' ? Number(raw) : raw)
 }
-
-const slots = useSlots()
-const hasConfig = computed(() => !!slots.config)
 
 const setRoomHidden = inject<((hidden: boolean) => void) | undefined>('setRoomHidden', undefined)
 
@@ -105,26 +83,12 @@ watch(
   }
 )
 
-const restoreStep = (): void => {
-  const remembered = rememberedSteps.get(props.matchmakerRoom)
-  if (remembered !== undefined) step.value = Math.min(remembered, totalSteps.value)
-}
-
 const handleLeaveRoom = (): void => {
-  rememberedSteps.delete(props.matchmakerRoom)
   emit('leaveRoom')
 }
 
-watch(
-  () => props.showResults,
-  (showResults) => {
-    if (!showResults) restoreStep()
-  }
-)
-
 onMounted(() => {
   if (!props.showResults && !fromLobby.value && !isPrivate.value) startSearching()
-  restoreStep()
 })
 </script>
 
@@ -132,17 +96,7 @@ onMounted(() => {
   <section class="glw" :style="{ '--glw-accent': accentColor }">
     <GameCard class="glw__card">
       <div v-if="!showResults">
-        <div class="glw__steps">
-          <span
-            v-for="n in totalSteps"
-            :key="n"
-            class="glw__step-dot"
-            :class="{ 'glw__step-dot--active': n === step, 'glw__step-dot--done': n < step }"
-          />
-        </div>
-
-        <!-- Step 1: Profile -->
-        <div v-if="step === 1" class="glw__body">
+        <div class="glw__body">
           <h3 class="glw__step-title">Your profile</h3>
           <input
             :value="playerName"
@@ -172,13 +126,39 @@ onMounted(() => {
 
           <slot name="profile-extra" />
 
-          <!-- Private toggle — always visible -->
+          <div v-if="configFields.length" class="glw__fields">
+            <label v-for="field in configFields" :key="field.key" class="glw__field">
+              {{ field.label }}
+              <select
+                v-if="field.type === 'select'"
+                :value="field.value"
+                @change="handleFieldChange(field, $event)"
+              >
+                <option
+                  v-for="opt in field.options"
+                  :key="opt.value"
+                  :value="opt.value"
+                  :selected="opt.value === field.value"
+                >
+                  {{ opt.label }}
+                </option>
+              </select>
+              <input
+                v-else
+                type="number"
+                :value="field.value"
+                :min="field.min"
+                :max="field.max"
+                @input="handleFieldChange(field, $event)"
+              />
+            </label>
+          </div>
+
           <label class="glw__private-toggle">
             <input v-model="isPrivate" type="checkbox" class="glw__private-checkbox" />
             <span>Private — only players with the link can join</span>
           </label>
 
-          <!-- Matchmaking status — only when not fromLobby -->
           <template v-if="!fromLobby && !isPrivate">
             <div v-if="isSearching" class="glw__searching">
               Looking for players
@@ -209,11 +189,11 @@ onMounted(() => {
             </ul>
           </template>
 
-          <!-- Guest: waiting for host -->
-          <template v-if="!isHost && playerList.length > 1">
+          <template v-if="playerList.length > 1">
             <div class="glw__players">
               <span class="glw__player-count">
-                {{ playerList.length }} player{{ playerList.length !== 1 ? 's' : '' }} in room
+                {{ playerList.length }} player{{ playerList.length !== 1 ? 's' : '' }}
+                {{ isHost ? 'ready' : 'in room' }}
               </span>
               <span
                 v-for="player in playerList"
@@ -223,74 +203,24 @@ onMounted(() => {
                 :title="player.name"
               />
             </div>
-            <button class="glw__btn glw__btn--ghost" type="button" @click="handleLeaveRoom">
+            <button
+              v-if="!isHost"
+              class="glw__btn glw__btn--ghost"
+              type="button"
+              @click="handleLeaveRoom"
+            >
               Leave room
             </button>
           </template>
         </div>
 
-        <!-- Step 2: Settings (host only) -->
-        <div v-else-if="step === 2" class="glw__body">
-          <h3 class="glw__step-title">Game settings</h3>
-          <slot v-if="hasConfig" name="config" />
-          <div class="glw__players">
-            <span class="glw__player-count">{{ playerList.length }} players ready</span>
-            <span
-              v-for="player in playerList"
-              :key="player.id"
-              class="glw__player-dot"
-              :style="{ background: player.color }"
-              :title="player.name"
-            />
-          </div>
-          <div class="glw__fields">
-            <label v-for="field in configFields" :key="field.key" class="glw__field">
-              {{ field.label }}
-              <select
-                v-if="field.type === 'select'"
-                :value="field.value"
-                @change="handleFieldChange(field, $event)"
-              >
-                <option
-                  v-for="opt in field.options"
-                  :key="opt.value"
-                  :value="opt.value"
-                  :selected="opt.value === field.value"
-                >
-                  {{ opt.label }}
-                </option>
-              </select>
-              <input
-                v-else
-                type="number"
-                :value="field.value"
-                :min="field.min"
-                :max="field.max"
-                @input="handleFieldChange(field, $event)"
-              />
-            </label>
-          </div>
-        </div>
-
-        <!-- Navigation -->
         <div class="glw__nav">
-          <button v-if="step > 1" class="glw__btn glw__btn--ghost" type="button" @click="goBack">
-            ← Back
-          </button>
           <span class="glw__nav-spacer" />
           <button
-            v-if="step < totalSteps"
-            class="glw__btn"
-            type="button"
-            :disabled="!canGoNext"
-            @click="goNext"
-          >
-            Next →
-          </button>
-          <button
-            v-else-if="isHost"
+            v-if="isHost"
             class="glw__start-btn"
             type="button"
+            autofocus
             :disabled="props.canStart === false"
             @click="handleStartGame"
           >
@@ -333,33 +263,6 @@ onMounted(() => {
   min-width: min(320px, 100%);
   max-width: 28rem;
   width: 100%;
-}
-
-.glw__steps {
-  display: flex;
-  justify-content: center;
-  gap: var(--spacing-2);
-}
-
-.glw__step-dot {
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 50%;
-  background: var(--game-border-light);
-  border: 2px solid var(--game-border-secondary);
-  transition:
-    background 0.15s ease,
-    border-color 0.15s ease;
-}
-
-.glw__step-dot--active {
-  background: var(--game-ink);
-  border-color: var(--game-border);
-}
-
-.glw__step-dot--done {
-  background: var(--glw-accent);
-  border-color: var(--glw-accent);
 }
 
 .glw__body {
@@ -443,19 +346,6 @@ onMounted(() => {
   border-radius: 50%;
   border: 2px solid var(--game-border);
   flex-shrink: 0;
-}
-
-.glw__hint {
-  margin: 0;
-  font-size: var(--font-size-sm);
-  font-weight: 700;
-  color: var(--game-ink-medium);
-}
-
-.glw__actions {
-  display: flex;
-  gap: var(--spacing-2);
-  flex-wrap: wrap;
 }
 
 .glw__private-toggle {
@@ -542,35 +432,6 @@ onMounted(() => {
 .glw__request-actions {
   display: flex;
   gap: var(--spacing-1);
-}
-
-.glw__settings-list {
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--spacing-2) var(--spacing-4);
-}
-
-.glw__settings-item {
-  display: flex;
-  flex-direction: column;
-  gap: 0.125rem;
-}
-
-.glw__settings-label {
-  font-size: var(--font-size-xs);
-  font-weight: 700;
-  color: var(--game-ink-medium);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.glw__settings-value {
-  margin: 0;
-  font-size: var(--font-size-sm);
-  font-weight: 700;
-  color: var(--game-ink);
 }
 
 .glw__fields {

--- a/src/utils/gameTimelineActions.ts
+++ b/src/utils/gameTimelineActions.ts
@@ -5,7 +5,7 @@ import { cameraFollowPlayer } from '@webgamekit/threejs'
 import type { ComplexModel } from '@webgamekit/threejs'
 import type { CoordinateTuple } from '@webgamekit/animation'
 
-type TimelineAction = {
+export type TimelineAction = {
   name: string
   category: string
   start: number
@@ -139,5 +139,31 @@ export const createFallCheckAction = (
     const mesh = getMesh()
     if (!mesh) return
     if (mesh.position.y < threshold) onFall()
+  }
+})
+
+/**
+ * Creates a timeline action that translates a Three.js mesh to follow a target's X/Z
+ * with a fixed Z offset. Used for ground/sky meshes that should track a moving player.
+ *
+ * @param getMesh - Getter returning the mesh to move (or null to skip)
+ * @param getTarget - Getter returning the target whose position drives the follow (or null to skip)
+ * @param offsetZ - Constant Z offset added to the target's z so the mesh stays slightly ahead/behind
+ * @returns Timeline action object for addAction()
+ */
+export const createMeshFollowAction = (
+  getMesh: () => THREE.Object3D | null,
+  getTarget: () => THREE.Object3D | null,
+  offsetZ: number
+): TimelineAction => ({
+  name: 'mesh-follow',
+  category: 'environment',
+  start: 0,
+  action: () => {
+    const mesh = getMesh()
+    const target = getTarget()
+    if (!mesh || !target) return
+    mesh.position.x = target.position.x
+    mesh.position.z = target.position.z + offsetZ
   }
 })

--- a/src/views/Games/MarbleMadness/MarbleMadness.vue
+++ b/src/views/Games/MarbleMadness/MarbleMadness.vue
@@ -7,7 +7,9 @@ import { storeToRefs } from 'pinia'
 import { useMarbleMadnessStore } from '@/stores/marbleMadness'
 import { useMarbleMadnessSession } from './useMarbleMadnessSession'
 import { useMarbleMadnessGame } from './useMarbleMadnessGame'
+import { useMarbleMadnessRushGame } from './useMarbleMadnessRushGame'
 import { useRoomId } from '@/composables/useRoomId'
+import type { GameMode } from './types'
 import { useMultiplayerLobbyHandlers } from '@/composables/useMultiplayerLobbyHandlers'
 import {
   loadProfile,
@@ -55,6 +57,8 @@ const bestTime = ref<number | null>(
 const gameReference = ref<InstanceType<typeof MarbleMadnessGame> | null>(null)
 const canvas = computed(() => gameReference.value?.canvas ?? null)
 
+const gameMode = ref<GameMode>('race')
+
 const marbleUrl = computed(
   () => MARBLE_OPTIONS.find((m) => m.id === playerMarble.value)?.url ?? DEFAULT_MARBLE.url
 )
@@ -79,6 +83,15 @@ const session = useMarbleMadnessSession(
 const { isHost, localPeerId } = session
 
 const solo = computed(() => store.solo)
+
+const rushGame = useMarbleMadnessRushGame({
+  canvas,
+  marble: marbleUrl,
+  onGameOver: () => {
+    store.winnerId = localPeerId.value || 'solo'
+    store.phase = 'summary'
+  }
+})
 
 const game = useMarbleMadnessGame({
   canvas,
@@ -145,10 +158,15 @@ const sidebarPlayers = computed((): MultiplayerPlayer[] =>
 watch(phase, async (newPhase) => {
   if (newPhase === 'playing') {
     await nextTick()
-    game.init()
+    if (gameMode.value === 'rush') {
+      rushGame.init()
+    } else {
+      game.init()
+    }
   }
   if (newPhase === 'lobby') {
     game.destroy()
+    rushGame.destroy()
   }
 })
 
@@ -188,7 +206,7 @@ const handleConfigChange = (key: string, value: string | number): void => {
 
 const handleStartGame = (): void => {
   const isSolo = playerList.value.length <= 1
-  if (isSolo) {
+  if (isSolo || gameMode.value === 'rush') {
     store.solo = true
     store.upsertPlayer({
       id: localPeerId.value || 'solo',
@@ -209,6 +227,11 @@ const handleRestart = (): void => {
     runElapsed.value = 0
     trackIndex.value = 0
     store.winnerId = null
+    if (gameMode.value === 'rush') {
+      rushGame.destroy()
+    } else {
+      game.destroy()
+    }
     store.phase = 'playing'
   } else {
     session.restartGame()
@@ -263,6 +286,7 @@ onUnmounted(() => {
       :is-host="isHost"
       :player-list="playerList"
       :room-id="roomId"
+      :mode="gameMode"
       @update:player-name="playerName = $event"
       @update:player-color="handleColorChange"
       @name-change="handleNameChange"
@@ -271,20 +295,27 @@ onUnmounted(() => {
       @leave-room="handleLeaveRoom"
       @config-change="handleConfigChange"
       @marble-change="handleMarbleChange"
+      @mode-change="gameMode = $event"
     />
 
     <div v-else class="mm__play-area">
       <MarbleMadnessGame
         ref="gameReference"
+        :mode="gameMode"
         :elapsed="game.elapsed.value"
-        :finished="game.finished.value"
-        :penalty-count="game.penaltyCount.value"
+        :countdown="rushGame.countdown.value"
+        :distance="rushGame.distance.value"
+        :finished="gameMode === 'rush' ? rushGame.finished.value : game.finished.value"
+        :penalty-count="gameMode === 'rush' ? rushGame.penaltyCount.value : game.penaltyCount.value"
         :track-name="track.name"
-        :current-actions="game.currentActions.value"
+        :current-actions="
+          gameMode === 'rush' ? rushGame.currentActions.value : game.currentActions.value
+        "
         @escape="store.phase = 'lobby'"
       />
       <MarbleMadnessSummary
         v-if="phase === 'summary'"
+        :mode="gameMode"
         :player-list="playerList"
         :winner-id="winnerId"
         :local-peer-id="localPeerId"
@@ -293,6 +324,9 @@ onUnmounted(() => {
         :solo-final-time="soloFinalTime"
         :best-time="bestTime"
         :is-new-best="isNewBest"
+        :rush-distance="Math.floor(rushGame.distance.value)"
+        :rush-best-distance="rushGame.bestDistance.value"
+        :is-new-rush-best="rushGame.isNewBest.value"
         @restart="handleRestart"
         @leave-room="handleLeaveRoom"
       />

--- a/src/views/Games/MarbleMadness/MarbleMadness.vue
+++ b/src/views/Games/MarbleMadness/MarbleMadness.vue
@@ -57,7 +57,7 @@ const bestTime = ref<number | null>(
 const gameReference = ref<InstanceType<typeof MarbleMadnessGame> | null>(null)
 const canvas = computed(() => gameReference.value?.canvas ?? null)
 
-const gameMode = ref<GameMode>('race')
+const gameMode = ref<GameMode>('rush')
 
 const marbleUrl = computed(
   () => MARBLE_OPTIONS.find((m) => m.id === playerMarble.value)?.url ?? DEFAULT_MARBLE.url
@@ -307,6 +307,7 @@ onUnmounted(() => {
         :distance="rushGame.distance.value"
         :finished="gameMode === 'rush' ? rushGame.finished.value : game.finished.value"
         :penalty-count="gameMode === 'rush' ? rushGame.penaltyCount.value : game.penaltyCount.value"
+        :pickup-count="rushGame.pickupCount.value"
         :track-name="track.name"
         :current-actions="
           gameMode === 'rush' ? rushGame.currentActions.value : game.currentActions.value

--- a/src/views/Games/MarbleMadness/MarbleMadnessGame.vue
+++ b/src/views/Games/MarbleMadness/MarbleMadnessGame.vue
@@ -151,7 +151,7 @@ onUnmounted(() => {
       v-if="isMobileDevice && currentActions"
       class="mm-game__fauxpad"
       :mapping="{ up: 'forward', down: 'backward', left: 'left', right: 'right' }"
-      :options="{ deadzone: 0.15 }"
+      :options="{ deadzone: 0.15, enableEightWay: true }"
       :current-actions="currentActions"
       :on-action="() => {}"
     />
@@ -236,7 +236,7 @@ onUnmounted(() => {
 .mm-game__pickup {
   position: absolute;
   top: 5rem;
-  right: var(--spacing-6);
+  left: 50%;
   font-size: clamp(2rem, 5vw, 3.5rem);
   font-weight: 900;
   font-family: var(--font-playful);

--- a/src/views/Games/MarbleMadness/MarbleMadnessGame.vue
+++ b/src/views/Games/MarbleMadness/MarbleMadnessGame.vue
@@ -3,11 +3,15 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { isMobile } from '@webgamekit/controls'
 import TouchControl from '@/components/TouchControl.vue'
 import { TIME_PENALTY_FALL } from './config'
+import type { GameMode } from './types'
 
 const isMobileDevice = isMobile()
 
 const props = defineProps<{
+  mode: GameMode
   elapsed: number
+  countdown: number
+  distance: number
   finished: boolean
   penaltyCount: number
   trackName: string
@@ -25,6 +29,10 @@ const elapsedDisplay = computed((): string => {
   const secs = total % 60
   return `${mins}:${secs.toString().padStart(2, '0')}`
 })
+
+const countdownDisplay = computed((): string => String(Math.ceil(props.countdown)).padStart(2, '0'))
+const distanceDisplay = computed((): string => `${Math.floor(props.distance)}m`)
+const countdownLow = computed((): boolean => props.countdown <= 10)
 
 const PENALTY_DISPLAY_MS = 1500
 const showPenalty = ref(false)
@@ -86,16 +94,24 @@ onUnmounted(() => {
 
 <template>
   <div class="mm-game">
-    <span class="mm-game__time">{{ elapsedDisplay }}</span>
+    <template v-if="mode === 'rush'">
+      <span class="mm-game__time" :class="{ 'mm-game__time--low': countdownLow }">
+        {{ countdownDisplay }}
+      </span>
+      <span class="mm-game__distance">{{ distanceDisplay }}</span>
+    </template>
+    <span v-else class="mm-game__time">{{ elapsedDisplay }}</span>
 
     <Transition name="mm-penalty">
       <span v-if="showPenalty" :key="penaltyCount" class="mm-game__penalty">
-        +{{ TIME_PENALTY_FALL }}s
+        {{ mode === 'rush' ? `-${TIME_PENALTY_FALL}s` : `+${TIME_PENALTY_FALL}s` }}
       </span>
     </Transition>
 
     <Transition name="mm-track-name">
-      <div v-if="showTrackName" class="mm-game__track-name">{{ trackName }}</div>
+      <div v-if="showTrackName && mode === 'race'" class="mm-game__track-name">
+        {{ trackName }}
+      </div>
     </Transition>
 
     <Transition name="mm-instructions">
@@ -152,6 +168,26 @@ onUnmounted(() => {
   color: #333;
   font-variant-numeric: tabular-nums;
   text-shadow: var(--shadow-text-game-large);
+  z-index: 10;
+  white-space: nowrap;
+  pointer-events: none;
+  line-height: 1;
+}
+
+.mm-game__time--low {
+  color: #f44;
+}
+
+.mm-game__distance {
+  position: absolute;
+  top: var(--spacing-3);
+  right: var(--spacing-4);
+  font-size: clamp(1.25rem, 3vw, 2rem);
+  font-weight: 900;
+  font-family: var(--font-playful);
+  color: #fff;
+  font-variant-numeric: tabular-nums;
+  text-shadow: var(--shadow-text-game);
   z-index: 10;
   white-space: nowrap;
   pointer-events: none;

--- a/src/views/Games/MarbleMadness/MarbleMadnessGame.vue
+++ b/src/views/Games/MarbleMadness/MarbleMadnessGame.vue
@@ -2,7 +2,7 @@
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { isMobile } from '@webgamekit/controls'
 import TouchControl from '@/components/TouchControl.vue'
-import { TIME_PENALTY_FALL } from './config'
+import { TIME_PENALTY_FALL, RUSH_TIME_BONUS } from './config'
 import type { GameMode } from './types'
 
 const isMobileDevice = isMobile()
@@ -14,6 +14,7 @@ const props = defineProps<{
   distance: number
   finished: boolean
   penaltyCount: number
+  pickupCount: number
   trackName: string
   currentActions?: Record<string, unknown>
 }>()
@@ -34,7 +35,7 @@ const countdownDisplay = computed((): string => String(Math.ceil(props.countdown
 const distanceDisplay = computed((): string => `${Math.floor(props.distance)}m`)
 const countdownLow = computed((): boolean => props.countdown <= 10)
 
-const PENALTY_DISPLAY_MS = 1500
+const FLASH_DISPLAY_MS = 1500
 const showPenalty = ref(false)
 let penaltyTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -47,7 +48,23 @@ watch(
     penaltyTimer = setTimeout(() => {
       showPenalty.value = false
       penaltyTimer = null
-    }, PENALTY_DISPLAY_MS)
+    }, FLASH_DISPLAY_MS)
+  }
+)
+
+const showPickup = ref(false)
+let pickupTimer: ReturnType<typeof setTimeout> | null = null
+
+watch(
+  () => props.pickupCount,
+  (count) => {
+    if (count === 0) return
+    if (pickupTimer) clearTimeout(pickupTimer)
+    showPickup.value = true
+    pickupTimer = setTimeout(() => {
+      showPickup.value = false
+      pickupTimer = null
+    }, FLASH_DISPLAY_MS)
   }
 )
 
@@ -88,6 +105,7 @@ onUnmounted(() => {
   window.removeEventListener('touchstart', hideInstructions)
   window.removeEventListener('keydown', handleEscKey)
   if (penaltyTimer) clearTimeout(penaltyTimer)
+  if (pickupTimer) clearTimeout(pickupTimer)
   if (trackNameTimer) clearTimeout(trackNameTimer)
 })
 </script>
@@ -105,6 +123,12 @@ onUnmounted(() => {
     <Transition name="mm-penalty">
       <span v-if="showPenalty" :key="penaltyCount" class="mm-game__penalty">
         {{ mode === 'rush' ? `-${TIME_PENALTY_FALL}s` : `+${TIME_PENALTY_FALL}s` }}
+      </span>
+    </Transition>
+
+    <Transition name="mm-penalty">
+      <span v-if="showPickup" :key="pickupCount" class="mm-game__pickup">
+        +{{ RUSH_TIME_BONUS }}s
       </span>
     </Transition>
 
@@ -202,6 +226,21 @@ onUnmounted(() => {
   font-weight: 900;
   font-family: var(--font-playful);
   color: #f44;
+  pointer-events: none;
+  z-index: 20;
+  white-space: nowrap;
+  text-shadow: var(--shadow-text-game);
+  line-height: 1;
+}
+
+.mm-game__pickup {
+  position: absolute;
+  top: 5rem;
+  right: var(--spacing-6);
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  font-weight: 900;
+  font-family: var(--font-playful);
+  color: #4caf50;
   pointer-events: none;
   z-index: 20;
   white-space: nowrap;

--- a/src/views/Games/MarbleMadness/MarbleMadnessLobby.vue
+++ b/src/views/Games/MarbleMadness/MarbleMadnessLobby.vue
@@ -2,6 +2,7 @@
 import GameLobbyWizard from '@/components/GameLobbyWizard.vue'
 import type { LobbyPlayer } from '@/types/lobbyWizard'
 import { MATCHMAKER_ROOM, TRACK_SELECT_FIELD, MARBLE_OPTIONS } from './config'
+import type { GameMode } from './types'
 
 const props = defineProps<{
   playerName: string
@@ -11,6 +12,7 @@ const props = defineProps<{
   isHost: boolean
   playerList: LobbyPlayer[]
   roomId: string
+  mode: GameMode
 }>()
 
 const emit = defineEmits<{
@@ -22,10 +24,13 @@ const emit = defineEmits<{
   leaveRoom: []
   'config-change': [key: string, value: string | number]
   'marble-change': [marbleId: string]
+  'mode-change': [mode: GameMode]
 }>()
 
 const isAvailable = (marbleId: string): boolean =>
   marbleId === props.playerMarble || !props.takenMarbles.includes(marbleId)
+
+const isSolo = (): boolean => props.playerList.length <= 1
 </script>
 
 <template>
@@ -47,6 +52,28 @@ const isAvailable = (marbleId: string): boolean =>
     @config-change="(key, value) => emit('config-change', key, value)"
   >
     <template #profile-extra>
+      <div v-if="isSolo()" class="mml__mode-picker">
+        <span class="mml__mode-label">Mode</span>
+        <div class="mml__mode-buttons">
+          <button
+            class="mml__mode-btn"
+            :class="{ 'mml__mode-btn--active': mode === 'race' }"
+            type="button"
+            @click="emit('mode-change', 'race')"
+          >
+            Race
+          </button>
+          <button
+            class="mml__mode-btn"
+            :class="{ 'mml__mode-btn--active': mode === 'rush' }"
+            type="button"
+            @click="emit('mode-change', 'rush')"
+          >
+            Rush
+          </button>
+        </div>
+      </div>
+
       <div class="mml__marble-picker">
         <span class="mml__marble-label">Your marble</span>
         <div class="mml__marble-grid">
@@ -75,6 +102,50 @@ const isAvailable = (marbleId: string): boolean =>
 </template>
 
 <style scoped>
+.mml__mode-picker {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
+}
+
+.mml__mode-label {
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  color: var(--game-ink);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.mml__mode-buttons {
+  display: flex;
+  gap: var(--spacing-2);
+}
+
+.mml__mode-btn {
+  flex: 1;
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 2px solid var(--game-ink-faint, #ccc);
+  border-radius: var(--radius-md, 0.5rem);
+  background: transparent;
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  color: var(--game-ink-medium);
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    color 0.15s,
+    background 0.15s;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.mml__mode-btn--active {
+  border-color: var(--mm-accent, #ff6b35);
+  color: var(--mm-accent, #ff6b35);
+  background: rgb(255 107 53 / 0.08);
+}
+
 .mml__marble-picker {
   display: flex;
   flex-direction: column;

--- a/src/views/Games/MarbleMadness/MarbleMadnessLobby.vue
+++ b/src/views/Games/MarbleMadness/MarbleMadnessLobby.vue
@@ -41,7 +41,7 @@ const isSolo = (): boolean => props.playerList.length <= 1
     :player-list="playerList"
     :room-id="roomId"
     :matchmaker-room="MATCHMAKER_ROOM"
-    :config-fields="[TRACK_SELECT_FIELD]"
+    :config-fields="mode === 'race' ? [TRACK_SELECT_FIELD] : []"
     accent-color="var(--mm-accent)"
     @update:player-name="emit('update:playerName', $event)"
     @update:player-color="emit('update:playerColor', $event)"

--- a/src/views/Games/MarbleMadness/MarbleMadnessSummary.vue
+++ b/src/views/Games/MarbleMadness/MarbleMadnessSummary.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref } from 'vue'
 import type { MmPlayer } from '@/stores/marbleMadness'
+import type { GameMode } from './types'
 
 const props = defineProps<{
+  mode: GameMode
   playerList: MmPlayer[]
   winnerId: string | null
   localPeerId: string
@@ -11,6 +13,9 @@ const props = defineProps<{
   soloFinalTime: number
   bestTime: number | null
   isNewBest: boolean
+  rushDistance: number
+  rushBestDistance: number | null
+  isNewRushBest: boolean
 }>()
 
 const emit = defineEmits<{
@@ -82,7 +87,21 @@ onUnmounted(() => {
 
 <template>
   <div class="mm-summary" :class="{ 'mm-summary--solo': isSolo }">
-    <template v-if="isSolo">
+    <template v-if="isSolo && mode === 'rush'">
+      <div class="mm-summary__solo-time">{{ rushDistance }}m</div>
+      <div v-if="isNewRushBest" class="mm-summary__best mm-summary__best--new">New best!</div>
+      <div v-else-if="rushBestDistance !== null" class="mm-summary__best">
+        Best: {{ rushBestDistance }}m
+      </div>
+      <Transition name="mm-summary-fade">
+        <div v-if="showPlayAgain" class="mm-summary__move-hint">Move to play again</div>
+      </Transition>
+      <Transition name="mm-summary-fade">
+        <div v-if="showPlayAgain" class="mm-summary__esc-hint">Esc — Settings</div>
+      </Transition>
+    </template>
+
+    <template v-else-if="isSolo">
       <div class="mm-summary__solo-time">{{ formatTime(soloFinalTime) }}</div>
       <div v-if="isNewBest" class="mm-summary__best mm-summary__best--new">New best!</div>
       <div v-else-if="bestTime !== null" class="mm-summary__best">

--- a/src/views/Games/MarbleMadness/config.ts
+++ b/src/views/Games/MarbleMadness/config.ts
@@ -359,8 +359,15 @@ const RUSH_GRAVITY = 9.81
 export const RUSH_JUMP_RANGE = MAX_LINEAR_SPEED * Math.sqrt((2 * MARBLE_RADIUS) / RUSH_GRAVITY)
 // Minimum gap that forces the ball to jump: just wider than its diameter.
 export const RUSH_GAP_MIN = 2 * MARBLE_RADIUS
-// At max difficulty the gap reaches this fraction of the theoretical maximum.
-export const RUSH_GAP_MAX = RUSH_JUMP_RANGE * 0.5
+// At max difficulty the gap reaches this fraction of the theoretical maximum (–30% from original 0.5).
+export const RUSH_GAP_MAX = RUSH_JUMP_RANGE * 0.35
+
+// Lateral drift: max X the cursor can shift per chunk, and absolute X boundary.
+export const RUSH_WIDE_X_DRIFT = 4
+export const RUSH_MEDIUM_X_DRIFT = 2.5
+export const RUSH_NARROW_X_DRIFT = 1.5
+export const RUSH_GAP_X_DRIFT = 4
+export const RUSH_MAX_X_OFFSET = 15
 
 export const RUSH_COUNTDOWN = 30
 export const RUSH_TIME_BONUS = 3

--- a/src/views/Games/MarbleMadness/config.ts
+++ b/src/views/Games/MarbleMadness/config.ts
@@ -353,6 +353,15 @@ export const CLOUD_AREA_CONTROLS = {
 
 export const PLATFORM_HALF_HEIGHT = 0.5
 
+const RUSH_GRAVITY = 9.81
+// Ball center is MARBLE_RADIUS above the platform top; that is the available fall height.
+// At MAX_LINEAR_SPEED the ball crosses: v * sqrt(2 * r / g) before dropping below the edge.
+export const RUSH_JUMP_RANGE = MAX_LINEAR_SPEED * Math.sqrt((2 * MARBLE_RADIUS) / RUSH_GRAVITY)
+// Minimum gap that forces the ball to jump: just wider than its diameter.
+export const RUSH_GAP_MIN = 2 * MARBLE_RADIUS
+// At max difficulty the gap reaches this fraction of the theoretical maximum.
+export const RUSH_GAP_MAX = RUSH_JUMP_RANGE * 0.5
+
 export const RUSH_COUNTDOWN = 30
 export const RUSH_TIME_BONUS = 3
 export const RUSH_FALL_PENALTY = 5

--- a/src/views/Games/MarbleMadness/config.ts
+++ b/src/views/Games/MarbleMadness/config.ts
@@ -64,7 +64,7 @@ export type PlatformDefinition = {
   isFinish?: boolean
 }
 
-export type ObstacleDef = {
+export type ObstacleDefinition = {
   size: CoordinateTuple
   position: CoordinateTuple
 }
@@ -72,7 +72,7 @@ export type ObstacleDef = {
 export type TrackConfig = {
   name: string
   platforms: PlatformDefinition[]
-  obstacles: ObstacleDef[]
+  obstacles: ObstacleDefinition[]
   spawnPosition: CoordinateTuple
   finishPosition: CoordinateTuple
   finishCheckRadius: number
@@ -370,7 +370,7 @@ export const RUSH_GAP_X_DRIFT = 4
 export const RUSH_MAX_X_OFFSET = 15
 
 export const RUSH_COUNTDOWN = 30
-export const RUSH_TIME_BONUS = 3
+export const RUSH_TIME_BONUS = 20
 export const RUSH_FALL_PENALTY = 5
 export const RUSH_LOOKAHEAD_Z = 120
 export const RUSH_DISPOSE_BEHIND = 80
@@ -379,11 +379,47 @@ export const RUSH_BEST_KEY = 'mm-rush-best'
 export const RUSH_SPAWN: CoordinateTuple = [0, 1.5, 0]
 export const RUSH_PLATFORM_COLOR = 0x1565c0
 export const RUSH_BRIDGE_COLOR = 0x0097a7
+export const RUSH_OBSTACLE_COLOR = 0xd32f2f
 export const RUSH_PICKUP_COLOR = 0xffc107
 export const RUSH_PICKUP_RADIUS = 0.45
 export const RUSH_PICKUP_COLLECT_RADIUS = 1.8
-export const RUSH_SKY_COLOR = 0x87ceeb
-export const RUSH_FOG_DENSITY = 0.006
+export const RUSH_SKY_COLOR = 0xb0d8f0
+export const RUSH_FOG_DENSITY = 0.0015
+
+// Slope/ramp: gentle angle so transitions between flat platforms stay reachable.
+// Surface drop across a slope = length * sin(angle).
+export const RUSH_SLOPE_ANGLE = 0.12
+export const RUSH_SLOPE_LENGTH = 20
+export const RUSH_RAMP_ANGLE = 0.18
+export const RUSH_RAMP_LENGTH = 14
+export const RUSH_MIN_Y = -16
+export const RUSH_MAX_Y = 0
+
+// Obstacles sit on top of platforms; size & spacing tuned for marble radius 0.8.
+export const RUSH_OBSTACLE_SIZE: CoordinateTuple = [2.5, 2, 2.5]
+export const RUSH_OBSTACLE_LIFT = 1
+
+// Cloud chunks: spawn ahead of the marble, dispose behind. Keeps active cloud count bounded.
+export const RUSH_CLOUD_CHUNK_LENGTH = 300
+export const RUSH_CLOUD_LOOKAHEAD_Z = 900
+export const RUSH_CLOUD_DISPOSE_BEHIND = 200
+export const RUSH_CLOUD_COUNT_PER_CHUNK = 8
+
+// Ground sphere follows the marble at this Z offset (kept below/ahead of camera).
+export const RUSH_GROUND_FOLLOW_OFFSET_Z = -120
+
+// Moving platforms / obstacles / pickups: probabilities and ranges.
+// Speed is the time (ms) for one full sinusoidal cycle, so smaller = faster.
+export const RUSH_MOVING_PLATFORM_CHANCE = 0.3
+export const RUSH_MOVING_OBSTACLE_CHANCE = 0.6
+export const RUSH_MOVING_PICKUP_CHANCE = 0.5
+export const RUSH_PLATFORM_SWAY_X = 2
+export const RUSH_PLATFORM_BOB_Y = 0.6
+export const RUSH_OBSTACLE_SWAY = 1.6
+export const RUSH_PICKUP_SWAY = 1.2
+export const RUSH_PLATFORM_CYCLE_MS = 2800
+export const RUSH_OBSTACLE_CYCLE_MS = 1600
+export const RUSH_PICKUP_CYCLE_MS = 2000
 
 export const KEYBOARD_MAPPING = {
   keyboard: {

--- a/src/views/Games/MarbleMadness/config.ts
+++ b/src/views/Games/MarbleMadness/config.ts
@@ -56,7 +56,7 @@ export const BRIDGE_COLOR = 0x9e9e9e
 export const OBSTACLE_COLOR = 0xd32f2f
 export const FINISH_COLOR = 0xffd700
 
-export type PlatformDef = {
+export type PlatformDefinition = {
   size: CoordinateTuple
   position: CoordinateTuple
   color: number
@@ -71,7 +71,7 @@ export type ObstacleDef = {
 
 export type TrackConfig = {
   name: string
-  platforms: PlatformDef[]
+  platforms: PlatformDefinition[]
   obstacles: ObstacleDef[]
   spawnPosition: CoordinateTuple
   finishPosition: CoordinateTuple
@@ -350,6 +350,24 @@ export const CLOUD_AREA_CONTROLS = {
     speed: { min: 0, max: 0, step: 0, label: 'Speed' }
   }
 }
+
+export const PLATFORM_HALF_HEIGHT = 0.5
+
+export const RUSH_COUNTDOWN = 30
+export const RUSH_TIME_BONUS = 3
+export const RUSH_FALL_PENALTY = 5
+export const RUSH_LOOKAHEAD_Z = 120
+export const RUSH_DISPOSE_BEHIND = 80
+export const RUSH_MAX_DIFFICULTY_DISTANCE = 400
+export const RUSH_BEST_KEY = 'mm-rush-best'
+export const RUSH_SPAWN: CoordinateTuple = [0, 1.5, 0]
+export const RUSH_PLATFORM_COLOR = 0x1565c0
+export const RUSH_BRIDGE_COLOR = 0x0097a7
+export const RUSH_PICKUP_COLOR = 0xffc107
+export const RUSH_PICKUP_RADIUS = 0.45
+export const RUSH_PICKUP_COLLECT_RADIUS = 1.8
+export const RUSH_SKY_COLOR = 0x87ceeb
+export const RUSH_FOG_DENSITY = 0.006
 
 export const KEYBOARD_MAPPING = {
   keyboard: {

--- a/src/views/Games/MarbleMadness/marbleEnvironment.ts
+++ b/src/views/Games/MarbleMadness/marbleEnvironment.ts
@@ -1,0 +1,336 @@
+import cloudUrl from '@/assets/images/goomba/cloud.png'
+export { cloudUrl }
+import { ref, reactive } from 'vue'
+import * as THREE from 'three'
+import {
+  getCube,
+  getBall,
+  generateAreaPositions,
+  getTools,
+  type ComplexModel
+} from '@webgamekit/threejs'
+import type { CoordinateTuple } from '@webgamekit/animation'
+import { registerTextureAreaProperties } from '@/utils/textureAreaProperties'
+import { useDebugSceneStore } from '@/stores/debugScene'
+import { useElementPropertiesStore } from '@/stores/elementProperties'
+import { CLOUD_AREA_NAME, CLOUD_AREA_SEED, CLOUD_AREA_CONTROLS } from './config'
+
+type UnwrapPromise<T> = T extends Promise<infer U> ? U : T
+type GetToolsResult = UnwrapPromise<ReturnType<typeof getTools>>
+export type WorldReference = NonNullable<GetToolsResult['world']>
+
+export type CloudBuildOptions = {
+  center: CoordinateTuple
+  size: CoordinateTuple
+  baseSize: CoordinateTuple
+  rotation: CoordinateTuple
+  sizeVariation: CoordinateTuple
+  rotationVariation: CoordinateTuple
+  pattern: 'random' | 'grid' | 'grid-jitter'
+  count: number
+  seed: number
+  opacity: number
+}
+
+const HALF = 0.5
+const applyVariation = (base: number, variation: number): number =>
+  base + (Math.random() - HALF) * 2 * variation
+
+export const buildCloudObjects = (
+  scene: THREE.Scene,
+  world: WorldReference,
+  options: CloudBuildOptions
+): ComplexModel[] => {
+  const {
+    center,
+    size,
+    baseSize,
+    rotation,
+    sizeVariation,
+    rotationVariation,
+    pattern,
+    count,
+    seed,
+    opacity
+  } = options
+  const positions = generateAreaPositions({ center, size, count, pattern, seed })
+  return positions.map((position) => {
+    const instanceSize: CoordinateTuple = [
+      Math.max(1, applyVariation(baseSize[0], sizeVariation[0])),
+      baseSize[1],
+      Math.max(1, applyVariation(baseSize[2], sizeVariation[2]))
+    ]
+    const instanceRotation: CoordinateTuple = [
+      rotation[0] + applyVariation(0, rotationVariation[0]),
+      rotation[1] + applyVariation(0, rotationVariation[1]),
+      rotation[2] + applyVariation(0, rotationVariation[2])
+    ]
+    const cloud = getCube(scene, world, {
+      size: instanceSize,
+      position,
+      rotation: instanceRotation,
+      texture: cloudUrl,
+      material: 'MeshBasicMaterial',
+      transparent: true,
+      opacity,
+      alphaTest: 0.5,
+      depthWrite: false,
+      renderOrder: 1,
+      type: 'fixed',
+      castShadow: false,
+      receiveShadow: false
+    })
+    const cloudMesh = cloud as unknown as THREE.Mesh
+    cloudMesh.geometry.dispose()
+    cloudMesh.geometry = new THREE.PlaneGeometry(instanceSize[0], instanceSize[2])
+    if (cloudMesh.material instanceof THREE.Material) cloudMesh.material.side = THREE.DoubleSide
+    cloudMesh.rotation.set(0, instanceRotation[1], instanceRotation[2])
+    return cloud
+  })
+}
+
+export const disposeClouds = (
+  objects: ComplexModel[],
+  scene: THREE.Scene | null,
+  world: WorldReference | null
+): void => {
+  objects.forEach((cloudObject) => {
+    const mesh = cloudObject as unknown as THREE.Mesh
+    scene?.remove(cloudObject)
+    mesh.geometry.dispose()
+    if (mesh.material instanceof THREE.Material) mesh.material.dispose()
+    world?.removeRigidBody(cloudObject.userData.body)
+  })
+}
+
+export const SHARED_CLOUD_OPTIONS: CloudBuildOptions = {
+  center: [0, -100, 50],
+  size: [600, 0, 1400],
+  baseSize: [145, 0.001, 60],
+  rotation: [Math.PI / 2, 0, 0],
+  sizeVariation: [0, 0, 0],
+  rotationVariation: [0, 0, 0],
+  pattern: 'grid-jitter',
+  count: 30,
+  seed: CLOUD_AREA_SEED,
+  opacity: 1
+}
+
+export const setupCloudArea = (
+  scene: THREE.Scene,
+  world: WorldReference,
+  onRebuild: (updated: ComplexModel[]) => void
+): ComplexModel[] => {
+  const areaConfigs = ref<Record<string, Record<string, unknown>>>({})
+  let currentObjects = buildCloudObjects(scene, world, SHARED_CLOUD_OPTIONS)
+  registerTextureAreaProperties({
+    areaName: CLOUD_AREA_NAME,
+    layers: [
+      {
+        name: CLOUD_AREA_NAME,
+        texture: cloudUrl,
+        baseSize: SHARED_CLOUD_OPTIONS.baseSize,
+        center: SHARED_CLOUD_OPTIONS.center,
+        size: SHARED_CLOUD_OPTIONS.size,
+        density: SHARED_CLOUD_OPTIONS.count,
+        seed: SHARED_CLOUD_OPTIONS.seed,
+        speed: 0,
+        opacity: 1
+      }
+    ],
+    schema: CLOUD_AREA_CONTROLS,
+    areaConfigs,
+    onUpdate: (name) => {
+      const config = areaConfigs.value[name]
+      if (!config) return
+      const area = config.area as {
+        center: { x: number; y: number; z: number }
+        size: { x: number; y: number; z: number }
+      }
+      const textures = config.textures as {
+        baseSize: { x: number; y: number; z: number }
+        sizeVariation: { x: number; y: number; z: number }
+        rotationVariation: { x: number; y: number; z: number }
+      }
+      const instances = config.instances as {
+        density: number
+        pattern: 'random' | 'grid' | 'grid-jitter'
+        seed: number
+      }
+      const rendering = config.rendering as { opacity: number }
+      disposeClouds(currentObjects, scene, world)
+      currentObjects = buildCloudObjects(scene, world, {
+        center: [area.center.x, area.center.y, area.center.z],
+        size: [area.size.x, area.size.y, area.size.z],
+        baseSize: [textures.baseSize.x, textures.baseSize.y, textures.baseSize.z],
+        rotation: SHARED_CLOUD_OPTIONS.rotation,
+        sizeVariation: [
+          textures.sizeVariation.x,
+          textures.sizeVariation.y,
+          textures.sizeVariation.z
+        ],
+        rotationVariation: [
+          textures.rotationVariation.x,
+          textures.rotationVariation.y,
+          textures.rotationVariation.z
+        ],
+        pattern: instances.pattern,
+        count: instances.density,
+        seed: instances.seed,
+        opacity: rendering.opacity
+      })
+      onRebuild(currentObjects)
+    }
+  })
+  return currentObjects
+}
+
+export const teardownCloudArea = (): void => {
+  useDebugSceneStore().removeSceneElement(CLOUD_AREA_NAME)
+  useElementPropertiesStore().unregisterElementProperties(CLOUD_AREA_NAME)
+}
+
+const GROUND_SPHERE_RADIUS = 1500
+const GROUND_SPHERE_Y = -1700
+const GROUND_SPHERE_Z = -120
+const GROUND_SPHERE_CENTER: CoordinateTuple = [0, GROUND_SPHERE_Y, GROUND_SPHERE_Z]
+const GROUND_SPHERE_COLOR = 0x4a7a3a
+
+export const addGroundSphereToScene = (scene: THREE.Scene): THREE.Mesh => {
+  const mesh = getBall(scene, undefined, {
+    size: GROUND_SPHERE_RADIUS,
+    position: GROUND_SPHERE_CENTER,
+    color: GROUND_SPHERE_COLOR,
+    segments: 64,
+    castShadow: false,
+    receiveShadow: false
+  })
+  mesh.userData.skipEdgeLines = true
+  return mesh as unknown as THREE.Mesh
+}
+
+export const registerGroundSphereProperties = (groundMesh: THREE.Mesh): void => {
+  const state = reactive({
+    position: { x: groundMesh.position.x, y: groundMesh.position.y, z: groundMesh.position.z },
+    radius: groundMesh.scale.x * GROUND_SPHERE_RADIUS,
+    color: (groundMesh.material as THREE.MeshStandardMaterial).color.getHex()
+  })
+  useDebugSceneStore().addSceneElement({ name: 'Ground', type: 'Mesh', hidden: false })
+  useElementPropertiesStore().registerElementProperties('Ground', {
+    title: 'Ground',
+    type: 'Mesh',
+    schema: {
+      position: {
+        label: 'Position',
+        component: 'CoordinateInput',
+        min: { x: -2000, y: -2000, z: -2000 },
+        max: { x: 2000, y: 2000, z: 2000 },
+        step: { x: 10, y: 10, z: 10 }
+      },
+      radius: { label: 'Radius', min: 100, max: 2000, step: 10 },
+      color: { label: 'Color', color: true }
+    },
+    getValue: (path: string) => {
+      if (path === 'position')
+        return { x: state.position.x, y: state.position.y, z: state.position.z }
+      if (path === 'radius') return state.radius
+      if (path === 'color') return state.color
+      return undefined
+    },
+    updateValue: (path: string, value: unknown) => {
+      if (path === 'position') {
+        const v = value as { x: number; y: number; z: number }
+        state.position = { x: v.x, y: v.y, z: v.z }
+        groundMesh.position.set(v.x, v.y, v.z)
+      } else if (path === 'radius') {
+        state.radius = value as number
+        const scale = (value as number) / GROUND_SPHERE_RADIUS
+        groundMesh.scale.set(scale, scale, scale)
+      } else if (path === 'color') {
+        state.color = value as number
+        ;(groundMesh.material as THREE.MeshStandardMaterial).color.setHex(value as number)
+      }
+    }
+  })
+}
+
+export const teardownGroundSphere = (): void => {
+  useDebugSceneStore().removeSceneElement('Ground')
+  useElementPropertiesStore().unregisterElementProperties('Ground')
+}
+
+export const moveGroundSphere = (mesh: THREE.Mesh, x: number, z: number): void => {
+  mesh.position.x = x
+  mesh.position.z = z
+}
+
+type CloudChunk = { startZ: number; endZ: number; meshes: ComplexModel[] }
+
+export type CloudChunkOptions = {
+  chunkLength: number
+  countPerChunk: number
+  lookaheadZ: number
+  disposeBehindZ: number
+  baseSize?: CoordinateTuple
+  centerY?: number
+  sizeX?: number
+  opacity?: number
+}
+
+export type CloudChunkManager = {
+  ensureAhead: (marbleZ: number) => void
+  prune: (marbleZ: number) => void
+  teardown: () => void
+}
+
+export const createCloudChunkManager = (
+  scene: THREE.Scene,
+  world: WorldReference,
+  options: CloudChunkOptions
+): CloudChunkManager => {
+  const baseSize = options.baseSize ?? SHARED_CLOUD_OPTIONS.baseSize
+  const centerY = options.centerY ?? SHARED_CLOUD_OPTIONS.center[1]
+  const sizeX = options.sizeX ?? SHARED_CLOUD_OPTIONS.size[0]
+  const opacity = options.opacity ?? SHARED_CLOUD_OPTIONS.opacity
+  let chunks: CloudChunk[] = []
+  let chunkSerial = 0
+
+  const spawnChunk = (startZ: number, endZ: number): void => {
+    const centerZ = (startZ + endZ) / 2
+    const chunkLength = startZ - endZ
+    const meshes = buildCloudObjects(scene, world, {
+      ...SHARED_CLOUD_OPTIONS,
+      center: [0, centerY, centerZ],
+      size: [sizeX, 0, chunkLength],
+      baseSize,
+      count: options.countPerChunk,
+      seed: CLOUD_AREA_SEED + chunkSerial,
+      opacity
+    })
+    chunkSerial += 1
+    chunks.push({ startZ, endZ, meshes })
+  }
+
+  const ensureAhead = (marbleZ: number): void => {
+    const targetFarZ = marbleZ - options.lookaheadZ
+    const tail = chunks[chunks.length - 1]
+    if (tail && tail.endZ <= targetFarZ) return
+    const startZ = tail ? tail.endZ : marbleZ + options.chunkLength
+    spawnChunk(startZ, startZ - options.chunkLength)
+    ensureAhead(marbleZ)
+  }
+
+  const prune = (marbleZ: number): void => {
+    const cutoffZ = marbleZ + options.disposeBehindZ
+    const toRemove = chunks.filter((c) => c.endZ > cutoffZ)
+    toRemove.forEach((c) => disposeClouds(c.meshes, scene, world))
+    chunks = chunks.filter((c) => c.endZ <= cutoffZ)
+  }
+
+  const teardown = (): void => {
+    chunks.forEach((c) => disposeClouds(c.meshes, scene, world))
+    chunks = []
+  }
+
+  return { ensureAhead, prune, teardown }
+}

--- a/src/views/Games/MarbleMadness/marbleVisuals.ts
+++ b/src/views/Games/MarbleMadness/marbleVisuals.ts
@@ -1,0 +1,47 @@
+import * as THREE from 'three'
+
+const STROKE_COLOR = 0x333333
+const STROKE_SCALE = 1.05
+const STROKE_MATERIAL = new THREE.MeshBasicMaterial({ color: STROKE_COLOR, side: THREE.BackSide })
+const EDGE_THRESHOLD_ANGLE = 15
+const EDGE_LINE_WIDTH = 2
+
+export const attachBallStroke = (mesh: THREE.Mesh): void => {
+  const hull = new THREE.Mesh(mesh.geometry, STROKE_MATERIAL)
+  hull.scale.setScalar(STROKE_SCALE)
+  hull.userData.skipEdgeLines = true
+  mesh.add(hull)
+}
+
+const isSolidMesh = (object: THREE.Object3D): object is THREE.Mesh => {
+  if (!(object instanceof THREE.Mesh)) return false
+  if (object.userData.skipEdgeLines) return false
+  if (object.userData.hasEdgeLines) return false
+  const mat = Array.isArray(object.material) ? object.material[0] : object.material
+  return !(mat instanceof THREE.Material && mat.transparent)
+}
+
+const attachEdgeLines = async (mesh: THREE.Mesh): Promise<void> => {
+  mesh.userData.hasEdgeLines = true
+  const [{ LineMaterial }, { LineSegments2 }, { LineSegmentsGeometry }] = await Promise.all([
+    import('three/examples/jsm/lines/LineMaterial.js'),
+    import('three/examples/jsm/lines/LineSegments2.js'),
+    import('three/examples/jsm/lines/LineSegmentsGeometry.js')
+  ])
+  const edges = new THREE.EdgesGeometry(mesh.geometry, EDGE_THRESHOLD_ANGLE)
+  const geometry = new LineSegmentsGeometry().fromEdgesGeometry(edges)
+  const material = new LineMaterial({
+    color: STROKE_COLOR,
+    linewidth: EDGE_LINE_WIDTH,
+    resolution: new THREE.Vector2(window.innerWidth, window.innerHeight)
+  })
+  const lines = new LineSegments2(geometry, material)
+  lines.userData.skipEdgeLines = true
+  mesh.add(lines)
+}
+
+export const addEdgeLinesToScene = (scene: THREE.Scene): void => {
+  scene.traverse((object) => {
+    if (isSolidMesh(object)) attachEdgeLines(object)
+  })
+}

--- a/src/views/Games/MarbleMadness/types.ts
+++ b/src/views/Games/MarbleMadness/types.ts
@@ -34,6 +34,8 @@ export type MmContext = {
   onStart: (trackIndex: number) => void
 }
 
+export type GameMode = 'race' | 'rush'
+
 export type GameDeps = {
   canvas: Ref<HTMLCanvasElement | null>
   isSolo: Ref<boolean>

--- a/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
+++ b/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
@@ -50,6 +50,7 @@ import {
   LIGHT_SHADOW_RADIUS,
   LIGHT_SHADOW_BIAS,
   LIGHT_SHADOW_CAMERA,
+  PLATFORM_HALF_HEIGHT,
   type TrackConfig
 } from './config'
 import type { GameDeps, BallPosPayload } from './types'
@@ -77,7 +78,6 @@ type MarbleState = {
 }
 
 const CAMERA_OFFSET: CoordinateTuple = [0, CAMERA_HEIGHT, CAMERA_BACK]
-const PLATFORM_HALF_HEIGHT = 0.5
 const STROKE_COLOR = 0x333333
 const STROKE_SCALE = 1.05
 const STROKE_MATERIAL = new THREE.MeshBasicMaterial({ color: STROKE_COLOR, side: THREE.BackSide })

--- a/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
+++ b/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
@@ -1,4 +1,5 @@
 import cloudUrl from '@/assets/images/goomba/cloud.png'
+import { attachBallStroke, addEdgeLinesToScene } from './marbleVisuals'
 import { ref, reactive, watch, onUnmounted } from 'vue'
 import type { Ref } from 'vue'
 import * as THREE from 'three'
@@ -78,49 +79,6 @@ type MarbleState = {
 }
 
 const CAMERA_OFFSET: CoordinateTuple = [0, CAMERA_HEIGHT, CAMERA_BACK]
-const STROKE_COLOR = 0x333333
-const STROKE_SCALE = 1.05
-const STROKE_MATERIAL = new THREE.MeshBasicMaterial({ color: STROKE_COLOR, side: THREE.BackSide })
-const EDGE_THRESHOLD_ANGLE = 15
-const EDGE_LINE_WIDTH = 2
-
-const attachBallStroke = (mesh: THREE.Mesh): void => {
-  const hull = new THREE.Mesh(mesh.geometry, STROKE_MATERIAL)
-  hull.scale.setScalar(STROKE_SCALE)
-  hull.userData.skipEdgeLines = true
-  mesh.add(hull)
-}
-
-const isSolidMesh = (object: THREE.Object3D): object is THREE.Mesh => {
-  if (!(object instanceof THREE.Mesh)) return false
-  if (object.userData.skipEdgeLines) return false
-  const mat = Array.isArray(object.material) ? object.material[0] : object.material
-  return !(mat instanceof THREE.Material && mat.transparent)
-}
-
-const attachEdgeLines = async (mesh: THREE.Mesh): Promise<void> => {
-  const [{ LineMaterial }, { LineSegments2 }, { LineSegmentsGeometry }] = await Promise.all([
-    import('three/examples/jsm/lines/LineMaterial.js'),
-    import('three/examples/jsm/lines/LineSegments2.js'),
-    import('three/examples/jsm/lines/LineSegmentsGeometry.js')
-  ])
-  const edges = new THREE.EdgesGeometry(mesh.geometry, EDGE_THRESHOLD_ANGLE)
-  const geometry = new LineSegmentsGeometry().fromEdgesGeometry(edges)
-  const material = new LineMaterial({
-    color: STROKE_COLOR,
-    linewidth: EDGE_LINE_WIDTH,
-    resolution: new THREE.Vector2(window.innerWidth, window.innerHeight)
-  })
-  const lines = new LineSegments2(geometry, material)
-  lines.userData.skipEdgeLines = true
-  mesh.add(lines)
-}
-
-const addEdgeLinesToScene = (scene: THREE.Scene): void => {
-  scene.traverse((object) => {
-    if (isSolidMesh(object)) attachEdgeLines(object)
-  })
-}
 
 const CLOUD_Y = -100
 const CLOUD_AREA_CENTER_Z = 50

--- a/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
+++ b/src/views/Games/MarbleMadness/useMarbleMadnessGame.ts
@@ -1,17 +1,16 @@
-import cloudUrl from '@/assets/images/goomba/cloud.png'
 import { attachBallStroke, addEdgeLinesToScene } from './marbleVisuals'
-import { ref, reactive, watch, onUnmounted } from 'vue'
+import {
+  setupCloudArea,
+  teardownCloudArea,
+  addGroundSphereToScene,
+  registerGroundSphereProperties,
+  teardownGroundSphere
+} from './marbleEnvironment'
+import { ref, watch, onUnmounted } from 'vue'
 import type { Ref } from 'vue'
 import * as THREE from 'three'
 import type { OrbitControls } from 'three/addons/controls/OrbitControls.js'
-import {
-  getTools,
-  getBall,
-  getCube,
-  moveDynamic,
-  generateAreaPositions,
-  type ComplexModel
-} from '@webgamekit/threejs'
+import { getTools, getBall, getCube, moveDynamic, type ComplexModel } from '@webgamekit/threejs'
 import {
   createCameraFollowAction,
   createDirectionalLightFollowAction,
@@ -23,9 +22,6 @@ import { createControls } from '@webgamekit/controls'
 import type { ControlsExtras, ControlsCurrents } from '@webgamekit/controls'
 import { createTimelineManager, type CoordinateTuple } from '@webgamekit/animation'
 import { registerCameraProperties } from '@/utils/cameraProperties'
-import { registerTextureAreaProperties } from '@/utils/textureAreaProperties'
-import { useDebugSceneStore } from '@/stores/debugScene'
-import { useElementPropertiesStore } from '@/stores/elementProperties'
 import {
   MARBLE_RADIUS,
   MARBLE_WEIGHT,
@@ -45,9 +41,6 @@ import {
   LIGHT_AMBIENT_INTENSITY,
   LIGHT_DIRECTIONAL_INTENSITY,
   LIGHT_DIRECTIONAL_POSITION,
-  CLOUD_AREA_NAME,
-  CLOUD_AREA_SEED,
-  CLOUD_AREA_CONTROLS,
   LIGHT_SHADOW_RADIUS,
   LIGHT_SHADOW_BIAS,
   LIGHT_SHADOW_CAMERA,
@@ -80,111 +73,8 @@ type MarbleState = {
 
 const CAMERA_OFFSET: CoordinateTuple = [0, CAMERA_HEIGHT, CAMERA_BACK]
 
-const CLOUD_Y = -100
-const CLOUD_AREA_CENTER_Z = 50
-const CLOUD_ROTATION: CoordinateTuple = [Math.PI / 2, 0, 0]
-const CLOUD_AREA_WIDTH = 600
-const CLOUD_AREA_DEPTH = 1400
-const CLOUD_BASE_WIDTH = 145
-const CLOUD_BASE_HEIGHT = 0.001
-const CLOUD_BASE_DEPTH = 60
-const CLOUD_DENSITY = 30
-const CLOUD_AREA_CENTER: CoordinateTuple = [0, CLOUD_Y, CLOUD_AREA_CENTER_Z]
-const CLOUD_AREA_SIZE: CoordinateTuple = [CLOUD_AREA_WIDTH, 0, CLOUD_AREA_DEPTH]
-const CLOUD_BASE_SIZE: CoordinateTuple = [CLOUD_BASE_WIDTH, CLOUD_BASE_HEIGHT, CLOUD_BASE_DEPTH]
-
 const FOG_COLOR = 0xb0d8f0
 const FOG_DENSITY = 0.0015
-
-const GROUND_SPHERE_RADIUS = 1500
-const GROUND_SPHERE_Y = -1700
-const GROUND_SPHERE_Z = -120
-const GROUND_SPHERE_CENTER: CoordinateTuple = [0, GROUND_SPHERE_Y, GROUND_SPHERE_Z]
-const GROUND_SPHERE_COLOR = 0x4a7a3a
-
-type CloudBuildOptions = {
-  center: CoordinateTuple
-  size: CoordinateTuple
-  baseSize: CoordinateTuple
-  rotation: CoordinateTuple
-  sizeVariation: CoordinateTuple
-  rotationVariation: CoordinateTuple
-  pattern: 'random' | 'grid' | 'grid-jitter'
-  count: number
-  seed: number
-  opacity: number
-}
-
-const HALF = 0.5
-const applyVariation = (base: number, variation: number): number =>
-  base + (Math.random() - HALF) * 2 * variation
-
-const buildCloudObjects = (
-  scene: THREE.Scene,
-  world: NonNullable<GetToolsResult['world']>,
-  options: CloudBuildOptions
-): ComplexModel[] => {
-  const {
-    center,
-    size,
-    baseSize,
-    rotation,
-    sizeVariation,
-    rotationVariation,
-    pattern,
-    count,
-    seed,
-    opacity
-  } = options
-  const positions = generateAreaPositions({ center, size, count, pattern, seed })
-  return positions.map((position) => {
-    const instanceSize: CoordinateTuple = [
-      Math.max(1, applyVariation(baseSize[0], sizeVariation[0])),
-      baseSize[1],
-      Math.max(1, applyVariation(baseSize[2], sizeVariation[2]))
-    ]
-    const instanceRotation: CoordinateTuple = [
-      rotation[0] + applyVariation(0, rotationVariation[0]),
-      rotation[1] + applyVariation(0, rotationVariation[1]),
-      rotation[2] + applyVariation(0, rotationVariation[2])
-    ]
-    const cloud = getCube(scene, world, {
-      size: instanceSize,
-      position,
-      rotation: instanceRotation,
-      texture: cloudUrl,
-      material: 'MeshBasicMaterial',
-      transparent: true,
-      opacity,
-      alphaTest: 0.5,
-      depthWrite: false,
-      renderOrder: 1,
-      type: 'fixed',
-      castShadow: false,
-      receiveShadow: false
-    })
-    const cloudMesh = cloud as unknown as THREE.Mesh
-    cloudMesh.geometry.dispose()
-    cloudMesh.geometry = new THREE.PlaneGeometry(instanceSize[0], instanceSize[2])
-    if (cloudMesh.material instanceof THREE.Material) cloudMesh.material.side = THREE.DoubleSide
-    cloudMesh.rotation.set(0, instanceRotation[1], instanceRotation[2])
-    return cloud
-  })
-}
-
-const disposeClouds = (
-  objects: ComplexModel[],
-  scene: THREE.Scene | null,
-  world: NonNullable<GetToolsResult['world']> | null
-): void => {
-  objects.forEach((cloudObject) => {
-    const mesh = cloudObject as unknown as THREE.Mesh
-    scene?.remove(cloudObject)
-    mesh.geometry.dispose()
-    if (mesh.material instanceof THREE.Material) mesh.material.dispose()
-    world?.removeRigidBody(cloudObject.userData.body)
-  })
-}
 
 const applyDamping = (model: ComplexModel): void => {
   model.userData.body.setLinearDamping(MARBLE_LINEAR_DAMPING)
@@ -373,87 +263,6 @@ const buildTimeline = (
   return timeline
 }
 
-type CloudAreaRebuildCallback = (options: CloudBuildOptions) => void
-
-const setupCloudArea = (
-  scene: THREE.Scene,
-  world: NonNullable<GetToolsResult['world']>,
-  areaConfigs: Ref<Record<string, Record<string, unknown>>>,
-  onRebuild: CloudAreaRebuildCallback
-): ComplexModel[] => {
-  const NO_VARIATION: CoordinateTuple = [0, 0, 0]
-  const initialObjects = buildCloudObjects(scene, world, {
-    center: CLOUD_AREA_CENTER,
-    size: CLOUD_AREA_SIZE,
-    baseSize: CLOUD_BASE_SIZE,
-    rotation: CLOUD_ROTATION,
-    sizeVariation: NO_VARIATION,
-    rotationVariation: NO_VARIATION,
-    pattern: 'grid-jitter',
-    count: CLOUD_DENSITY,
-    seed: CLOUD_AREA_SEED,
-    opacity: 1
-  })
-  registerTextureAreaProperties({
-    areaName: CLOUD_AREA_NAME,
-    layers: [
-      {
-        name: CLOUD_AREA_NAME,
-        texture: cloudUrl,
-        baseSize: CLOUD_BASE_SIZE,
-        center: CLOUD_AREA_CENTER,
-        size: CLOUD_AREA_SIZE,
-        density: CLOUD_DENSITY,
-        seed: CLOUD_AREA_SEED,
-        speed: 0,
-        opacity: 1
-      }
-    ],
-    schema: CLOUD_AREA_CONTROLS,
-    areaConfigs,
-    onUpdate: (name) => {
-      const config = areaConfigs.value[name]
-      if (!config) return
-      const area = config.area as {
-        center: { x: number; y: number; z: number }
-        size: { x: number; y: number; z: number }
-      }
-      const textures = config.textures as {
-        baseSize: { x: number; y: number; z: number }
-        sizeVariation: { x: number; y: number; z: number }
-        rotationVariation: { x: number; y: number; z: number }
-      }
-      const instances = config.instances as {
-        density: number
-        pattern: 'random' | 'grid' | 'grid-jitter'
-        seed: number
-      }
-      const rendering = config.rendering as { opacity: number }
-      onRebuild({
-        center: [area.center.x, area.center.y, area.center.z],
-        size: [area.size.x, area.size.y, area.size.z],
-        baseSize: [textures.baseSize.x, textures.baseSize.y, textures.baseSize.z],
-        rotation: CLOUD_ROTATION,
-        sizeVariation: [
-          textures.sizeVariation.x,
-          textures.sizeVariation.y,
-          textures.sizeVariation.z
-        ],
-        rotationVariation: [
-          textures.rotationVariation.x,
-          textures.rotationVariation.y,
-          textures.rotationVariation.z
-        ],
-        pattern: instances.pattern,
-        count: instances.density,
-        seed: instances.seed,
-        opacity: rendering.opacity
-      })
-    }
-  })
-  return initialObjects
-}
-
 const buildSceneSetupConfig = (track: TrackConfig) => ({
   camera: {
     position: [
@@ -475,52 +284,6 @@ const buildSceneSetupConfig = (track: TrackConfig) => ({
   }
 })
 
-const registerGroundSphereProperties = (groundMesh: THREE.Mesh): void => {
-  const state = reactive({
-    position: { x: groundMesh.position.x, y: groundMesh.position.y, z: groundMesh.position.z },
-    radius: groundMesh.scale.x * GROUND_SPHERE_RADIUS,
-    color: (groundMesh.material as THREE.MeshStandardMaterial).color.getHex()
-  })
-
-  useDebugSceneStore().addSceneElement({ name: 'Ground', type: 'Mesh', hidden: false })
-  useElementPropertiesStore().registerElementProperties('Ground', {
-    title: 'Ground',
-    type: 'Mesh',
-    schema: {
-      position: {
-        label: 'Position',
-        component: 'CoordinateInput',
-        min: { x: -2000, y: -2000, z: -2000 },
-        max: { x: 2000, y: 2000, z: 2000 },
-        step: { x: 10, y: 10, z: 10 }
-      },
-      radius: { label: 'Radius', min: 100, max: 2000, step: 10 },
-      color: { label: 'Color', color: true }
-    },
-    getValue: (path: string) => {
-      if (path === 'position')
-        return { x: state.position.x, y: state.position.y, z: state.position.z }
-      if (path === 'radius') return state.radius
-      if (path === 'color') return state.color
-      return undefined
-    },
-    updateValue: (path: string, value: unknown) => {
-      if (path === 'position') {
-        const v = value as { x: number; y: number; z: number }
-        state.position = { x: v.x, y: v.y, z: v.z }
-        groundMesh.position.set(v.x, v.y, v.z)
-      } else if (path === 'radius') {
-        state.radius = value as number
-        const scale = (value as number) / GROUND_SPHERE_RADIUS
-        groundMesh.scale.set(scale, scale, scale)
-      } else if (path === 'color') {
-        state.color = value as number
-        ;(groundMesh.material as THREE.MeshStandardMaterial).color.setHex(value as number)
-      }
-    }
-  })
-}
-
 /**
  * Set up and manage the MarbleMadness Three.js scene, physics, and game loop.
  * @param deps - Canvas ref, solo flag, track config, win/position callbacks.
@@ -539,38 +302,20 @@ export const useMarbleMadnessGame = (deps: GameDeps) => {
   }
   let cleanupTools: (() => void) | null = null
   const ghostRegistry: GhostRegistry = { meshes: new Map(), scene: null }
-  let sceneReference: THREE.Scene | null = null
-  let worldReference: NonNullable<GetToolsResult['world']> | null = null
-  let cloudObjects: ComplexModel[] = []
   const currentActionsReference = ref<Record<string, unknown>>({})
-  const areaConfigs = ref<Record<string, Record<string, unknown>>>({})
 
   const buildGame = async ({ scene, world, camera, getDelta, animate, orbit }: SceneContext) => {
     if (!world) return
-    sceneReference = scene
     ghostRegistry.scene = scene
-    worldReference = world
     scene.fog = new THREE.FogExp2(FOG_COLOR, FOG_DENSITY)
     scene.background = new THREE.Color(FOG_COLOR)
     state.directionalLight =
       (scene.children.find((c) => c instanceof THREE.DirectionalLight) as THREE.DirectionalLight) ??
       null
     const track = deps.track.value
-    cloudObjects = setupCloudArea(scene, world, areaConfigs, (options) => {
-      if (!sceneReference || !worldReference) return
-      disposeClouds(cloudObjects, sceneReference, worldReference)
-      cloudObjects = buildCloudObjects(sceneReference, worldReference, options)
-    })
+    setupCloudArea(scene, world, () => {})
     buildCourse(scene, world, track)
-    state.groundSphereMesh = getBall(scene, undefined, {
-      size: GROUND_SPHERE_RADIUS,
-      position: GROUND_SPHERE_CENTER,
-      color: GROUND_SPHERE_COLOR,
-      segments: 64,
-      castShadow: false,
-      receiveShadow: false
-    })
-    state.groundSphereMesh.userData.skipEdgeLines = true
+    state.groundSphereMesh = addGroundSphereToScene(scene)
     registerGroundSphereProperties(state.groundSphereMesh)
     state.marbleMesh = getBall(scene, world, {
       size: MARBLE_RADIUS,
@@ -631,14 +376,9 @@ export const useMarbleMadnessGame = (deps: GameDeps) => {
     state.directionalLight = null
     ghostRegistry.meshes.clear()
     ghostRegistry.scene = null
-    sceneReference = null
-    worldReference = null
-    cloudObjects = []
     state.groundSphereMesh = null
-    useDebugSceneStore().removeSceneElement(CLOUD_AREA_NAME)
-    useDebugSceneStore().removeSceneElement('Ground')
-    useElementPropertiesStore().unregisterElementProperties(CLOUD_AREA_NAME)
-    useElementPropertiesStore().unregisterElementProperties('Ground')
+    teardownCloudArea()
+    teardownGroundSphere()
     if (cleanupTools) {
       cleanupTools()
       cleanupTools = null

--- a/src/views/Games/MarbleMadness/useMarbleMadnessRushGame.ts
+++ b/src/views/Games/MarbleMadness/useMarbleMadnessRushGame.ts
@@ -364,15 +364,7 @@ const initRushScene = async (
   ) as THREE.DirectionalLight | null
 
   state.controls = createControls({ mapping: KEYBOARD_MAPPING })
-  state.controls.onAction((action, actionState) => {
-    if (actionState === 'start')
-      reactives.currentActions.value = { ...reactives.currentActions.value, [action]: true }
-    else {
-      const next = { ...reactives.currentActions.value }
-      delete next[action]
-      reactives.currentActions.value = next
-    }
-  })
+  reactives.currentActions.value = state.controls.currentActions as unknown as ControlsCurrents
 
   const initialMeshes = spawnChunkMeshes(scene, world, [
     {
@@ -499,7 +491,8 @@ export const useMarbleMadnessRushGame = (deps: RushDeps) => {
   let state = makeInitialState()
 
   const init = (): void => {
-    if (deps.canvas.value) initRushScene(deps.canvas.value, deps, state, reactives)
+    if (deps.canvas.value)
+      initRushScene(deps.canvas.value, deps, state, reactives).catch(console.error)
   }
 
   const destroy = (): void => {

--- a/src/views/Games/MarbleMadness/useMarbleMadnessRushGame.ts
+++ b/src/views/Games/MarbleMadness/useMarbleMadnessRushGame.ts
@@ -17,6 +17,7 @@ import {
   createPhysicsSyncAction,
   createFallCheckAction
 } from '@/utils/gameTimelineActions'
+import { attachBallStroke, addEdgeLinesToScene } from './marbleVisuals'
 import {
   MARBLE_RADIUS,
   MARBLE_WEIGHT,
@@ -248,6 +249,7 @@ const spawnNextChunk = (
   })
   state.cursor = { z: endZ, x: state.cursor.x }
   state.chunkId += 1
+  addEdgeLinesToScene(scene)
 }
 
 const disposeChunk = (world: WorldReference, chunk: RushChunk): void => {
@@ -399,6 +401,8 @@ const initRushScene = async (
   }) as unknown as ComplexModel
   state.marble.userData.body.setLinearDamping(MARBLE_LINEAR_DAMPING)
   state.marble.userData.body.setAngularDamping(MARBLE_ANGULAR_DAMPING)
+  attachBallStroke(state.marble as unknown as THREE.Mesh)
+  addEdgeLinesToScene(scene)
 
   const timeline = createTimelineManager()
   timeline.addAction(createPhysicsSyncAction(() => state.marble, PLATFORM_HALF_HEIGHT))

--- a/src/views/Games/MarbleMadness/useMarbleMadnessRushGame.ts
+++ b/src/views/Games/MarbleMadness/useMarbleMadnessRushGame.ts
@@ -1,0 +1,528 @@
+import { ref, type Ref } from 'vue'
+import * as THREE from 'three'
+import {
+  getTools,
+  getBall,
+  getCube,
+  removeElements,
+  moveDynamic,
+  type ComplexModel
+} from '@webgamekit/threejs'
+import { createControls } from '@webgamekit/controls'
+import type { ControlsExtras, ControlsCurrents } from '@webgamekit/controls'
+import { createTimelineManager, type CoordinateTuple } from '@webgamekit/animation'
+import {
+  createCameraFollowAction,
+  createDirectionalLightFollowAction,
+  createPhysicsSyncAction,
+  createFallCheckAction
+} from '@/utils/gameTimelineActions'
+import {
+  MARBLE_RADIUS,
+  MARBLE_WEIGHT,
+  MARBLE_RESTITUTION,
+  MARBLE_FRICTION,
+  MARBLE_LINEAR_DAMPING,
+  MARBLE_ANGULAR_DAMPING,
+  MOVE_FORCE,
+  MAX_LINEAR_SPEED,
+  CAMERA_HEIGHT,
+  CAMERA_BACK,
+  FALL_THRESHOLD_Y,
+  KEYBOARD_MAPPING,
+  LIGHT_AMBIENT_INTENSITY,
+  LIGHT_DIRECTIONAL_INTENSITY,
+  LIGHT_DIRECTIONAL_POSITION,
+  LIGHT_SHADOW_RADIUS,
+  LIGHT_SHADOW_BIAS,
+  LIGHT_SHADOW_CAMERA,
+  PLATFORM_HALF_HEIGHT,
+  RUSH_COUNTDOWN,
+  RUSH_TIME_BONUS,
+  RUSH_FALL_PENALTY,
+  RUSH_LOOKAHEAD_Z,
+  RUSH_DISPOSE_BEHIND,
+  RUSH_MAX_DIFFICULTY_DISTANCE,
+  RUSH_BEST_KEY,
+  RUSH_SPAWN,
+  RUSH_PLATFORM_COLOR,
+  RUSH_BRIDGE_COLOR,
+  RUSH_PICKUP_COLOR,
+  RUSH_PICKUP_RADIUS,
+  RUSH_PICKUP_COLLECT_RADIUS,
+  RUSH_SKY_COLOR,
+  RUSH_FOG_DENSITY,
+  type PlatformDefinition
+} from './config'
+
+type UnwrapPromise<T> = T extends Promise<infer U> ? U : T
+type GetToolsResult = UnwrapPromise<ReturnType<typeof getTools>>
+type WorldReference = NonNullable<GetToolsResult['world']>
+
+export type RushDeps = {
+  canvas: Ref<HTMLCanvasElement | null>
+  marble: Ref<string>
+  onGameOver: () => void
+}
+
+type ChunkCursor = { z: number; x: number }
+
+type RushChunk = {
+  id: number
+  startZ: number
+  endZ: number
+  meshes: ComplexModel[]
+  pickupMesh: THREE.Mesh | null
+  pickupBaseY: number
+  pickupCollected: boolean
+}
+
+type ChunkBuildResult = {
+  platforms: PlatformDefinition[]
+  chunkLength: number
+  pickupCenterZ: number | null
+}
+
+type RushReactives = {
+  countdown: Ref<number>
+  distance: Ref<number>
+  bestDistance: Ref<number>
+  isNewBest: Ref<boolean>
+  finished: Ref<boolean>
+  penaltyCount: Ref<number>
+  currentActions: Ref<ControlsCurrents>
+}
+
+type RushGameState = {
+  cleanup: (() => void) | null
+  marble: ComplexModel | null
+  light: THREE.DirectionalLight | null
+  controls: ControlsExtras | null
+  chunks: RushChunk[]
+  cursor: ChunkCursor
+  chunkId: number
+  lastSafe: { x: number; y: number; z: number }
+}
+
+const CAMERA_OFFSET: CoordinateTuple = [0, CAMERA_HEIGHT, CAMERA_BACK]
+const INITIAL_CHUNK_Z_START = 4
+const INITIAL_CHUNK_LENGTH = 28
+const SAFE_Y_MIN = FALL_THRESHOLD_Y + 4
+const SAFE_VEL_Y_MAX = 2
+
+const pickupGeometry = new THREE.SphereGeometry(RUSH_PICKUP_RADIUS, 8, 8)
+const pickupMaterial = new THREE.MeshStandardMaterial({
+  color: RUSH_PICKUP_COLOR,
+  emissive: RUSH_PICKUP_COLOR,
+  emissiveIntensity: 0.5,
+  roughness: 0.3,
+  metalness: 0
+})
+
+const buildWide = (cursor: ChunkCursor): ChunkBuildResult => {
+  const length = 24
+  return {
+    platforms: [
+      {
+        size: [14, 1, length],
+        position: [cursor.x, 0, cursor.z - length / 2],
+        color: RUSH_PLATFORM_COLOR
+      }
+    ],
+    chunkLength: length,
+    pickupCenterZ: Math.random() < 0.6 ? cursor.z - length / 2 : null
+  }
+}
+
+const buildMedium = (cursor: ChunkCursor): ChunkBuildResult => {
+  const length = 20
+  return {
+    platforms: [
+      {
+        size: [10, 1, length],
+        position: [cursor.x, 0, cursor.z - length / 2],
+        color: RUSH_PLATFORM_COLOR
+      }
+    ],
+    chunkLength: length,
+    pickupCenterZ: Math.random() < 0.5 ? cursor.z - length / 2 : null
+  }
+}
+
+const buildNarrow = (cursor: ChunkCursor, difficulty: number): ChunkBuildResult => {
+  const width = Math.max(3, Math.round(7 - difficulty * 4))
+  const length = 20
+  return {
+    platforms: [
+      {
+        size: [width, 1, length],
+        position: [cursor.x, 0, cursor.z - length / 2],
+        color: RUSH_BRIDGE_COLOR
+      }
+    ],
+    chunkLength: length,
+    pickupCenterZ: Math.random() < 0.35 ? cursor.z - length / 2 : null
+  }
+}
+
+const buildGap = (cursor: ChunkCursor, difficulty: number): ChunkBuildResult => {
+  const gapSize = 1.5 + difficulty * 2.5
+  const landingLength = 10
+  const width = Math.max(6, Math.round(12 - difficulty * 6))
+  const landingCenterZ = cursor.z - gapSize - landingLength / 2
+  return {
+    platforms: [
+      {
+        size: [width, 1, landingLength],
+        position: [cursor.x, 0, landingCenterZ],
+        color: RUSH_PLATFORM_COLOR
+      }
+    ],
+    chunkLength: gapSize + landingLength,
+    pickupCenterZ: landingCenterZ
+  }
+}
+
+const selectChunkType = (difficulty: number): string => {
+  const r = Math.random()
+  if (difficulty < 0.25) return r < 0.65 ? 'wide' : 'medium'
+  if (difficulty < 0.5) return r < 0.3 ? 'wide' : r < 0.65 ? 'medium' : r < 0.85 ? 'narrow' : 'gap'
+  if (difficulty < 0.75) return r < 0.15 ? 'medium' : r < 0.55 ? 'narrow' : 'gap'
+  return r < 0.3 ? 'narrow' : 'gap'
+}
+
+const buildChunkResult = (cursor: ChunkCursor, difficulty: number): ChunkBuildResult => {
+  const type = selectChunkType(difficulty)
+  if (type === 'wide') return buildWide(cursor)
+  if (type === 'medium') return buildMedium(cursor)
+  if (type === 'narrow') return buildNarrow(cursor, difficulty)
+  return buildGap(cursor, difficulty)
+}
+
+const spawnChunkMeshes = (
+  scene: THREE.Scene,
+  world: WorldReference,
+  platforms: PlatformDefinition[]
+): ComplexModel[] =>
+  platforms.map(({ size, position, rotation, color }) =>
+    getCube(scene, world, {
+      size: size as CoordinateTuple,
+      position: position as CoordinateTuple,
+      rotation: rotation as CoordinateTuple | undefined,
+      type: 'fixed',
+      color,
+      friction: MARBLE_FRICTION,
+      restitution: MARBLE_RESTITUTION
+    })
+  )
+
+const spawnPickupMesh = (scene: THREE.Scene, x: number, y: number, centerZ: number): THREE.Mesh => {
+  const mesh = new THREE.Mesh(pickupGeometry, pickupMaterial)
+  mesh.position.set(x, y + 1.5, centerZ)
+  mesh.castShadow = true
+  scene.add(mesh)
+  return mesh
+}
+
+const spawnNextChunk = (
+  scene: THREE.Scene,
+  world: WorldReference,
+  state: RushGameState,
+  difficulty: number
+): void => {
+  const result = buildChunkResult(state.cursor, difficulty)
+  const meshes = spawnChunkMeshes(scene, world, result.platforms)
+  const endZ = state.cursor.z - result.chunkLength
+  const pickupMesh =
+    result.pickupCenterZ !== null
+      ? spawnPickupMesh(scene, state.cursor.x, 0, result.pickupCenterZ)
+      : null
+  state.chunks.push({
+    id: state.chunkId,
+    startZ: state.cursor.z,
+    endZ,
+    meshes,
+    pickupMesh,
+    pickupBaseY: pickupMesh?.position.y ?? 0,
+    pickupCollected: pickupMesh === null
+  })
+  state.cursor = { z: endZ, x: state.cursor.x }
+  state.chunkId += 1
+}
+
+const disposeChunk = (world: WorldReference, chunk: RushChunk): void => {
+  removeElements(world, chunk.meshes)
+  if (chunk.pickupMesh) chunk.pickupMesh.removeFromParent()
+}
+
+const pruneOldChunks = (world: WorldReference, state: RushGameState, marbleZ: number): void => {
+  const toDispose = state.chunks.filter((c) => marbleZ < c.endZ - RUSH_DISPOSE_BEHIND)
+  toDispose.forEach((c) => disposeChunk(world, c))
+  state.chunks = state.chunks.filter((c) => marbleZ >= c.endZ - RUSH_DISPOSE_BEHIND)
+}
+
+const ensureChunksAhead = (
+  scene: THREE.Scene,
+  world: WorldReference,
+  state: RushGameState,
+  marbleZ: number,
+  difficulty: number
+): void => {
+  if (state.cursor.z <= marbleZ - RUSH_LOOKAHEAD_Z) return
+  spawnNextChunk(scene, world, state, difficulty)
+  ensureChunksAhead(scene, world, state, marbleZ, difficulty)
+}
+
+const animatePickups = (chunks: RushChunk[], time: number): void => {
+  chunks.forEach((chunk) => {
+    if (chunk.pickupMesh && !chunk.pickupCollected) {
+      chunk.pickupMesh.position.y = chunk.pickupBaseY + Math.sin(time / 400) * 0.3
+      chunk.pickupMesh.rotation.y = time / 600
+    }
+  })
+}
+
+const checkPickupCollection = (
+  chunks: RushChunk[],
+  marblePos: THREE.Vector3,
+  countdown: Ref<number>
+): void => {
+  chunks.forEach((chunk) => {
+    if (chunk.pickupCollected || !chunk.pickupMesh) return
+    if (marblePos.distanceTo(chunk.pickupMesh.position) < RUSH_PICKUP_COLLECT_RADIUS) {
+      chunk.pickupMesh.removeFromParent()
+      chunk.pickupMesh = null
+      chunk.pickupCollected = true
+      countdown.value = Math.min(countdown.value + RUSH_TIME_BONUS, RUSH_COUNTDOWN * 2)
+    }
+  })
+}
+
+const updateLastSafePosition = (
+  state: RushGameState,
+  marblePos: THREE.Vector3,
+  velY: number
+): void => {
+  if (marblePos.y > SAFE_Y_MIN && Math.abs(velY) < SAFE_VEL_Y_MAX) {
+    state.lastSafe = { x: marblePos.x, y: marblePos.y, z: marblePos.z }
+  }
+}
+
+const respawnAtLastSafe = (
+  marble: ComplexModel,
+  lastSafe: { x: number; y: number; z: number }
+): void => {
+  const body = marble.userData.body
+  body.setTranslation({ x: lastSafe.x, y: lastSafe.y + 1, z: lastSafe.z }, true)
+  body.setLinvel({ x: 0, y: 0, z: 0 }, true)
+  body.setAngvel({ x: 0, y: 0, z: 0 }, true)
+}
+
+const computeImpulse = (actions: ControlsCurrents) => ({
+  x: ('left' in actions ? -MOVE_FORCE : 0) + ('right' in actions ? MOVE_FORCE : 0),
+  y: 0,
+  z: ('forward' in actions ? -MOVE_FORCE : 0) + ('backward' in actions ? MOVE_FORCE : 0)
+})
+
+const getRushSceneConfig = () => ({
+  camera: { position: [0, CAMERA_HEIGHT, CAMERA_BACK] as CoordinateTuple, fov: 60 },
+  lights: {
+    ambient: { color: 0xffffff, intensity: LIGHT_AMBIENT_INTENSITY },
+    directional: {
+      color: 0xffffff,
+      intensity: LIGHT_DIRECTIONAL_INTENSITY,
+      position: LIGHT_DIRECTIONAL_POSITION,
+      castShadow: true,
+      shadow: {
+        mapSize: { width: 2048, height: 2048 },
+        camera: LIGHT_SHADOW_CAMERA,
+        bias: LIGHT_SHADOW_BIAS,
+        radius: LIGHT_SHADOW_RADIUS
+      }
+    }
+  },
+  ground: false as const,
+  sky: false as const,
+  orbit: false as const
+})
+
+const initRushScene = async (
+  canvas: HTMLCanvasElement,
+  deps: RushDeps,
+  state: RushGameState,
+  reactives: RushReactives
+): Promise<void> => {
+  const tools = await getTools({ canvas })
+  state.cleanup = tools.cleanup
+  const { scene, world, camera, getDelta, animate } = tools
+  await tools.setup({ config: getRushSceneConfig() })
+
+  scene.background = new THREE.Color(RUSH_SKY_COLOR)
+  scene.fog = new THREE.FogExp2(RUSH_SKY_COLOR, RUSH_FOG_DENSITY)
+  state.light = scene.children.find(
+    (c) => c instanceof THREE.DirectionalLight
+  ) as THREE.DirectionalLight | null
+
+  state.controls = createControls({ mapping: KEYBOARD_MAPPING })
+  state.controls.onAction((action, actionState) => {
+    if (actionState === 'start')
+      reactives.currentActions.value = { ...reactives.currentActions.value, [action]: true }
+    else {
+      const next = { ...reactives.currentActions.value }
+      delete next[action]
+      reactives.currentActions.value = next
+    }
+  })
+
+  const initialMeshes = spawnChunkMeshes(scene, world, [
+    {
+      size: [14, 1, INITIAL_CHUNK_LENGTH],
+      position: [0, 0, INITIAL_CHUNK_Z_START - INITIAL_CHUNK_LENGTH / 2],
+      color: RUSH_PLATFORM_COLOR
+    }
+  ])
+  state.chunks.push({
+    id: 0,
+    startZ: INITIAL_CHUNK_Z_START,
+    endZ: INITIAL_CHUNK_Z_START - INITIAL_CHUNK_LENGTH,
+    meshes: initialMeshes,
+    pickupMesh: null,
+    pickupBaseY: 0,
+    pickupCollected: true
+  })
+  state.cursor = { z: INITIAL_CHUNK_Z_START - INITIAL_CHUNK_LENGTH, x: 0 }
+  state.chunkId = 1
+
+  state.marble = getBall(scene, world, {
+    size: MARBLE_RADIUS,
+    position: RUSH_SPAWN,
+    restitution: MARBLE_RESTITUTION,
+    friction: MARBLE_FRICTION,
+    weight: MARBLE_WEIGHT,
+    texture: deps.marble.value,
+    roughness: 0.08,
+    metalness: 0.2,
+    segments: 48,
+    type: 'dynamic'
+  }) as unknown as ComplexModel
+  state.marble.userData.body.setLinearDamping(MARBLE_LINEAR_DAMPING)
+  state.marble.userData.body.setAngularDamping(MARBLE_ANGULAR_DAMPING)
+
+  const timeline = createTimelineManager()
+  timeline.addAction(createPhysicsSyncAction(() => state.marble, PLATFORM_HALF_HEIGHT))
+  timeline.addAction(createCameraFollowAction(camera, () => state.marble, CAMERA_OFFSET))
+  timeline.addAction(
+    createDirectionalLightFollowAction(
+      () => state.light,
+      () => state.marble,
+      LIGHT_DIRECTIONAL_POSITION
+    )
+  )
+  timeline.addAction(
+    createFallCheckAction(
+      () => state.marble,
+      FALL_THRESHOLD_Y,
+      () => {
+        reactives.countdown.value = Math.max(0, reactives.countdown.value - RUSH_FALL_PENALTY)
+        reactives.penaltyCount.value += 1
+        if (state.marble) respawnAtLastSafe(state.marble, state.lastSafe)
+      }
+    )
+  )
+
+  const spawnZ = RUSH_SPAWN[2]
+  animate({
+    beforeTimeline: () => {
+      if (reactives.finished.value) return
+      const delta = getDelta()
+      reactives.countdown.value = Math.max(0, reactives.countdown.value - delta)
+      if (reactives.countdown.value <= 0) {
+        reactives.finished.value = true
+        const finalDistance = reactives.distance.value
+        if (finalDistance > reactives.bestDistance.value) {
+          reactives.isNewBest.value = true
+          reactives.bestDistance.value = finalDistance
+          localStorage.setItem(RUSH_BEST_KEY, String(finalDistance))
+        }
+        deps.onGameOver()
+        return
+      }
+      if (state.marble) {
+        const pos = state.marble.position
+        reactives.distance.value = Math.max(reactives.distance.value, Math.max(0, spawnZ - pos.z))
+        const velY = state.marble.userData.body?.linvel?.()?.y ?? 0
+        updateLastSafePosition(state, pos, velY)
+        checkPickupCollection(state.chunks, pos, reactives.countdown)
+        const difficulty = Math.min(1, reactives.distance.value / RUSH_MAX_DIFFICULTY_DISTANCE)
+        pruneOldChunks(world, state, pos.z)
+        ensureChunksAhead(scene, world, state, pos.z, difficulty)
+        animatePickups(state.chunks, Date.now())
+      }
+      if (state.controls && state.marble) {
+        const impulse = computeImpulse(state.controls.currentActions)
+        if (impulse.x !== 0 || impulse.z !== 0) moveDynamic(state.marble, impulse, MAX_LINEAR_SPEED)
+      }
+    },
+    timeline
+  })
+}
+
+const makeInitialState = (): RushGameState => ({
+  cleanup: null,
+  marble: null,
+  light: null,
+  controls: null,
+  chunks: [],
+  cursor: { z: INITIAL_CHUNK_Z_START - INITIAL_CHUNK_LENGTH, x: 0 },
+  chunkId: 0,
+  lastSafe: { x: RUSH_SPAWN[0], y: RUSH_SPAWN[1], z: RUSH_SPAWN[2] }
+})
+
+export const useMarbleMadnessRushGame = (deps: RushDeps) => {
+  const countdown = ref(RUSH_COUNTDOWN)
+  const distance = ref(0)
+  const bestDistance = ref<number>(parseInt(localStorage.getItem(RUSH_BEST_KEY) ?? '0', 10))
+  const isNewBest = ref(false)
+  const finished = ref(false)
+  const penaltyCount = ref(0)
+  const currentActions = ref<ControlsCurrents>({})
+
+  const reactives: RushReactives = {
+    countdown,
+    distance,
+    bestDistance,
+    isNewBest,
+    finished,
+    penaltyCount,
+    currentActions
+  }
+  let state = makeInitialState()
+
+  const init = (): void => {
+    if (deps.canvas.value) initRushScene(deps.canvas.value, deps, state, reactives)
+  }
+
+  const destroy = (): void => {
+    state.controls?.destroyControls()
+    if (state.cleanup) state.cleanup()
+    state = makeInitialState()
+    countdown.value = RUSH_COUNTDOWN
+    distance.value = 0
+    isNewBest.value = false
+    finished.value = false
+    penaltyCount.value = 0
+    currentActions.value = {}
+  }
+
+  return {
+    countdown,
+    distance,
+    bestDistance,
+    isNewBest,
+    finished,
+    penaltyCount,
+    currentActions,
+    init,
+    destroy
+  }
+}

--- a/src/views/Games/MarbleMadness/useMarbleMadnessRushGame.ts
+++ b/src/views/Games/MarbleMadness/useMarbleMadnessRushGame.ts
@@ -53,6 +53,8 @@ import {
   RUSH_PICKUP_COLLECT_RADIUS,
   RUSH_SKY_COLOR,
   RUSH_FOG_DENSITY,
+  RUSH_GAP_MIN,
+  RUSH_GAP_MAX,
   type PlatformDefinition
 } from './config'
 
@@ -167,7 +169,7 @@ const buildNarrow = (cursor: ChunkCursor, difficulty: number): ChunkBuildResult 
 }
 
 const buildGap = (cursor: ChunkCursor, difficulty: number): ChunkBuildResult => {
-  const gapSize = 1.5 + difficulty * 2.5
+  const gapSize = RUSH_GAP_MIN + difficulty * (RUSH_GAP_MAX - RUSH_GAP_MIN)
   const landingLength = 10
   const width = Math.max(6, Math.round(12 - difficulty * 6))
   const landingCenterZ = cursor.z - gapSize - landingLength / 2

--- a/src/views/Games/MarbleMadness/useMarbleMadnessRushGame.ts
+++ b/src/views/Games/MarbleMadness/useMarbleMadnessRushGame.ts
@@ -15,9 +15,18 @@ import {
   createCameraFollowAction,
   createDirectionalLightFollowAction,
   createPhysicsSyncAction,
-  createFallCheckAction
+  createFallCheckAction,
+  createMeshFollowAction,
+  type TimelineAction
 } from '@/utils/gameTimelineActions'
 import { attachBallStroke, addEdgeLinesToScene } from './marbleVisuals'
+import {
+  addGroundSphereToScene,
+  registerGroundSphereProperties,
+  teardownGroundSphere,
+  createCloudChunkManager,
+  type CloudChunkManager
+} from './marbleEnvironment'
 import {
   MARBLE_RADIUS,
   MARBLE_WEIGHT,
@@ -48,6 +57,7 @@ import {
   RUSH_SPAWN,
   RUSH_PLATFORM_COLOR,
   RUSH_BRIDGE_COLOR,
+  RUSH_OBSTACLE_COLOR,
   RUSH_PICKUP_COLOR,
   RUSH_PICKUP_RADIUS,
   RUSH_PICKUP_COLLECT_RADIUS,
@@ -60,7 +70,31 @@ import {
   RUSH_NARROW_X_DRIFT,
   RUSH_GAP_X_DRIFT,
   RUSH_MAX_X_OFFSET,
-  type PlatformDefinition
+  RUSH_SLOPE_ANGLE,
+  RUSH_SLOPE_LENGTH,
+  RUSH_RAMP_ANGLE,
+  RUSH_RAMP_LENGTH,
+  RUSH_MIN_Y,
+  RUSH_MAX_Y,
+  RUSH_OBSTACLE_SIZE,
+  RUSH_OBSTACLE_LIFT,
+  RUSH_CLOUD_CHUNK_LENGTH,
+  RUSH_CLOUD_LOOKAHEAD_Z,
+  RUSH_CLOUD_DISPOSE_BEHIND,
+  RUSH_CLOUD_COUNT_PER_CHUNK,
+  RUSH_GROUND_FOLLOW_OFFSET_Z,
+  RUSH_MOVING_PLATFORM_CHANCE,
+  RUSH_MOVING_OBSTACLE_CHANCE,
+  RUSH_MOVING_PICKUP_CHANCE,
+  RUSH_PLATFORM_SWAY_X,
+  RUSH_PLATFORM_BOB_Y,
+  RUSH_OBSTACLE_SWAY,
+  RUSH_PICKUP_SWAY,
+  RUSH_PLATFORM_CYCLE_MS,
+  RUSH_OBSTACLE_CYCLE_MS,
+  RUSH_PICKUP_CYCLE_MS,
+  type PlatformDefinition,
+  type ObstacleDefinition
 } from './config'
 
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T
@@ -73,23 +107,56 @@ export type RushDeps = {
   onGameOver: () => void
 }
 
-type ChunkCursor = { z: number; x: number }
+type ChunkCursor = { z: number; x: number; y: number }
+
+type MotionAxis = 'x' | 'y' | 'z'
+
+type MotionSpec = {
+  axis: MotionAxis
+  amplitude: number
+  cycleMs: number
+  phaseOffset: number
+}
+
+type MotionState = MotionSpec & {
+  base: { x: number; y: number; z: number }
+}
+
+type KinematicBody = {
+  setNextKinematicTranslation: (pos: { x: number; y: number; z: number }) => void
+}
+
+type ChunkMotion = {
+  body: KinematicBody | null
+  mesh: THREE.Object3D
+  state: MotionState
+}
+
+type RushPlatform = PlatformDefinition & { motion?: MotionSpec }
+type RushObstacle = ObstacleDefinition & { motion?: MotionSpec }
 
 type RushChunk = {
   id: number
   startZ: number
   endZ: number
   meshes: ComplexModel[]
+  motions: ChunkMotion[]
   pickupMesh: THREE.Mesh | null
   pickupBaseY: number
+  pickupBaseX: number
+  pickupMotion: MotionState | null
   pickupCollected: boolean
 }
 
 type ChunkBuildResult = {
-  platforms: PlatformDefinition[]
+  platforms: RushPlatform[]
+  obstacles?: RushObstacle[]
   chunkLength: number
   pickupCenterZ: number | null
+  pickupY?: number
+  pickupMotion?: MotionSpec
   maxXDrift: number
+  nextY?: number
 }
 
 type RushReactives = {
@@ -112,6 +179,8 @@ type RushGameState = {
   cursor: ChunkCursor
   chunkId: number
   lastSafe: { x: number; y: number; z: number }
+  groundSphereMesh: THREE.Mesh | null
+  cloudManager: CloudChunkManager | null
 }
 
 const CAMERA_OFFSET: CoordinateTuple = [0, CAMERA_HEIGHT, CAMERA_BACK]
@@ -129,18 +198,59 @@ const pickupMaterial = new THREE.MeshStandardMaterial({
   metalness: 0
 })
 
+const TWO_PI = Math.PI * 2
+
+const randomPhase = (): number => Math.random() * TWO_PI
+
+const rollPlatformMotion = (): MotionSpec | undefined => {
+  if (Math.random() >= RUSH_MOVING_PLATFORM_CHANCE) return undefined
+  const axis: MotionAxis = Math.random() < 0.7 ? 'x' : 'y'
+  return {
+    axis,
+    amplitude: axis === 'x' ? RUSH_PLATFORM_SWAY_X : RUSH_PLATFORM_BOB_Y,
+    cycleMs: RUSH_PLATFORM_CYCLE_MS,
+    phaseOffset: randomPhase()
+  }
+}
+
+const rollObstacleMotion = (): MotionSpec | undefined => {
+  if (Math.random() >= RUSH_MOVING_OBSTACLE_CHANCE) return undefined
+  return {
+    axis: 'x',
+    amplitude: RUSH_OBSTACLE_SWAY,
+    cycleMs: RUSH_OBSTACLE_CYCLE_MS,
+    phaseOffset: randomPhase()
+  }
+}
+
+const rollPickupMotion = (): MotionSpec | undefined => {
+  if (Math.random() >= RUSH_MOVING_PICKUP_CHANCE) return undefined
+  return {
+    axis: Math.random() < 0.5 ? 'x' : 'z',
+    amplitude: RUSH_PICKUP_SWAY,
+    cycleMs: RUSH_PICKUP_CYCLE_MS,
+    phaseOffset: randomPhase()
+  }
+}
+
+const computeMotionOffset = (state: MotionState, time: number): number =>
+  state.amplitude * Math.sin((time / state.cycleMs) * TWO_PI + state.phaseOffset)
+
 const buildWide = (cursor: ChunkCursor): ChunkBuildResult => {
   const length = 24
   return {
     platforms: [
       {
         size: [14, 1, length],
-        position: [cursor.x, 0, cursor.z - length / 2],
-        color: RUSH_PLATFORM_COLOR
+        position: [cursor.x, cursor.y, cursor.z - length / 2],
+        color: RUSH_PLATFORM_COLOR,
+        motion: rollPlatformMotion()
       }
     ],
     chunkLength: length,
-    pickupCenterZ: Math.random() < 0.6 ? cursor.z - length / 2 : null,
+    pickupCenterZ: Math.random() < 0.06 ? cursor.z - length / 2 : null,
+    pickupY: cursor.y + 1.5,
+    pickupMotion: rollPickupMotion(),
     maxXDrift: RUSH_WIDE_X_DRIFT
   }
 }
@@ -151,12 +261,15 @@ const buildMedium = (cursor: ChunkCursor): ChunkBuildResult => {
     platforms: [
       {
         size: [10, 1, length],
-        position: [cursor.x, 0, cursor.z - length / 2],
-        color: RUSH_PLATFORM_COLOR
+        position: [cursor.x, cursor.y, cursor.z - length / 2],
+        color: RUSH_PLATFORM_COLOR,
+        motion: rollPlatformMotion()
       }
     ],
     chunkLength: length,
-    pickupCenterZ: Math.random() < 0.5 ? cursor.z - length / 2 : null,
+    pickupCenterZ: Math.random() < 0.05 ? cursor.z - length / 2 : null,
+    pickupY: cursor.y + 1.5,
+    pickupMotion: rollPickupMotion(),
     maxXDrift: RUSH_MEDIUM_X_DRIFT
   }
 }
@@ -168,12 +281,15 @@ const buildNarrow = (cursor: ChunkCursor, difficulty: number): ChunkBuildResult 
     platforms: [
       {
         size: [width, 1, length],
-        position: [cursor.x, 0, cursor.z - length / 2],
-        color: RUSH_BRIDGE_COLOR
+        position: [cursor.x, cursor.y, cursor.z - length / 2],
+        color: RUSH_BRIDGE_COLOR,
+        motion: rollPlatformMotion()
       }
     ],
     chunkLength: length,
-    pickupCenterZ: Math.random() < 0.35 ? cursor.z - length / 2 : null,
+    pickupCenterZ: Math.random() < 0.035 ? cursor.z - length / 2 : null,
+    pickupY: cursor.y + 1.5,
+    pickupMotion: rollPickupMotion(),
     maxXDrift: RUSH_NARROW_X_DRIFT
   }
 }
@@ -187,13 +303,119 @@ const buildGap = (cursor: ChunkCursor, difficulty: number): ChunkBuildResult => 
     platforms: [
       {
         size: [width, 1, landingLength],
-        position: [cursor.x, 0, landingCenterZ],
-        color: RUSH_PLATFORM_COLOR
+        position: [cursor.x, cursor.y, landingCenterZ],
+        color: RUSH_PLATFORM_COLOR,
+        motion: rollPlatformMotion()
       }
     ],
     chunkLength: gapSize + landingLength,
-    pickupCenterZ: landingCenterZ,
+    pickupCenterZ: Math.random() < 0.1 ? landingCenterZ : null,
+    pickupY: cursor.y + 1.5,
+    pickupMotion: rollPickupMotion(),
     maxXDrift: RUSH_GAP_X_DRIFT
+  }
+}
+
+const buildSlopeDown = (cursor: ChunkCursor): ChunkBuildResult => {
+  const length = RUSH_SLOPE_LENGTH
+  const angle = RUSH_SLOPE_ANGLE
+  const drop = length * Math.sin(angle)
+  const centerY = cursor.y - (length / 2) * Math.sin(angle)
+  const centerZ = cursor.z - length / 2
+  return {
+    platforms: [
+      {
+        size: [7, 1, length],
+        position: [cursor.x, centerY, centerZ],
+        color: RUSH_BRIDGE_COLOR,
+        rotation: [-angle, 0, 0]
+      }
+    ],
+    chunkLength: length,
+    pickupCenterZ: Math.random() < 0.04 ? centerZ : null,
+    pickupY: centerY + 1.5,
+    pickupMotion: rollPickupMotion(),
+    nextY: Math.max(RUSH_MIN_Y, cursor.y - drop),
+    maxXDrift: RUSH_NARROW_X_DRIFT
+  }
+}
+
+const buildSlopeUp = (cursor: ChunkCursor): ChunkBuildResult => {
+  const length = RUSH_SLOPE_LENGTH
+  const angle = RUSH_SLOPE_ANGLE
+  const rise = length * Math.sin(angle)
+  const centerY = cursor.y + (length / 2) * Math.sin(angle)
+  const centerZ = cursor.z - length / 2
+  return {
+    platforms: [
+      {
+        size: [7, 1, length],
+        position: [cursor.x, centerY, centerZ],
+        color: RUSH_BRIDGE_COLOR,
+        rotation: [angle, 0, 0]
+      }
+    ],
+    chunkLength: length,
+    pickupCenterZ: Math.random() < 0.04 ? centerZ : null,
+    pickupY: centerY + 1.5,
+    pickupMotion: rollPickupMotion(),
+    nextY: Math.min(RUSH_MAX_Y, cursor.y + rise),
+    maxXDrift: RUSH_NARROW_X_DRIFT
+  }
+}
+
+const buildRamp = (cursor: ChunkCursor): ChunkBuildResult => {
+  const length = RUSH_RAMP_LENGTH
+  const angle = RUSH_RAMP_ANGLE
+  const rise = length * Math.sin(angle)
+  const centerY = cursor.y + (length / 2) * Math.sin(angle)
+  const centerZ = cursor.z - length / 2
+  return {
+    platforms: [
+      {
+        size: [8, 1, length],
+        position: [cursor.x, centerY, centerZ],
+        color: RUSH_BRIDGE_COLOR,
+        rotation: [angle, 0, 0]
+      }
+    ],
+    chunkLength: length,
+    pickupCenterZ: Math.random() < 0.1 ? centerZ : null,
+    pickupY: centerY + 1.5,
+    pickupMotion: rollPickupMotion(),
+    nextY: Math.min(RUSH_MAX_Y, cursor.y + rise),
+    maxXDrift: RUSH_WIDE_X_DRIFT
+  }
+}
+
+const buildObstacleCorridor = (cursor: ChunkCursor, difficulty: number): ChunkBuildResult => {
+  const length = 22
+  const obstacleCount = 2 + Math.floor(difficulty * 2)
+  const spacing = length / (obstacleCount + 1)
+  const obstacles: RushObstacle[] = Array.from({ length: obstacleCount }, (_, i) => {
+    const offsetZ = -(spacing * (i + 1))
+    const offsetX = (i % 2 === 0 ? -1 : 1) * (1.5 + Math.random())
+    return {
+      size: RUSH_OBSTACLE_SIZE,
+      position: [cursor.x + offsetX, cursor.y + RUSH_OBSTACLE_LIFT, cursor.z + offsetZ],
+      motion: rollObstacleMotion()
+    }
+  })
+  return {
+    platforms: [
+      {
+        size: [11, 1, length],
+        position: [cursor.x, cursor.y, cursor.z - length / 2],
+        color: RUSH_PLATFORM_COLOR,
+        motion: rollPlatformMotion()
+      }
+    ],
+    obstacles,
+    chunkLength: length,
+    pickupCenterZ: Math.random() < 0.1 ? cursor.z - length / 2 : null,
+    pickupY: cursor.y + 1.5,
+    pickupMotion: rollPickupMotion(),
+    maxXDrift: RUSH_MEDIUM_X_DRIFT
   }
 }
 
@@ -205,42 +427,137 @@ const computeNextX = (currentX: number, maxDrift: number): number => {
   return next
 }
 
-const selectChunkType = (difficulty: number): string => {
+type ChunkWeight = { threshold: number; type: string }
+
+const TIER_EASY: ChunkWeight[] = [
+  { threshold: 0.45, type: 'wide' },
+  { threshold: 0.75, type: 'medium' },
+  { threshold: 0.9, type: 'slope-down' },
+  { threshold: 1, type: 'obstacle' }
+]
+
+const TIER_MEDIUM: ChunkWeight[] = [
+  { threshold: 0.2, type: 'wide' },
+  { threshold: 0.4, type: 'medium' },
+  { threshold: 0.55, type: 'narrow' },
+  { threshold: 0.65, type: 'gap' },
+  { threshold: 0.8, type: 'slope-down' },
+  { threshold: 0.9, type: 'ramp' },
+  { threshold: 1, type: 'obstacle' }
+]
+
+const TIER_HARD: ChunkWeight[] = [
+  { threshold: 0.12, type: 'medium' },
+  { threshold: 0.32, type: 'narrow' },
+  { threshold: 0.5, type: 'gap' },
+  { threshold: 0.65, type: 'slope-down' },
+  { threshold: 0.8, type: 'ramp' },
+  { threshold: 0.95, type: 'slope-up' },
+  { threshold: 1, type: 'obstacle' }
+]
+
+const TIER_EXPERT: ChunkWeight[] = [
+  { threshold: 0.22, type: 'narrow' },
+  { threshold: 0.45, type: 'gap' },
+  { threshold: 0.65, type: 'ramp' },
+  { threshold: 0.8, type: 'slope-down' },
+  { threshold: 0.92, type: 'slope-up' },
+  { threshold: 1, type: 'obstacle' }
+]
+
+const pickTier = (difficulty: number): ChunkWeight[] => {
+  if (difficulty < 0.25) return TIER_EASY
+  if (difficulty < 0.5) return TIER_MEDIUM
+  if (difficulty < 0.75) return TIER_HARD
+  return TIER_EXPERT
+}
+
+const selectChunkType = (difficulty: number, cursor: ChunkCursor): string => {
+  if (cursor.y <= RUSH_MIN_Y + 0.5) return Math.random() < 0.5 ? 'ramp' : 'slope-up'
   const r = Math.random()
-  if (difficulty < 0.25) return r < 0.65 ? 'wide' : 'medium'
-  if (difficulty < 0.5) return r < 0.3 ? 'wide' : r < 0.65 ? 'medium' : r < 0.85 ? 'narrow' : 'gap'
-  if (difficulty < 0.75) return r < 0.15 ? 'medium' : r < 0.55 ? 'narrow' : 'gap'
-  return r < 0.3 ? 'narrow' : 'gap'
+  const tier = pickTier(difficulty)
+  return tier.find((entry) => r < entry.threshold)?.type ?? tier[tier.length - 1].type
 }
 
 const buildChunkResult = (cursor: ChunkCursor, difficulty: number): ChunkBuildResult => {
-  const type = selectChunkType(difficulty)
+  const type = selectChunkType(difficulty, cursor)
   if (type === 'wide') return buildWide(cursor)
   if (type === 'medium') return buildMedium(cursor)
   if (type === 'narrow') return buildNarrow(cursor, difficulty)
+  if (type === 'slope-down') return buildSlopeDown(cursor)
+  if (type === 'slope-up') return buildSlopeUp(cursor)
+  if (type === 'ramp') return buildRamp(cursor)
+  if (type === 'obstacle') return buildObstacleCorridor(cursor, difficulty)
   return buildGap(cursor, difficulty)
 }
 
-const spawnChunkMeshes = (
+type SpawnedChunkParts = { meshes: ComplexModel[]; motions: ChunkMotion[] }
+
+const toMotionState = (motion: MotionSpec, position: CoordinateTuple): MotionState => ({
+  ...motion,
+  base: { x: position[0], y: position[1], z: position[2] }
+})
+
+const spawnPlatform = (
   scene: THREE.Scene,
   world: WorldReference,
-  platforms: PlatformDefinition[]
-): ComplexModel[] =>
-  platforms.map(({ size, position, rotation, color }) =>
-    getCube(scene, world, {
-      size: size as CoordinateTuple,
-      position: position as CoordinateTuple,
-      rotation: rotation as CoordinateTuple | undefined,
-      type: 'fixed',
-      color,
-      friction: MARBLE_FRICTION,
-      restitution: MARBLE_RESTITUTION
-    })
-  )
+  platform: RushPlatform
+): { mesh: ComplexModel; motion: ChunkMotion | null } => {
+  const { size, position, rotation, color, motion } = platform
+  const mesh = getCube(scene, world, {
+    size: size as CoordinateTuple,
+    position: position as CoordinateTuple,
+    rotation: rotation as CoordinateTuple | undefined,
+    type: motion ? 'kinematicPositionBased' : 'fixed',
+    color,
+    friction: MARBLE_FRICTION,
+    restitution: MARBLE_RESTITUTION
+  })
+  const motionEntry = motion
+    ? { body: mesh.userData.body as KinematicBody, mesh, state: toMotionState(motion, position) }
+    : null
+  return { mesh, motion: motionEntry }
+}
+
+const spawnObstacle = (
+  scene: THREE.Scene,
+  world: WorldReference,
+  obstacle: RushObstacle
+): { mesh: ComplexModel; motion: ChunkMotion | null } => {
+  const { size, position, motion } = obstacle
+  const mesh = getCube(scene, world, {
+    size: size as CoordinateTuple,
+    position: position as CoordinateTuple,
+    type: motion ? 'kinematicPositionBased' : 'fixed',
+    color: RUSH_OBSTACLE_COLOR,
+    friction: 0.5,
+    restitution: 0.1
+  })
+  const motionEntry = motion
+    ? { body: mesh.userData.body as KinematicBody, mesh, state: toMotionState(motion, position) }
+    : null
+  return { mesh, motion: motionEntry }
+}
+
+const spawnChunkParts = (
+  scene: THREE.Scene,
+  world: WorldReference,
+  platforms: RushPlatform[],
+  obstacles: RushObstacle[] = []
+): SpawnedChunkParts => {
+  const spawned = [
+    ...platforms.map((p) => spawnPlatform(scene, world, p)),
+    ...obstacles.map((o) => spawnObstacle(scene, world, o))
+  ]
+  return {
+    meshes: spawned.map((s) => s.mesh),
+    motions: spawned.flatMap((s) => (s.motion ? [s.motion] : []))
+  }
+}
 
 const spawnPickupMesh = (scene: THREE.Scene, x: number, y: number, centerZ: number): THREE.Mesh => {
   const mesh = new THREE.Mesh(pickupGeometry, pickupMaterial)
-  mesh.position.set(x, y + 1.5, centerZ)
+  mesh.position.set(x, y, centerZ)
   mesh.castShadow = true
   scene.add(mesh)
   return mesh
@@ -253,22 +570,38 @@ const spawnNextChunk = (
   difficulty: number
 ): void => {
   const result = buildChunkResult(state.cursor, difficulty)
-  const meshes = spawnChunkMeshes(scene, world, result.platforms)
+  const { meshes, motions } = spawnChunkParts(scene, world, result.platforms, result.obstacles)
   const endZ = state.cursor.z - result.chunkLength
+  const pickupY = result.pickupY ?? state.cursor.y + 1.5
   const pickupMesh =
     result.pickupCenterZ !== null
-      ? spawnPickupMesh(scene, state.cursor.x, 0, result.pickupCenterZ)
+      ? spawnPickupMesh(scene, state.cursor.x, pickupY, result.pickupCenterZ)
+      : null
+  const pickupMotion =
+    pickupMesh && result.pickupMotion
+      ? toMotionState(result.pickupMotion, [
+          state.cursor.x,
+          pickupY,
+          result.pickupCenterZ as number
+        ])
       : null
   state.chunks.push({
     id: state.chunkId,
     startZ: state.cursor.z,
     endZ,
     meshes,
+    motions,
     pickupMesh,
     pickupBaseY: pickupMesh?.position.y ?? 0,
+    pickupBaseX: pickupMesh?.position.x ?? 0,
+    pickupMotion,
     pickupCollected: pickupMesh === null
   })
-  state.cursor = { z: endZ, x: computeNextX(state.cursor.x, result.maxXDrift) }
+  state.cursor = {
+    z: endZ,
+    x: computeNextX(state.cursor.x, result.maxXDrift),
+    y: result.nextY ?? state.cursor.y
+  }
   state.chunkId += 1
   addEdgeLinesToScene(scene)
 }
@@ -298,12 +631,45 @@ const ensureChunksAhead = (
 
 const animatePickups = (chunks: RushChunk[], time: number): void => {
   chunks.forEach((chunk) => {
-    if (chunk.pickupMesh && !chunk.pickupCollected) {
-      chunk.pickupMesh.position.y = chunk.pickupBaseY + Math.sin(time / 400) * 0.3
-      chunk.pickupMesh.rotation.y = time / 600
+    if (!chunk.pickupMesh || chunk.pickupCollected) return
+    chunk.pickupMesh.position.y = chunk.pickupBaseY + Math.sin(time / 400) * 0.3
+    chunk.pickupMesh.rotation.y = time / 600
+    if (chunk.pickupMotion) {
+      const offset = computeMotionOffset(chunk.pickupMotion, time)
+      if (chunk.pickupMotion.axis === 'x') {
+        chunk.pickupMesh.position.x = chunk.pickupBaseX + offset
+      } else if (chunk.pickupMotion.axis === 'z') {
+        chunk.pickupMesh.position.z = chunk.pickupMotion.base.z + offset
+      }
     }
   })
 }
+
+const applyChunkMotions = (chunks: RushChunk[], time: number): void => {
+  chunks.forEach((chunk) => {
+    chunk.motions.forEach((entry) => {
+      const offset = computeMotionOffset(entry.state, time)
+      const pos = { x: entry.state.base.x, y: entry.state.base.y, z: entry.state.base.z }
+      pos[entry.state.axis] += offset
+      entry.body?.setNextKinematicTranslation(pos)
+      entry.mesh.position.set(pos.x, pos.y, pos.z)
+    })
+  })
+}
+
+const createChunkMotionAction = (getChunks: () => RushChunk[]): TimelineAction => ({
+  name: 'chunk-motion',
+  category: 'physics',
+  start: 0,
+  action: () => applyChunkMotions(getChunks(), Date.now())
+})
+
+const createPickupAnimationAction = (getChunks: () => RushChunk[]): TimelineAction => ({
+  name: 'pickup-animation',
+  category: 'visual',
+  start: 0,
+  action: () => animatePickups(getChunks(), Date.now())
+})
 
 const checkPickupCollection = (
   chunks: RushChunk[],
@@ -350,7 +716,13 @@ const computeImpulse = (actions: ControlsCurrents) => ({
 })
 
 const getRushSceneConfig = () => ({
-  camera: { position: [0, CAMERA_HEIGHT, CAMERA_BACK] as CoordinateTuple, fov: 60 },
+  camera: {
+    position: [
+      RUSH_SPAWN[0],
+      RUSH_SPAWN[1] + CAMERA_HEIGHT,
+      RUSH_SPAWN[2] + CAMERA_BACK
+    ] as CoordinateTuple
+  },
   lights: {
     ambient: { color: 0xffffff, intensity: LIGHT_AMBIENT_INTENSITY },
     directional: {
@@ -391,7 +763,7 @@ const initRushScene = async (
   state.controls = createControls({ mapping: KEYBOARD_MAPPING })
   reactives.currentActions.value = state.controls.currentActions as unknown as ControlsCurrents
 
-  const initialMeshes = spawnChunkMeshes(scene, world, [
+  const initial = spawnChunkParts(scene, world, [
     {
       size: [14, 1, INITIAL_CHUNK_LENGTH],
       position: [0, 0, INITIAL_CHUNK_Z_START - INITIAL_CHUNK_LENGTH / 2],
@@ -402,12 +774,15 @@ const initRushScene = async (
     id: 0,
     startZ: INITIAL_CHUNK_Z_START,
     endZ: INITIAL_CHUNK_Z_START - INITIAL_CHUNK_LENGTH,
-    meshes: initialMeshes,
+    meshes: initial.meshes,
+    motions: initial.motions,
     pickupMesh: null,
     pickupBaseY: 0,
+    pickupBaseX: 0,
+    pickupMotion: null,
     pickupCollected: true
   })
-  state.cursor = { z: INITIAL_CHUNK_Z_START - INITIAL_CHUNK_LENGTH, x: 0 }
+  state.cursor = { z: INITIAL_CHUNK_Z_START - INITIAL_CHUNK_LENGTH, x: 0, y: 0 }
   state.chunkId = 1
 
   state.marble = getBall(scene, world, {
@@ -427,7 +802,18 @@ const initRushScene = async (
   attachBallStroke(state.marble as unknown as THREE.Mesh)
   addEdgeLinesToScene(scene)
 
+  state.cloudManager = createCloudChunkManager(scene, world, {
+    chunkLength: RUSH_CLOUD_CHUNK_LENGTH,
+    countPerChunk: RUSH_CLOUD_COUNT_PER_CHUNK,
+    lookaheadZ: RUSH_CLOUD_LOOKAHEAD_Z,
+    disposeBehindZ: RUSH_CLOUD_DISPOSE_BEHIND
+  })
+  state.cloudManager.ensureAhead(RUSH_SPAWN[2])
+  state.groundSphereMesh = addGroundSphereToScene(scene)
+  registerGroundSphereProperties(state.groundSphereMesh)
+
   const timeline = createTimelineManager()
+  timeline.addAction(createChunkMotionAction(() => state.chunks))
   timeline.addAction(createPhysicsSyncAction(() => state.marble, PLATFORM_HALF_HEIGHT))
   timeline.addAction(createCameraFollowAction(camera, () => state.marble, CAMERA_OFFSET))
   timeline.addAction(
@@ -437,11 +823,20 @@ const initRushScene = async (
       LIGHT_DIRECTIONAL_POSITION
     )
   )
+  timeline.addAction(createPickupAnimationAction(() => state.chunks))
+  timeline.addAction(
+    createMeshFollowAction(
+      () => state.groundSphereMesh,
+      () => state.marble,
+      RUSH_GROUND_FOLLOW_OFFSET_Z
+    )
+  )
   timeline.addAction(
     createFallCheckAction(
       () => state.marble,
       FALL_THRESHOLD_Y,
       () => {
+        if (reactives.finished.value) return
         reactives.countdown.value = Math.max(0, reactives.countdown.value - RUSH_FALL_PENALTY)
         reactives.penaltyCount.value += 1
         if (state.marble) respawnAtLastSafe(state.marble, state.lastSafe)
@@ -475,7 +870,10 @@ const initRushScene = async (
         const difficulty = Math.min(1, reactives.distance.value / RUSH_MAX_DIFFICULTY_DISTANCE)
         pruneOldChunks(world, state, pos.z)
         ensureChunksAhead(scene, world, state, pos.z, difficulty)
-        animatePickups(state.chunks, Date.now())
+        if (state.cloudManager) {
+          state.cloudManager.ensureAhead(pos.z)
+          state.cloudManager.prune(pos.z)
+        }
       }
       if (state.controls && state.marble) {
         const impulse = computeImpulse(state.controls.currentActions)
@@ -492,9 +890,11 @@ const makeInitialState = (): RushGameState => ({
   light: null,
   controls: null,
   chunks: [],
-  cursor: { z: INITIAL_CHUNK_Z_START - INITIAL_CHUNK_LENGTH, x: 0 },
+  cursor: { z: INITIAL_CHUNK_Z_START - INITIAL_CHUNK_LENGTH, x: 0, y: 0 },
   chunkId: 0,
-  lastSafe: { x: RUSH_SPAWN[0], y: RUSH_SPAWN[1], z: RUSH_SPAWN[2] }
+  lastSafe: { x: RUSH_SPAWN[0], y: RUSH_SPAWN[1], z: RUSH_SPAWN[2] },
+  groundSphereMesh: null,
+  cloudManager: null
 })
 
 export const useMarbleMadnessRushGame = (deps: RushDeps) => {
@@ -526,7 +926,11 @@ export const useMarbleMadnessRushGame = (deps: RushDeps) => {
 
   const destroy = (): void => {
     state.controls?.destroyControls()
-    if (state.cleanup) state.cleanup()
+    if (state.cleanup) {
+      state.cloudManager?.teardown()
+      teardownGroundSphere()
+      state.cleanup()
+    }
     state = makeInitialState()
     countdown.value = RUSH_COUNTDOWN
     distance.value = 0

--- a/src/views/Games/MarbleMadness/useMarbleMadnessRushGame.ts
+++ b/src/views/Games/MarbleMadness/useMarbleMadnessRushGame.ts
@@ -55,6 +55,11 @@ import {
   RUSH_FOG_DENSITY,
   RUSH_GAP_MIN,
   RUSH_GAP_MAX,
+  RUSH_WIDE_X_DRIFT,
+  RUSH_MEDIUM_X_DRIFT,
+  RUSH_NARROW_X_DRIFT,
+  RUSH_GAP_X_DRIFT,
+  RUSH_MAX_X_OFFSET,
   type PlatformDefinition
 } from './config'
 
@@ -84,6 +89,7 @@ type ChunkBuildResult = {
   platforms: PlatformDefinition[]
   chunkLength: number
   pickupCenterZ: number | null
+  maxXDrift: number
 }
 
 type RushReactives = {
@@ -93,6 +99,7 @@ type RushReactives = {
   isNewBest: Ref<boolean>
   finished: Ref<boolean>
   penaltyCount: Ref<number>
+  pickupCount: Ref<number>
   currentActions: Ref<ControlsCurrents>
 }
 
@@ -133,7 +140,8 @@ const buildWide = (cursor: ChunkCursor): ChunkBuildResult => {
       }
     ],
     chunkLength: length,
-    pickupCenterZ: Math.random() < 0.6 ? cursor.z - length / 2 : null
+    pickupCenterZ: Math.random() < 0.6 ? cursor.z - length / 2 : null,
+    maxXDrift: RUSH_WIDE_X_DRIFT
   }
 }
 
@@ -148,7 +156,8 @@ const buildMedium = (cursor: ChunkCursor): ChunkBuildResult => {
       }
     ],
     chunkLength: length,
-    pickupCenterZ: Math.random() < 0.5 ? cursor.z - length / 2 : null
+    pickupCenterZ: Math.random() < 0.5 ? cursor.z - length / 2 : null,
+    maxXDrift: RUSH_MEDIUM_X_DRIFT
   }
 }
 
@@ -164,7 +173,8 @@ const buildNarrow = (cursor: ChunkCursor, difficulty: number): ChunkBuildResult 
       }
     ],
     chunkLength: length,
-    pickupCenterZ: Math.random() < 0.35 ? cursor.z - length / 2 : null
+    pickupCenterZ: Math.random() < 0.35 ? cursor.z - length / 2 : null,
+    maxXDrift: RUSH_NARROW_X_DRIFT
   }
 }
 
@@ -182,8 +192,17 @@ const buildGap = (cursor: ChunkCursor, difficulty: number): ChunkBuildResult => 
       }
     ],
     chunkLength: gapSize + landingLength,
-    pickupCenterZ: landingCenterZ
+    pickupCenterZ: landingCenterZ,
+    maxXDrift: RUSH_GAP_X_DRIFT
   }
+}
+
+const computeNextX = (currentX: number, maxDrift: number): number => {
+  const drift = (Math.random() * 2 - 1) * maxDrift
+  const next = currentX + drift
+  if (next > RUSH_MAX_X_OFFSET) return RUSH_MAX_X_OFFSET * 2 - next
+  if (next < -RUSH_MAX_X_OFFSET) return -RUSH_MAX_X_OFFSET * 2 - next
+  return next
 }
 
 const selectChunkType = (difficulty: number): string => {
@@ -249,7 +268,7 @@ const spawnNextChunk = (
     pickupBaseY: pickupMesh?.position.y ?? 0,
     pickupCollected: pickupMesh === null
   })
-  state.cursor = { z: endZ, x: state.cursor.x }
+  state.cursor = { z: endZ, x: computeNextX(state.cursor.x, result.maxXDrift) }
   state.chunkId += 1
   addEdgeLinesToScene(scene)
 }
@@ -289,7 +308,8 @@ const animatePickups = (chunks: RushChunk[], time: number): void => {
 const checkPickupCollection = (
   chunks: RushChunk[],
   marblePos: THREE.Vector3,
-  countdown: Ref<number>
+  countdown: Ref<number>,
+  pickupCount: Ref<number>
 ): void => {
   chunks.forEach((chunk) => {
     if (chunk.pickupCollected || !chunk.pickupMesh) return
@@ -298,6 +318,7 @@ const checkPickupCollection = (
       chunk.pickupMesh = null
       chunk.pickupCollected = true
       countdown.value = Math.min(countdown.value + RUSH_TIME_BONUS, RUSH_COUNTDOWN * 2)
+      pickupCount.value += 1
     }
   })
 }
@@ -450,7 +471,7 @@ const initRushScene = async (
         reactives.distance.value = Math.max(reactives.distance.value, Math.max(0, spawnZ - pos.z))
         const velY = state.marble.userData.body?.linvel?.()?.y ?? 0
         updateLastSafePosition(state, pos, velY)
-        checkPickupCollection(state.chunks, pos, reactives.countdown)
+        checkPickupCollection(state.chunks, pos, reactives.countdown, reactives.pickupCount)
         const difficulty = Math.min(1, reactives.distance.value / RUSH_MAX_DIFFICULTY_DISTANCE)
         pruneOldChunks(world, state, pos.z)
         ensureChunksAhead(scene, world, state, pos.z, difficulty)
@@ -483,6 +504,7 @@ export const useMarbleMadnessRushGame = (deps: RushDeps) => {
   const isNewBest = ref(false)
   const finished = ref(false)
   const penaltyCount = ref(0)
+  const pickupCount = ref(0)
   const currentActions = ref<ControlsCurrents>({})
 
   const reactives: RushReactives = {
@@ -492,6 +514,7 @@ export const useMarbleMadnessRushGame = (deps: RushDeps) => {
     isNewBest,
     finished,
     penaltyCount,
+    pickupCount,
     currentActions
   }
   let state = makeInitialState()
@@ -510,6 +533,7 @@ export const useMarbleMadnessRushGame = (deps: RushDeps) => {
     isNewBest.value = false
     finished.value = false
     penaltyCount.value = 0
+    pickupCount.value = 0
     currentActions.value = {}
   }
 
@@ -520,6 +544,7 @@ export const useMarbleMadnessRushGame = (deps: RushDeps) => {
     isNewBest,
     finished,
     penaltyCount,
+    pickupCount,
     currentActions,
     init,
     destroy


### PR DESCRIPTION
Closes #172

## Summary

- New **Rush** game mode added to the existing Marble Madness game (accessible via `?game=MarbleMadness`)
- 30-second countdown timer; clock pickups scattered on the track add +3s
- Falling subtracts 5s and respawns at the last safe position
- Score = distance in meters; personal best saved to localStorage
- Procedurally generated infinite track: wide/medium/narrow/gap chunks with difficulty scaling from 0→1 over 400m
- Lobby shows a Race/Rush mode picker (solo only — multiplayer always forces Race)
- Rush HUD: countdown centered top (turns red below 10s), distance top-right, penalty shows `-5s`
- Summary screen shows distance and best distance for Rush mode

## Key Changes

- `config.ts` — Rush constants + rename `PlatformDef` → `PlatformDefinition`
- `types.ts` — `GameMode = 'race' | 'rush'`
- `useMarbleMadnessRushGame.ts` — new composable; module-level helpers + `RushGameState` object keep the exported function under the 150-line lint limit; `ensureChunksAhead` uses recursion instead of a `while` loop
- `useMarbleMadnessGame.ts` — import `PLATFORM_HALF_HEIGHT` from config (was re-declared locally); resolve rebase conflict preserving stroke-outline code from #171
- `MarbleMadnessGame.vue` — `mode` prop, Rush-specific HUD
- `MarbleMadnessSummary.vue` — Rush summary (distance + best)
- `MarbleMadnessLobby.vue` — Race/Rush toggle
- `MarbleMadness.vue` — wire `gameMode`, `rushGame` composable, phase watch
- `packages/threejs/src/core.ts` — fix TS2551: cast to concrete camera type before `updateProjectionMatrix()`

## Test Plan

- [ ] Open `?game=MarbleMadness`, verify Race mode works as before
- [ ] Switch to Rush in the lobby, start solo — ball spawns on a blue platform, countdown starts
- [ ] Roll forward, verify chunks generate ahead and old chunks are pruned
- [ ] Pick up a clock orb, verify countdown increases
- [ ] Fall off, verify -5s penalty and respawn at last safe position
- [ ] Let timer reach 0, verify summary shows distance + best
- [ ] Restart Rush, verify fresh countdown and distance reset
- [ ] Verify CI passes (build + lint + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)