### PR TITLE
fix: load LandingPage font as a bundled asset

### DIFF
--- a/documentation/docs/journey/landing-page-font-asset.md
+++ b/documentation/docs/journey/landing-page-font-asset.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 108
+---
+
+# A Font That Only Existed in Development
+
+## The symptom
+
+In production, the LandingPage experiment threw an uncaught error that surfaced
+in monitoring as a JSON syntax error complaining about an unexpected `<` and a
+`<!doctype` string. The same view worked perfectly in local development, so the
+failure only appeared once the app was deployed.
+
+## Why the same code behaved differently
+
+The view loads a Three.js typeface so it can extrude the site name into 3D text.
+That font was being fetched at runtime from a path that pointed straight into the
+installed dependencies folder. During development the dev server happily serves
+files out of that folder, so the request returned the real font and everything
+rendered.
+
+A production build is a different world. The dependencies folder is a build-time
+detail; it is never published. When the browser asked for a file that does not
+exist, the single-page-app hosting did what it always does for an unknown path:
+it returned the application shell — an HTML document — with a success status.
+The font loader, expecting structured font data, was instead handed a page of
+HTML beginning with a doctype declaration, and parsing it as data failed. The
+green success status on the request is what makes this class of bug confusing:
+nothing looks broken until something downstream tries to read the response.
+
+```mermaid
+flowchart TD
+    A[View requests font by path] --> B{Where does the path point?}
+    B -- dev server --> C[Dependencies folder is served]
+    C --> D[Real font data returned]
+    D --> E[3D text renders]
+    B -- production --> F[Path does not exist in the build]
+    F --> G[App shell HTML returned with success status]
+    G --> H[Loader parses HTML as data]
+    H --> I[Failure: not valid data]
+```
+
+## The shift in thinking
+
+The fix is to stop treating the font as a live URL into someone else's folder and
+start treating it as an asset the build owns. When the font is imported as a
+build asset, the bundler copies it into the published output under a
+content-hashed name and hands back the correct address for it. That address is
+resolved the same way in development and in production, because in both cases the
+file genuinely exists where the import says it does. The runtime path that only
+happened to work locally disappears entirely.
+
+## The lesson
+
+Anything the app needs at runtime must come through the build, not through a path
+that merely happens to resolve while developing. A request that returns the app
+shell with a success status — rather than an honest not-found — is the
+fingerprint of this mistake: a resource that lives only in the development
+environment. Treat fonts, data files, and other static dependencies as owned
+assets so the build is responsible for shipping them and for telling the code
+where they are.

--- a/src/views/Experiments/LandingPage/LandingPage.vue
+++ b/src/views/Experiments/LandingPage/LandingPage.vue
@@ -6,6 +6,7 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
 import { FontLoader } from 'three/addons/loaders/FontLoader.js'
 import type { Font } from 'three/addons/loaders/FontLoader.js'
 import { TextGeometry } from 'three/addons/geometries/TextGeometry.js'
+import helvetikerBoldUrl from 'three/examples/fonts/helvetiker_bold.typeface.json?url'
 import { getTools, getWalls, getModel, getPhysic } from '@webgamekit/threejs'
 import type { LoadProgress } from '@webgamekit/threejs'
 import LoadingOverlay from '@/components/LoadingOverlay.vue'
@@ -443,12 +444,9 @@ const init = async (canvasElement: HTMLCanvasElement): Promise<void> => {
   const bodies: PhysicsBodies = new Map()
   await loadLogo(scene, world, bodies, contentMaterial)
 
-  new FontLoader().load(
-    '/node_modules/three/examples/fonts/helvetiker_bold.typeface.json',
-    (font) => {
-      loadText(scene, world, bodies, contentMaterial, font)
-    }
-  )
+  new FontLoader().load(helvetikerBoldUrl, (font) => {
+    loadText(scene, world, bodies, contentMaterial, font)
+  })
 
   const wallAspect = window.innerWidth / window.innerHeight
   const wallLength = Math.ceil(FRUSTUM_HEIGHT * wallAspect)


### PR DESCRIPTION
Closes #190

## Summary

In production, the LandingPage experiment threw `SyntaxError: Unexpected token '<', "<!doctype "... is not valid JSON` (Sentry event `88d05800`). The view loaded the Three.js `FontLoader` typeface from a hardcoded `/node_modules/three/examples/fonts/helvetiker_bold.typeface.json` URL. That path is served by Vite in dev but does not exist in the production build, so Netlify's SPA fallback returned `index.html` (`<!doctype html>`) with a **200** and `FontLoader` fed HTML into `JSON.parse`.

## Key Changes

- Import the font as a Vite asset (`three/examples/fonts/helvetiker_bold.typeface.json?url`) so it is emitted with a content hash and resolves identically in dev and production, instead of referencing a `node_modules` path at runtime.
- Add a journey doc (`documentation/docs/journey/landing-page-font-asset.md`) on the dev-vs-prod `node_modules` asset pitfall.

## Test Plan

- `vue-tsc --noEmit` and ESLint: clean.
- `vite build` emits `dist/assets/helvetiker_bold.typeface-*.json`; the runtime LandingPage chunk references the hashed asset with **zero** `node_modules/three/examples/fonts` references in the JS (only the sourcemap, which is expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)