### PR TITLE
fix(#188): use modern Sass compiler API (drop legacy JS API)

### DIFF
--- a/documentation/docs/journey/sass-modern-api.md
+++ b/documentation/docs/journey/sass-modern-api.md
@@ -1,0 +1,46 @@
+---
+sidebar_position: 107
+---
+
+# Moving Off the Deprecated Sass Legacy JS API
+
+## The symptom
+
+A deploy build printed the Sass **legacy JS API** deprecation warning
+(`https://sass-lang.com/d/legacy-js-api`) and a run then fell over with an
+unhandled `ECONNRESET`. The two looked related because they appeared together,
+but they are different layers: the warning is about how SCSS is compiled, the
+socket error comes from the deploy environment.
+
+## What was actually happening
+
+The project compiles its `.scss` with pure Dart Sass (`sass`), and Vite was
+calling it through the **legacy** JavaScript API by default — Dart Sass has
+deprecated that API and will remove it in version 2. Nothing in the repo's own
+build scripts opens a socket (the route pre-render step is plain file I/O), so
+the `ECONNRESET` is raised by the deploy transport, not the build. Staying on the
+deprecated compiler path is still the thing to fix: it is the warning the deploy
+surfaced, and the modern API is the supported, more robust route.
+
+```mermaid
+flowchart LR
+    A[vite build] --> B{SCSS api set?}
+    B -- no --> C[Legacy JS API\ndeprecation warning]
+    B -- modern-compiler --> D[Modern Dart Sass API\nno warning]
+    A -. unrelated .-> E[Deploy transport\nECONNRESET]
+```
+
+## The fix
+
+Vite is told to use the modern compiler API for SCSS, and `sass` is pinned as an
+explicit dev dependency rather than relied on transitively. The build then
+compiles cleanly with no deprecation warning.
+
+## Guarding against regression
+
+Importing the whole Vite config inside the test runner is unreliable — under the
+jsdom environment it trips an esbuild `TextEncoder` invariant, and the config
+also pulls in plugins that have no business loading during a unit test. So the
+regression test reads the config **as source** and asserts the modern Sass API is
+configured. It is a deliberately shallow check, but it is exactly enough to stop
+the legacy API silently creeping back in a future edit.

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "postcss": "^8.5.6",
     "prettier": "^3.0.3",
     "radix-vue": "^1.9.17",
+    "sass": "^1.97.3",
     "sharp": "^0.34.5",
     "size-limit": "^12.1.0",
     "stylelint": "^17.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       radix-vue:
         specifier: ^1.9.17
         version: 1.9.17(vue@3.5.25(typescript@5.4.5))
+      sass:
+        specifier: ^1.97.3
+        version: 1.97.3
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -5270,7 +5273,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.5.6
       '@parcel/watcher-darwin-arm64': 2.5.6

--- a/vite.config.test.ts
+++ b/vite.config.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Importing the full Vite config pulls in plugins/esbuild that misbehave under
+// jsdom, so this guards the setting at the source level instead: it must keep
+// compiling SCSS with the modern Sass API, never the deprecated legacy JS API.
+const source = readFileSync(join(process.cwd(), 'vite.config.ts'), 'utf-8')
+
+describe('vite config SCSS', () => {
+  it('configures the modern Sass compiler API', () => {
+    expect(source).toMatch(/preprocessorOptions/)
+    expect(source).toMatch(/scss:\s*{[\S\s]*?api:\s*["']modern-compiler["']/)
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,15 @@ export default defineConfig({
     },
     dedupe: ['three']
   },
+  css: {
+    preprocessorOptions: {
+      // Use Dart Sass's modern compiler API; the default legacy JS API is
+      // deprecated (https://sass-lang.com/d/legacy-js-api) and removed in Sass 2.
+      scss: {
+        api: 'modern-compiler'
+      }
+    }
+  },
   build: {
     target: 'esnext',
     sourcemap: true,


### PR DESCRIPTION
Closes #188

## Summary

- The deploy build emitted the Sass **legacy JS API** deprecation warning (`https://sass-lang.com/d/legacy-js-api`). Vite compiled SCSS via Dart Sass's deprecated legacy `render` API by default.
- Switch Vite to the **modern Sass compiler API** and pin `sass` as an explicit devDependency. The build now compiles with no legacy-API warning.

## Key Changes

- `vite.config.ts`: `css.preprocessorOptions.scss.api = 'modern-compiler'`.
- `package.json`: add `sass` (^1.97.3) to devDependencies (was only transitive).
- `vite.config.test.ts`: source-level regression test asserting the modern API stays configured.
- `documentation/docs/journey/sass-modern-api.md`: report on the cause and fix.

## Faced Difficulties and Learned Lessons

- **Importing the Vite config in a unit test is unreliable.** Under jsdom it trips an esbuild `TextEncoder` invariant, and it loads plugins that shouldn't run in a unit test. Lesson: guard the setting at the **source** level instead.
- **The `ECONNRESET` is separate from the warning.** The repo's build scripts open no sockets (the route pre-render is plain file I/O), so the reset comes from the deploy transport, not the build. Moving off the deprecated API removes the warning the deploy surfaced and the known compiler fragility, but the socket reset is an environment concern.

## Test Plan

- [x] `pnpm build` — no legacy-JS-API deprecation warning
- [x] `pnpm test:unit` — 1257 pass, incl. the new `vite config SCSS` guard
- [x] `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
