### PR TITLE
feat: LobbyUI showcase — focus polish + drop dropdown edit-mode

### DIFF
--- a/src/assets/styles/lobby-ui.scss
+++ b/src/assets/styles/lobby-ui.scss
@@ -43,6 +43,11 @@
   // checkbox box). Matches the text-shadow vocabulary: solid black, no blur.
   --lui-border-shadow: 3px 3px 0 #000;
 
+  // Focus highlight color. Applied to the text fill of simple controls
+  // (text input, dropdown value, number value) and to the border / box fill
+  // of complex controls (button, toggle option, checkbox).
+  --lui-focus-color: #ffd700;
+
   // Inverted variation — white text on a black "chip" background. The text
   // shadow is preserved so the inverted text still has depth/legibility.
   --lui-text-color-inverted: #fff;

--- a/src/components/LobbyUI/LobbyUIButton.vue
+++ b/src/components/LobbyUI/LobbyUIButton.vue
@@ -65,7 +65,8 @@ withDefaults(
 
 .lui-btn:focus,
 .lui-btn:focus-visible {
-  outline: 3px solid #ffd700;
-  outline-offset: 4px;
+  outline: none;
+  border-color: var(--lui-focus-color);
+  color: var(--lui-focus-color);
 }
 </style>

--- a/src/components/LobbyUI/LobbyUIColorSwatches.vue
+++ b/src/components/LobbyUI/LobbyUIColorSwatches.vue
@@ -51,12 +51,15 @@ const emit = defineEmits<{
   transition: transform 0.1s ease;
 }
 
-.lui-swatch:hover,
+.lui-swatch:hover {
+  transform: scale(1.15);
+}
+
 .lui-swatch:focus,
 .lui-swatch:focus-visible {
+  outline: none;
   transform: scale(1.15);
-  outline: 3px solid #ffd700;
-  outline-offset: 4px;
+  border-color: var(--lui-focus-color);
 }
 
 .lui-swatch--active {

--- a/src/components/LobbyUI/LobbyUIConfigField.vue
+++ b/src/components/LobbyUI/LobbyUIConfigField.vue
@@ -61,16 +61,15 @@ const onChange = (field: LobbyConfigField, event: Event): void => {
   width: 4rem;
 }
 
-.lui-field__control:hover,
-.lui-field__control:focus,
-.lui-field__control:focus-visible {
+.lui-field__control:hover {
   border-bottom-color: var(--lui-stroke);
 }
 
 .lui-field__control:focus,
 .lui-field__control:focus-visible {
-  outline: 3px solid #ffd700;
-  outline-offset: 4px;
+  outline: none;
+  color: var(--lui-focus-color);
+  border-bottom-color: var(--lui-focus-color);
 }
 
 .lui-field__control option {

--- a/src/components/LobbyUI/LobbyUIImageGrid.vue
+++ b/src/components/LobbyUI/LobbyUIImageGrid.vue
@@ -102,8 +102,9 @@ const selectedName = (): string =>
 
 .lui-grid__btn:focus,
 .lui-grid__btn:focus-visible {
-  outline: 3px solid #ffd700;
-  outline-offset: 4px;
+  outline: none;
+  transform: scale(1.2);
+  border-color: var(--lui-focus-color);
 }
 
 .lui-grid__btn--disabled {

--- a/src/components/LobbyUI/LobbyUINameInput.vue
+++ b/src/components/LobbyUI/LobbyUINameInput.vue
@@ -53,11 +53,15 @@ const onInput = (event: Event): void => {
   text-shadow: var(--lui-text-shadow);
 }
 
-.lui-name-input:hover,
+.lui-name-input:hover {
+  border-bottom-color: var(--lui-stroke);
+}
+
 .lui-name-input:focus,
 .lui-name-input:focus-visible {
-  border-bottom-color: var(--lui-stroke);
   outline: none;
-  box-shadow: 0 0 0 3px #ffd700;
+  color: var(--lui-focus-color);
+  border-bottom-color: var(--lui-focus-color);
+  caret-color: var(--lui-focus-color);
 }
 </style>

--- a/src/components/LobbyUI/LobbyUIOptionToggle.vue
+++ b/src/components/LobbyUI/LobbyUIOptionToggle.vue
@@ -55,7 +55,8 @@ const emit = defineEmits<{
 
 .lui-toggle__btn:focus,
 .lui-toggle__btn:focus-visible {
-  outline: 3px solid #ffd700;
-  outline-offset: 4px;
+  outline: none;
+  border-color: var(--lui-focus-color);
+  color: var(--lui-focus-color);
 }
 </style>

--- a/src/components/LobbyUI/LobbyUIPrivateToggle.vue
+++ b/src/components/LobbyUI/LobbyUIPrivateToggle.vue
@@ -54,7 +54,12 @@ const handleChange = (event: Event): void => {
 
 .lui-private__native:focus + .lui-private__box,
 .lui-private__native:focus-visible + .lui-private__box {
-  outline: 3px solid #ffd700;
-  outline-offset: 4px;
+  outline: none;
+  border-color: var(--lui-focus-color);
+}
+
+.lui-private__native:focus + .lui-private__box.lui-private__box--checked,
+.lui-private__native:focus-visible + .lui-private__box.lui-private__box--checked {
+  background: var(--lui-focus-color);
 }
 </style>

--- a/src/composables/useMenuNavigation.ts
+++ b/src/composables/useMenuNavigation.ts
@@ -77,21 +77,30 @@ const announceGamepad = (event: GamepadEvent): void => {
   )
 }
 
+export type MenuSource = 'keyboard' | 'gamepad'
+
+const sourceOf = (rawSource: string | undefined): MenuSource =>
+  rawSource === 'gamepad' || rawSource === 'gamepad-axis' ? 'gamepad' : 'keyboard'
+
 /**
  * Registers a callback for menu-style navigation events emitted by either the
  * keyboard arrow cluster or a connected gamepad's d-pad / left stick / A / B.
  * Filters out unmapped inputs so the handler only ever sees known MenuActions.
- * @param handler Called with the semantic action whenever a navigation input fires.
+ * @param handler Called with the semantic action and its originating input source.
  * @returns Object with `destroy()` for manual teardown; the composable also cleans up on unmount.
  */
-export function useMenuNavigation(handler: (action: MenuAction) => void): { destroy: () => void } {
+export function useMenuNavigation(handler: (action: MenuAction, source: MenuSource) => void): {
+  destroy: () => void
+} {
   let controls: ControlsExtras | null = null
 
   const setup = (): void => {
     controls = createControls({
       mapping: MENU_MAPPING,
-      onAction: (action) => {
-        if (MENU_ACTIONS.has(action as MenuAction)) handler(action as MenuAction)
+      onAction: (action, _key, rawSource) => {
+        if (MENU_ACTIONS.has(action as MenuAction)) {
+          handler(action as MenuAction, sourceOf(rawSource as string | undefined))
+        }
       }
     })
     window.addEventListener('keydown', preventScrollKeys)

--- a/src/views/Tests/LobbyUIShowcase/LobbyUIShowcase.vue
+++ b/src/views/Tests/LobbyUIShowcase/LobbyUIShowcase.vue
@@ -15,7 +15,11 @@ import {
 import { PLAYER_COLORS } from '@/utils/playerProfile'
 import { MARBLE_OPTIONS } from '@/views/Games/MarbleMadness/config'
 import { loadGoogleFont, removeGoogleFont } from '@/utils/ui'
-import { useMenuNavigation, type MenuAction } from '@/composables/useMenuNavigation'
+import {
+  useMenuNavigation,
+  type MenuAction,
+  type MenuSource
+} from '@/composables/useMenuNavigation'
 import type { LobbyConfigField, LobbyPlayer } from '@/types/lobbyWizard'
 
 type Screen = 'lobby' | 'results'
@@ -54,14 +58,26 @@ type HintRect = { top: number; left: number; width: number; height: number }
 type HintPart = { glyph: string; label: string }
 
 const focusedHint = ref<{ rect: HintRect; parts: HintPart[] } | null>(null)
+type LocalInputSource = MenuSource | 'mouse'
+const inputSource = ref<LocalInputSource | null>(null)
+// Element currently in "edit mode" — Up/Down cycles its value while held here.
+// Only populated for <select> and <input type="number">.
+const editing = ref<HTMLElement | null>(null)
 
 const HINT_GAP_PX = 12
+
+const isEditing = (element: HTMLElement | null): boolean => !!element && editing.value === element
 
 const describeControl = (element: HTMLElement): HintPart[] => {
   if (element instanceof HTMLInputElement) {
     if (element.type === 'checkbox') return [{ glyph: '✕', label: 'Toggle' }]
-    if (element.type === 'number') return [{ glyph: '✕', label: 'Confirm' }]
+    if (element.type === 'number') {
+      return [{ glyph: '✕', label: isEditing(element) ? 'Confirm' : 'Change' }]
+    }
     return [{ glyph: '✕', label: 'Edit' }]
+  }
+  if (element instanceof HTMLSelectElement) {
+    return [{ glyph: '✕', label: isEditing(element) ? 'Confirm' : 'Change' }]
   }
   return [{ glyph: '✕', label: 'Confirm' }]
 }
@@ -115,6 +131,9 @@ const cycleSelect = (select: HTMLSelectElement, direction: 1 | -1): void => {
 }
 
 const moveRow = (delta: number, rowCount: number): void => {
+  // Leaving a row always exits edit mode — Up/Down on a dropdown/number when
+  // not editing falls through to row navigation, so this is the natural exit.
+  editing.value = null
   focusRow.value = Math.min(Math.max(focusRow.value + delta, 0), rowCount - 1)
   focusCol.value = 0
   applyFocus()
@@ -122,6 +141,7 @@ const moveRow = (delta: number, rowCount: number): void => {
 
 const moveCol = (delta: number, row: HTMLElement | undefined): void => {
   if (!row) return
+  editing.value = null
   const focusables = queryFocusables(row)
   focusCol.value = Math.min(Math.max(focusCol.value + delta, 0), focusables.length - 1)
   applyFocus()
@@ -152,39 +172,43 @@ const refreshDiagnostics = (): void => {
   }
 }
 
-const handleNumberAction = (
-  input: HTMLInputElement,
-  action: MenuAction,
-  rowCount: number
-): boolean => {
+const handleNumberAction = (input: HTMLInputElement, action: MenuAction): boolean => {
+  if (!isEditing(input)) {
+    if (action === 'activate') {
+      editing.value = input
+      updateFocusedHint(input)
+      return true
+    }
+    return false // up/down fall through to row nav
+  }
   if (action === 'up' || action === 'down') {
     bumpNumberInput(input, action === 'up' ? 1 : -1)
     return true
   }
   if (action === 'activate') {
-    // X confirms the cycled value and exits focus-trap by moving down a row,
-    // matching the dropdown UX. Native browser stepping never fires because
-    // arrow keys are preventDefault'd by useMenuNavigation.
-    moveRow(1, rowCount)
+    editing.value = null
+    updateFocusedHint(input)
     return true
   }
   return false
 }
 
-const handleSelectAction = (
-  select: HTMLSelectElement,
-  action: MenuAction,
-  rowCount: number
-): boolean => {
+const handleSelectAction = (select: HTMLSelectElement, action: MenuAction): boolean => {
+  if (!isEditing(select)) {
+    if (action === 'activate') {
+      editing.value = select
+      updateFocusedHint(select)
+      return true
+    }
+    return false // up/down fall through to row nav
+  }
   if (action === 'up' || action === 'down') {
     cycleSelect(select, action === 'down' ? 1 : -1)
     return true
   }
   if (action === 'activate') {
-    // X confirms the currently-cycled value and exits the dropdown's
-    // focus-trap mode by moving down to the next row. The native picker is
-    // never invoked, so the dropdown stays closed throughout.
-    moveRow(1, rowCount)
+    editing.value = null
+    updateFocusedHint(select)
     return true
   }
   return false
@@ -194,23 +218,20 @@ const handleSelectAction = (
  * Returns true if the action was consumed by control-specific handling and the
  * row/col navigation should be skipped.
  */
-const handleControlAction = (
-  active: Element | null,
-  action: MenuAction,
-  rowCount: number
-): boolean => {
+const handleControlAction = (active: Element | null, action: MenuAction): boolean => {
   if (isTextInput(active) && (action === 'left' || action === 'right')) return true
-  if (isNumberInput(active)) return handleNumberAction(active, action, rowCount)
-  if (isSelect(active)) return handleSelectAction(active, action, rowCount)
+  if (isNumberInput(active)) return handleNumberAction(active, action)
+  if (isSelect(active)) return handleSelectAction(active, action)
   return false
 }
 
-const handleMenu = (action: MenuAction): void => {
+const handleMenu = (action: MenuAction, source: MenuSource): void => {
+  inputSource.value = source
   lastAction.value = action
   lastActionCount.value += 1
   const active = document.activeElement
   const rows = queryRows()
-  if (!rows.length || handleControlAction(active, action, rows.length)) {
+  if (!rows.length || handleControlAction(active, action)) {
     refreshDiagnostics()
     return
   }
@@ -246,11 +267,17 @@ const onWindowFocus = (): void => {
   if (active instanceof HTMLElement) updateFocusedHint(active)
 }
 
+const onMouseActivity = (): void => {
+  inputSource.value = 'mouse'
+}
+
 onMounted(() => {
   window.addEventListener('gamepadconnected', onGamepadConnected)
   window.addEventListener('gamepaddisconnected', onGamepadDisconnected)
   window.addEventListener('blur', onWindowBlur)
   window.addEventListener('focus', onWindowFocus)
+  window.addEventListener('mousedown', onMouseActivity)
+  window.addEventListener('mousemove', onMouseActivity, { passive: true })
 })
 
 onUnmounted(() => {
@@ -258,6 +285,8 @@ onUnmounted(() => {
   window.removeEventListener('gamepaddisconnected', onGamepadDisconnected)
   window.removeEventListener('blur', onWindowBlur)
   window.removeEventListener('focus', onWindowFocus)
+  window.removeEventListener('mousedown', onMouseActivity)
+  window.removeEventListener('mousemove', onMouseActivity)
 })
 
 useMenuNavigation(handleMenu)
@@ -433,7 +462,7 @@ const isMarbleAvailable = (_id: string): boolean => true
     </main>
 
     <div
-      v-if="focusedHint"
+      v-if="focusedHint && inputSource === 'gamepad'"
       class="lui-showcase__hint"
       aria-hidden="true"
       :style="{
@@ -556,7 +585,7 @@ const isMarbleAvailable = (_id: string): boolean => true
   font-size: var(--lui-text-small);
   line-height: 1;
   color: #000;
-  background: #ffd700;
+  background: var(--lui-focus-color);
   padding-inline: 0.7em;
   padding-block: 0.4em;
   border-radius: 999px;

--- a/src/views/Tests/LobbyUIShowcase/LobbyUIShowcase.vue
+++ b/src/views/Tests/LobbyUIShowcase/LobbyUIShowcase.vue
@@ -60,25 +60,21 @@ type HintPart = { glyph: string; label: string }
 const focusedHint = ref<{ rect: HintRect; parts: HintPart[] } | null>(null)
 type LocalInputSource = MenuSource | 'mouse'
 const inputSource = ref<LocalInputSource | null>(null)
-// Element currently in "edit mode" — Up/Down cycles its value while held here.
-// Only populated for <select> and <input type="number">.
-const editing = ref<HTMLElement | null>(null)
 
 const HINT_GAP_PX = 12
 
-const isEditing = (element: HTMLElement | null): boolean => !!element && editing.value === element
+const CYCLE_HINT_PARTS: HintPart[] = [
+  { glyph: '↕', label: 'Change' },
+  { glyph: '✕', label: 'Confirm' }
+]
 
 const describeControl = (element: HTMLElement): HintPart[] => {
   if (element instanceof HTMLInputElement) {
     if (element.type === 'checkbox') return [{ glyph: '✕', label: 'Toggle' }]
-    if (element.type === 'number') {
-      return [{ glyph: '✕', label: isEditing(element) ? 'Confirm' : 'Change' }]
-    }
+    if (element.type === 'number') return CYCLE_HINT_PARTS
     return [{ glyph: '✕', label: 'Edit' }]
   }
-  if (element instanceof HTMLSelectElement) {
-    return [{ glyph: '✕', label: isEditing(element) ? 'Confirm' : 'Change' }]
-  }
+  if (element instanceof HTMLSelectElement) return CYCLE_HINT_PARTS
   return [{ glyph: '✕', label: 'Confirm' }]
 }
 
@@ -131,9 +127,6 @@ const cycleSelect = (select: HTMLSelectElement, direction: 1 | -1): void => {
 }
 
 const moveRow = (delta: number, rowCount: number): void => {
-  // Leaving a row always exits edit mode — Up/Down on a dropdown/number when
-  // not editing falls through to row navigation, so this is the natural exit.
-  editing.value = null
   focusRow.value = Math.min(Math.max(focusRow.value + delta, 0), rowCount - 1)
   focusCol.value = 0
   applyFocus()
@@ -141,7 +134,6 @@ const moveRow = (delta: number, rowCount: number): void => {
 
 const moveCol = (delta: number, row: HTMLElement | undefined): void => {
   if (!row) return
-  editing.value = null
   const focusables = queryFocusables(row)
   focusCol.value = Math.min(Math.max(focusCol.value + delta, 0), focusables.length - 1)
   applyFocus()
@@ -172,43 +164,33 @@ const refreshDiagnostics = (): void => {
   }
 }
 
-const handleNumberAction = (input: HTMLInputElement, action: MenuAction): boolean => {
-  if (!isEditing(input)) {
-    if (action === 'activate') {
-      editing.value = input
-      updateFocusedHint(input)
-      return true
-    }
-    return false // up/down fall through to row nav
-  }
+const handleNumberAction = (
+  input: HTMLInputElement,
+  action: MenuAction,
+  rowCount: number
+): boolean => {
   if (action === 'up' || action === 'down') {
     bumpNumberInput(input, action === 'up' ? 1 : -1)
     return true
   }
   if (action === 'activate') {
-    editing.value = null
-    updateFocusedHint(input)
+    moveRow(1, rowCount)
     return true
   }
   return false
 }
 
-const handleSelectAction = (select: HTMLSelectElement, action: MenuAction): boolean => {
-  if (!isEditing(select)) {
-    if (action === 'activate') {
-      editing.value = select
-      updateFocusedHint(select)
-      return true
-    }
-    return false // up/down fall through to row nav
-  }
+const handleSelectAction = (
+  select: HTMLSelectElement,
+  action: MenuAction,
+  rowCount: number
+): boolean => {
   if (action === 'up' || action === 'down') {
     cycleSelect(select, action === 'down' ? 1 : -1)
     return true
   }
   if (action === 'activate') {
-    editing.value = null
-    updateFocusedHint(select)
+    moveRow(1, rowCount)
     return true
   }
   return false
@@ -218,10 +200,14 @@ const handleSelectAction = (select: HTMLSelectElement, action: MenuAction): bool
  * Returns true if the action was consumed by control-specific handling and the
  * row/col navigation should be skipped.
  */
-const handleControlAction = (active: Element | null, action: MenuAction): boolean => {
+const handleControlAction = (
+  active: Element | null,
+  action: MenuAction,
+  rowCount: number
+): boolean => {
   if (isTextInput(active) && (action === 'left' || action === 'right')) return true
-  if (isNumberInput(active)) return handleNumberAction(active, action)
-  if (isSelect(active)) return handleSelectAction(active, action)
+  if (isNumberInput(active)) return handleNumberAction(active, action, rowCount)
+  if (isSelect(active)) return handleSelectAction(active, action, rowCount)
   return false
 }
 
@@ -231,7 +217,7 @@ const handleMenu = (action: MenuAction, source: MenuSource): void => {
   lastActionCount.value += 1
   const active = document.activeElement
   const rows = queryRows()
-  if (!rows.length || handleControlAction(active, action)) {
+  if (!rows.length || handleControlAction(active, action, rows.length)) {
     refreshDiagnostics()
     return
   }


### PR DESCRIPTION
Closes #178

## Summary
Second round of LobbyUI showcase UX polish, on top of the kit that landed in #175. Bundles the focus-style overhaul (in-place yellow + gamepad-only confirmation chip) that was drafted on the old PR branch but never merged, plus a follow-up that drops the dropdown / number-input "edit-mode trap" in favor of direct Up/Down cycling.

## Key Changes
### Focus styling (commit 1)
- New `--lui-focus-color` token in `lobby-ui.scss` (yellow `#ffd700`)
- Every LobbyUI component now signals focus by re-coloring its own border, text, or box fill in yellow instead of layering a generic outline ring. Text-bearing controls flip text + underline; box-like controls flip border (and box fill for the checked checkbox)
- Confirmation chip renders only when the most recent input was a gamepad press — keyboard and mouse navigation is left with only the native focus state
- Mouse activity (mousedown / mousemove) flips the source tracker off-gamepad immediately
- `useMenuNavigation` exposes a `MenuSource` ('keyboard' | 'gamepad') as the handler's second arg

### Cycle behavior (commit 2)
- Up/Down on a focused `<select>` or number input cycles the value in place — no need to press X first to enter an "edit mode"
- X confirms and moves down to the next row
- The confirmation chip on dropdowns / number inputs becomes a two-part hint: `↕ Change   ✕ Confirm`
- Removes the `editing` ref + `isEditing` helper from the showcase script

## Test plan
- [ ] `pnpm test:unit`, `pnpm lint`, `pnpm type-check` pass
- [ ] Visit `/tests/LobbyUIShowcase` with mouse → no overlay chip
- [ ] Tab through with keyboard arrows → no chip, native focus visible
- [ ] Navigate with a connected DualShock / Xbox / Switch gamepad → yellow chip appears flush against focused control
- [ ] Track dropdown + Laps number input cycle on Up/Down, commit + advance on X
- [ ] Each focusable shows yellow in place rather than the previous outline ring

🤖 Generated with [Claude Code](https://claude.com/claude-code)