### PR TITLE
feat(#66): smooth model rotation interpolation with target-driven movement

### DIFF
--- a/.github/rules/code-style.md
+++ b/.github/rules/code-style.md
@@ -174,6 +174,7 @@
   - `documentation/docs/packages/` — Package API documentation
   - `documentation/docs/architecture/` — Project architecture docs
   - `documentation/docs/guides/` — How-to guides and tutorials
+  - `documentation/docs/journey/` — Problem-solving write-ups: the theory, research findings, and non-obvious decisions behind a feature
 - **Run docs locally**: `cd documentation && pnpm start`
 - **Adding new docs**: Create `.md` files in the appropriate `docs/` subfolder with frontmatter:
 
@@ -185,6 +186,14 @@
   # Your Title Here
   ```
 
+- **Record theory and research findings in the journey**: Whenever you solve a
+  non-trivial problem using theory, a mathematical technique, or findings from
+  research or experiments, write it up in `documentation/docs/journey/`. Always
+  capture the _why_, the underlying theory, and what the research/experiments
+  revealed — not just the final code. Journey docs favour abstract prose, tables,
+  and Mermaid diagrams over code snippets; include only the minimal formula or
+  snippet needed to make the theory concrete. Do this as part of the same change
+  that solved the problem, not later.
 - **Keep tutorials in sync with the code**: When you change a file that a tutorial
   documents (its APIs, options, file paths, or worked example), update that tutorial
   in the same change so it never goes stale. Each tutorial lists the source files it

--- a/documentation/docs/journey/rotation-interpolation.md
+++ b/documentation/docs/journey/rotation-interpolation.md
@@ -1,0 +1,136 @@
+---
+sidebar_position: 100
+---
+
+# Smooth Model Rotation: Interpolation, Heading, and Orientation
+
+How the player-turning animation was built (issue #66, PR #195): interpolating a
+model's rotation instead of snapping it, keeping movement responsive while the
+model visually catches up, and correcting models whose geometry is oriented the
+"wrong" way. The theory below is what made the difference between a fix that
+worked and several that looked right on paper but failed on screen.
+
+## Snapping versus interpolating
+
+The original controller set the model's `rotation.y` directly to the input
+heading every frame. Direction changes were instantaneous — there was no sense of
+the character _turning_ to face a new way. The goal was to move the rotation
+toward the target a little each frame so the turn is visible.
+
+The naive approach — lerp the current angle toward the target — breaks at the
+0°/360° seam. Interpolating from 350° to 10° the naive way sweeps backward
+through 340°, spinning the model almost all the way around instead of nudging it
+20° forward.
+
+## Shortest-path angular interpolation
+
+The core theory is computing the **shortest signed angular distance** between two
+angles, which must respect wrap-around. The robust, branch-free way to get a
+difference folded into the range `[-π, π]` is:
+
+```
+difference = atan2(sin(target − current), cos(target − current))
+```
+
+`sin`/`cos` map the raw difference onto the unit circle, discarding full
+turns; `atan2` reads the angle back out, always choosing the representative in
+`[-π, π]` — i.e. the shortest way round. From 350° to 10° this yields `+20°`, not
+`-340°`. Each frame we then apply at most a fixed step of that difference, so the
+model rotates toward the target the short way and stops cleanly once aligned.
+
+## Choosing how the turn is paced
+
+Three common ways to pace an interpolated rotation, and why the project uses the
+first:
+
+| Approach               | Behaviour                                        | Trade-off                                                       |
+| ---------------------- | ------------------------------------------------ | --------------------------------------------------------------- |
+| Max degrees per step   | Cap the applied change to _N_ degrees each frame | Constant, predictable turn speed; simple; the chosen default    |
+| Angular velocity (°/s) | Multiply a turn rate by frame delta              | Frame-rate independent, but doesn't map to the issue's "step"   |
+| Fixed lerp factor      | Move a fixed fraction of the remaining angle     | Smooth ease-out, but never a constant speed and never "arrives" |
+
+The default step is 25° per frame — a full 180° turn resolves in roughly seven
+frames: snappy but visibly a turn rather than a snap.
+
+## Decoupling movement from facing
+
+An early version moved the character along whichever way the mesh currently faced.
+Because the mesh now turns gradually, the character _curved_ into the new heading
+instead of going where the player pressed — it felt unresponsive on sharp turns.
+
+The fix separates two concerns that had been conflated:
+
+- **Movement** goes straight to the **target** heading immediately (responsive).
+- **Facing** is purely visual and lags behind, catching up over a few frames.
+
+```mermaid
+flowchart LR
+    I[Directional input] --> H[Target heading]
+    H --> M[Movement: go to target now]
+    H --> F[Facing: rotate toward target one step]
+    M --> R[On-screen: moves straight, model pivots to follow]
+    F --> R
+```
+
+Both derive from the same target heading, so they never disagree about
+_direction_ — only about _how fast the visual catches up_.
+
+## A three.js finding: `getWorldDirection` returns +Z
+
+While deriving the movement vector from a heading angle, the first implementation
+pointed the character the wrong way. The cause was an assumption about which axis
+is "forward".
+
+`Object3D.getWorldDirection()` returns the world-space direction of the object's
+local **+Z** axis (it reads the third column of the world matrix, `e[8], e[9],
+e[10]`). Cameras look down **−Z**, so it is easy to assume models face −Z too —
+but the helper reports +Z. For a rotation `θ` about Y the direction is therefore
+`(sin θ, 0, cos θ)`, **not** `(−sin θ, 0, −cos θ)`.
+
+A unit test that compared the hand-derived direction against `getWorldDirection`
+caught the sign error immediately — a good argument for pinning down engine
+conventions with a test rather than reasoning about them in the abstract.
+
+## Unifying the games behind one convention
+
+Several games each compensated for their camera and model differently (mirrored
+input maps, "move backward" flags). They all in fact use cameras on the **+Z
+side** looking toward −Z. Because the shared heading convention treats "up" as 0°
+= +Z, "away from the camera" is −Z — so an "up" press must map to the `move-down`
+action. Adopting that single mapping plus one shared facing helper made every
+game behave identically, leaving only genuine per-model quirks to configure.
+
+## Model orientation: rotation versus reflection
+
+Two independent things can be wrong with a loaded model's facing, and — this is
+the key finding — they are **mathematically different transforms**:
+
+| Problem                                    | Correction             | Nature                    |
+| ------------------------------------------ | ---------------------- | ------------------------- |
+| Model faces backward (front/back inverted) | `facingOffset: 180`    | Rotation (additive angle) |
+| Model turns the mirror-image way           | `mirroredFacing: true` | Reflection (sign flip)    |
+
+A **rotation offset cannot produce a mirror**. Adding a constant to every angle
+can never turn left/right handedness around — a reflection is `θ → −θ`, an
+additive offset is `θ → θ + c`, and no choice of `c` makes one equal the other.
+This is why repeatedly tweaking an offset never fixed a model that _turned the
+mirror way_: the tool was the wrong kind of transform.
+
+The reflection is implemented by deriving the facing heading from the mirrored
+directional map (which swaps left/right, i.e. `θ → 360° − θ`) while movement keeps
+using the non-mirrored heading. Movement direction stays correct; only the visual
+turn is reflected.
+
+Both corrections are declared once in the model's load options and stored on the
+model, so orientation quirks live with the model definition rather than being
+re-derived in each game's movement code.
+
+## Knobs, in summary
+
+| Symptom                                    | Fix                                                         |
+| ------------------------------------------ | ----------------------------------------------------------- |
+| Turn is instant, no sense of pivoting      | Interpolate with a per-step cap                             |
+| Character curves instead of going straight | Drive movement from the target heading, not the mesh facing |
+| Pressing "up" moves toward the camera      | Map up-input to `move-down` for +Z cameras                  |
+| Model faces its own back                   | `facingOffset: 180`                                         |
+| Model turns the mirror-image way           | `mirroredFacing: true`                                      |

--- a/packages/animation/src/index.test.ts
+++ b/packages/animation/src/index.test.ts
@@ -836,15 +836,14 @@ describe('animation', () => {
       expect(model.rotation.y).toBeCloseTo(THREE.MathUtils.degToRad(25), 5)
     })
 
-    it('uses the mirrored map when requested', () => {
+    it('keeps the movement heading but faces the mirrored heading when mirroredFacing is set', () => {
       const model = createFacingModel()
-      const heading = updatePlayerFacing(
-        model,
-        { 'move-left': true },
-        DEFAULT_ROTATION_STEP_DEGREES,
-        true
-      )
-      expect(heading).toBe(90)
+      model.userData.mirroredFacing = true
+      const heading = updatePlayerFacing(model, { 'move-left': true })
+      // Movement heading stays non-mirrored (left = 270)
+      expect(heading).toBe(270)
+      // Facing uses the mirrored map (left = 90), turned toward within one step
+      expect(model.rotation.y).toBeCloseTo(THREE.MathUtils.degToRad(25), 5)
     })
   })
 

--- a/packages/animation/src/index.test.ts
+++ b/packages/animation/src/index.test.ts
@@ -12,6 +12,7 @@ import {
   rotateTowards,
   DEFAULT_ROTATION_STEP_DEGREES,
   getMovementDirection,
+  updatePlayerFacing,
   createTimelineManager,
   type AnimationData
 } from './index'
@@ -803,6 +804,47 @@ describe('animation', () => {
       const aligned = rotateTowards(model, 90)
       expect(aligned).toBe(false)
       expect(model.rotation.y).toBe(0)
+    })
+  })
+
+  describe('updatePlayerFacing', () => {
+    const createFacingModel = () => {
+      const mockMesh = new THREE.Group()
+      mockMesh.rotation.set(0, 0, 0)
+      return Object.assign(mockMesh, { userData: {} }) as unknown as ComplexModel
+    }
+
+    it('returns the target heading and faces the model toward it', () => {
+      const model = createFacingModel()
+      const heading = updatePlayerFacing(model, { 'move-right': true })
+      expect(heading).toBe(90)
+      // 90° is within a single 25° step from 0? No — capped, so it turns toward it.
+      expect(model.rotation.y).toBeCloseTo(THREE.MathUtils.degToRad(25), 5)
+    })
+
+    it('returns null and leaves rotation untouched when there is no input', () => {
+      const model = createFacingModel()
+      const heading = updatePlayerFacing(model, {})
+      expect(heading).toBeNull()
+      expect(model.rotation.y).toBe(0)
+    })
+
+    it('applies the model facing offset to the visual rotation', () => {
+      const model = createFacingModel()
+      updatePlayerFacing(model, { 'move-up': true }, 180)
+      expect(model.rotation.y).toBeCloseTo(THREE.MathUtils.degToRad(25), 5)
+    })
+
+    it('uses the mirrored map when requested', () => {
+      const model = createFacingModel()
+      const heading = updatePlayerFacing(
+        model,
+        { 'move-left': true },
+        0,
+        DEFAULT_ROTATION_STEP_DEGREES,
+        true
+      )
+      expect(heading).toBe(90)
     })
   })
 

--- a/packages/animation/src/index.test.ts
+++ b/packages/animation/src/index.test.ts
@@ -829,9 +829,10 @@ describe('animation', () => {
       expect(model.rotation.y).toBe(0)
     })
 
-    it('applies the model facing offset to the visual rotation', () => {
+    it('applies the model facingOffset from userData to the visual rotation', () => {
       const model = createFacingModel()
-      updatePlayerFacing(model, { 'move-up': true }, 180)
+      model.userData.facingOffset = 180
+      updatePlayerFacing(model, { 'move-up': true })
       expect(model.rotation.y).toBeCloseTo(THREE.MathUtils.degToRad(25), 5)
     })
 
@@ -840,7 +841,6 @@ describe('animation', () => {
       const heading = updatePlayerFacing(
         model,
         { 'move-left': true },
-        0,
         DEFAULT_ROTATION_STEP_DEGREES,
         true
       )

--- a/packages/animation/src/index.test.ts
+++ b/packages/animation/src/index.test.ts
@@ -9,6 +9,9 @@ import {
   checkGroundAtPosition,
   getRotation,
   setRotation,
+  rotateTowards,
+  DEFAULT_ROTATION_STEP_DEGREES,
+  getMovementDirection,
   createTimelineManager,
   type AnimationData
 } from './index'
@@ -748,6 +751,107 @@ describe('animation', () => {
       // Test 45 degrees (diagonal)
       setRotation(mockModel, 45)
       expect(mockModel.rotation.y).toBeCloseTo(Math.PI / 4, 5)
+    })
+  })
+
+  describe('rotateTowards', () => {
+    const createRotatingModel = (startDegrees = 0) => {
+      const mockMesh = new THREE.Group()
+      mockMesh.rotation.set(0, THREE.MathUtils.degToRad(startDegrees), 0)
+      return Object.assign(mockMesh, { userData: {} }) as unknown as ComplexModel
+    }
+
+    it('exposes 25 as the default step', () => {
+      expect(DEFAULT_ROTATION_STEP_DEGREES).toBe(25)
+    })
+
+    it.each([
+      [0, 90, 25, 25, false, 'caps a far turn to the step size'],
+      [0, 10, 25, 10, true, 'snaps to target and reports aligned when within step'],
+      [90, 90, 25, 90, true, 'stays put and reports aligned when already facing target'],
+      [0, 200, 25, -25, false, 'turns the short way (negative) for targets past 180°'],
+      [350, 10, 25, 370, true, 'wraps forward across 0° via the shortest path'],
+      [10, 350, 25, -10, true, 'wraps backward across 0° via the shortest path'],
+      [0, 45, 25, 25, false, 'resolves a 45° grid turn in two steps'],
+      [0, 100, 100, 100, true, 'reaches a far target in one step when step is large']
+    ])(
+      'from %d° toward %d° step %d° → %d° (aligned=%s): %s',
+      (start, target, step, expectedDegrees, expectedAligned) => {
+        const model = createRotatingModel(start)
+        const aligned = rotateTowards(model, target, step)
+        expect(model.rotation.y).toBeCloseTo(THREE.MathUtils.degToRad(expectedDegrees), 5)
+        expect(aligned).toBe(expectedAligned)
+      }
+    )
+
+    it('applies modelOffset to the target', () => {
+      const model = createRotatingModel(0)
+      rotateTowards(model, 0, 25, 90)
+      expect(model.rotation.y).toBeCloseTo(THREE.MathUtils.degToRad(25), 5)
+    })
+
+    it('uses the 25° default step when none is provided', () => {
+      const model = createRotatingModel(0)
+      rotateTowards(model, 90)
+      expect(model.rotation.y).toBeCloseTo(THREE.MathUtils.degToRad(25), 5)
+    })
+
+    it('is blocked when performing and allowRotation=false', () => {
+      const model = createRotatingModel(0)
+      model.userData.performing = true
+      model.userData.allowRotation = false
+      const aligned = rotateTowards(model, 90)
+      expect(aligned).toBe(false)
+      expect(model.rotation.y).toBe(0)
+    })
+  })
+
+  describe('getMovementDirection', () => {
+    const createModelAt = (rotationDegrees = 0) => {
+      const mockMesh = new THREE.Group()
+      mockMesh.position.set(0, 0, 0)
+      mockMesh.rotation.set(0, THREE.MathUtils.degToRad(rotationDegrees), 0)
+      return Object.assign(mockMesh, { userData: {} }) as unknown as ComplexModel
+    }
+
+    it.each([
+      [0, 0, 1],
+      [90, 1, 0],
+      [180, 0, -1],
+      [270, -1, 0]
+    ])('heading %d° yields direction (%d, _, %d)', (heading, expectedX, expectedZ) => {
+      const model = createModelAt(0)
+      const { direction } = getMovementDirection(model, 1, false, heading)
+      expect(direction.x).toBeCloseTo(expectedX, 5)
+      expect(direction.z).toBeCloseTo(expectedZ, 5)
+    })
+
+    it('follows the target heading regardless of the model’s current facing', () => {
+      const facingUp = createModelAt(0)
+      const { direction } = getMovementDirection(facingUp, 1, false, 90)
+      expect(direction.x).toBeCloseTo(1, 5)
+      expect(direction.z).toBeCloseTo(0, 5)
+    })
+
+    it('matches getWorldDirection when heading equals the model rotation', () => {
+      const model = createModelAt(90)
+      const worldDirection = new THREE.Vector3()
+      model.getWorldDirection(worldDirection)
+      const { direction } = getMovementDirection(model, 1, false, 90)
+      expect(direction.x).toBeCloseTo(worldDirection.x, 5)
+      expect(direction.z).toBeCloseTo(worldDirection.z, 5)
+    })
+
+    it('negates the heading direction when backward is true', () => {
+      const model = createModelAt(0)
+      const { direction } = getMovementDirection(model, 1, true, 0)
+      expect(direction.z).toBeCloseTo(-1, 5)
+    })
+
+    it('falls back to the model facing when no heading is given', () => {
+      const model = createModelAt(180)
+      const { direction } = getMovementDirection(model, 1, false)
+      expect(direction.z).toBeCloseTo(-1, 5)
     })
   })
 

--- a/packages/animation/src/index.ts
+++ b/packages/animation/src/index.ts
@@ -1132,10 +1132,10 @@ const getRotation = (
  * Resolve the target heading from directional input and smoothly turn the model
  * to face it. Movement should be applied toward the returned heading (forward, via
  * getMovementDirection's headingDegrees) so movement direction and model facing stay
- * consistent across games. Per-model front/back inversion is corrected with modelOffset.
+ * consistent across games. A front/back-inverted model is corrected automatically via
+ * its `facingOffset` (declared in the model's load options and stored on userData).
  * @param player The player model to face toward the input direction
  * @param currentActions Record of active control actions
- * @param modelOffset Degrees added to the visual facing for a front/back-inverted model
  * @param stepDegrees Maximum degrees to rotate this step
  * @param mirrored Whether to use the mirrored directional map
  * @returns Target heading in degrees, or null when there is no directional input
@@ -1143,13 +1143,12 @@ const getRotation = (
 const updatePlayerFacing = (
   player: ComplexModel,
   currentActions: Record<string, unknown>,
-  modelOffset: number = 0,
   stepDegrees: number = DEFAULT_ROTATION_STEP_DEGREES,
   mirrored: boolean = false
 ): number | null => {
   const targetRotation = getRotation(currentActions, mirrored)
   if (targetRotation !== null) {
-    rotateTowards(player, targetRotation, stepDegrees, modelOffset)
+    rotateTowards(player, targetRotation, stepDegrees, player.userData.facingOffset ?? 0)
   }
   return targetRotation
 }

--- a/packages/animation/src/index.ts
+++ b/packages/animation/src/index.ts
@@ -253,6 +253,7 @@ interface AnimationData {
   speed?: number
   backward?: boolean // For adjusting model direction
   distance?: number // Length of action movement
+  targetRotation?: number // Heading in degrees to move toward; overrides the model's current facing
 }
 
 interface PlayActionOptions {
@@ -617,16 +618,23 @@ interface MovementDirectionResult {
  * @param model The model to get direction from
  * @param distance Movement distance
  * @param backward Whether to move backward
+ * @param headingDegrees Optional target heading in degrees; when provided, movement follows this direction (about the Y axis) instead of the model's current facing, so the model heads straight to the target while its visual rotation catches up
  * @returns Direction vector and positions
  */
 const getMovementDirection = (
   model: ComplexModel,
   distance: number,
-  backward: boolean = false
+  backward: boolean = false,
+  headingDegrees?: number
 ): MovementDirectionResult => {
   const oldPosition = model.position.clone()
   const direction = new THREE.Vector3()
-  model.getWorldDirection(direction)
+  if (headingDegrees === undefined) {
+    model.getWorldDirection(direction)
+  } else {
+    const radians = THREE.MathUtils.degToRad(headingDegrees)
+    direction.set(Math.sin(radians), 0, Math.cos(radians))
+  }
 
   if (backward) {
     direction.negate()
@@ -959,12 +967,23 @@ const controllerForward = (
 ): void => {
   const options = resolveControllerOptions(rawOptions)
   const { debug } = options
-  const { actionName, player: model, backward = false, distance = 0 } = animationData
+  const {
+    actionName,
+    player: model,
+    backward = false,
+    distance = 0,
+    targetRotation
+  } = animationData
 
   if (model.userData.performing && model.userData.allowMovement === false) return
 
   const { actions, mixer } = model.userData
-  const { direction, oldPosition, newPosition } = getMovementDirection(model, distance, backward)
+  const { direction, oldPosition, newPosition } = getMovementDirection(
+    model,
+    distance,
+    backward,
+    targetRotation
+  )
 
   const { canMove, finalPosition } = resolveForwardMovement({
     oldPosition,
@@ -1020,6 +1039,40 @@ const setRotation = (model: ComplexModel, degrees: number, modelOffset: number =
   const radians = THREE.MathUtils.degToRad(degrees + modelOffset)
   model.rotation.y = radians
   return true
+}
+
+/** Default maximum rotation applied per step, in degrees, for 8-axis player turning */
+const DEFAULT_ROTATION_STEP_DEGREES = 25
+
+/**
+ * Smoothly rotate a model toward a target Y rotation, capping the change per step.
+ *
+ * Interpolates along the shortest angular path so the model turns the natural way
+ * (e.g. 350°→10° rotates +20°, not -340°). This drives only the visual turn; pair it
+ * with a target-driven movement direction (see getMovementDirection's headingDegrees)
+ * so the model heads straight to the target while its rotation visually catches up.
+ * @param model The model to rotate
+ * @param degrees Target rotation in degrees
+ * @param stepDegrees Maximum degrees to rotate this step (default 25)
+ * @param modelOffset Offset in degrees to correct for models facing wrong direction
+ * @returns true if the model is now facing the target within this step, false if still turning or blocked
+ */
+const rotateTowards = (
+  model: ComplexModel,
+  degrees: number,
+  stepDegrees: number = DEFAULT_ROTATION_STEP_DEGREES,
+  modelOffset: number = 0
+): boolean => {
+  if (model.userData.performing && model.userData.allowRotation === false) {
+    return false
+  }
+  const target = THREE.MathUtils.degToRad(degrees + modelOffset)
+  const current = model.rotation.y
+  const difference = Math.atan2(Math.sin(target - current), Math.cos(target - current))
+  const maxStep = THREE.MathUtils.degToRad(Math.abs(stepDegrees))
+  const aligned = Math.abs(difference) <= maxStep
+  model.rotation.y = current + (aligned ? difference : Math.sign(difference) * maxStep)
+  return aligned
 }
 
 /** Rotation mapping for directional input combinations */
@@ -1122,6 +1175,8 @@ export {
   controllerJump,
   controllerTurn,
   setRotation,
+  rotateTowards,
+  DEFAULT_ROTATION_STEP_DEGREES,
   getRotation,
   bodyJump,
   checkGroundAtPosition,

--- a/packages/animation/src/index.ts
+++ b/packages/animation/src/index.ts
@@ -1129,28 +1129,29 @@ const getRotation = (
 }
 
 /**
- * Resolve the target heading from directional input and smoothly turn the model
- * to face it. Movement should be applied toward the returned heading (forward, via
- * getMovementDirection's headingDegrees) so movement direction and model facing stay
- * consistent across games. A front/back-inverted model is corrected automatically via
- * its `facingOffset` (declared in the model's load options and stored on userData).
+ * Resolve the movement heading from directional input and smoothly turn the model
+ * to face it. The returned heading drives forward movement (via getMovementDirection's
+ * headingDegrees). The model's visual facing is corrected per model, declared in its
+ * load options and read from userData: `facingOffset` degrees for a front/back-inverted
+ * model, and `mirroredFacing` to turn along the mirrored (left/right-swapped) heading.
  * @param player The player model to face toward the input direction
  * @param currentActions Record of active control actions
  * @param stepDegrees Maximum degrees to rotate this step
- * @param mirrored Whether to use the mirrored directional map
- * @returns Target heading in degrees, or null when there is no directional input
+ * @returns Movement heading in degrees, or null when there is no directional input
  */
 const updatePlayerFacing = (
   player: ComplexModel,
   currentActions: Record<string, unknown>,
-  stepDegrees: number = DEFAULT_ROTATION_STEP_DEGREES,
-  mirrored: boolean = false
+  stepDegrees: number = DEFAULT_ROTATION_STEP_DEGREES
 ): number | null => {
-  const targetRotation = getRotation(currentActions, mirrored)
-  if (targetRotation !== null) {
-    rotateTowards(player, targetRotation, stepDegrees, player.userData.facingOffset ?? 0)
+  const movementHeading = getRotation(currentActions, false)
+  if (movementHeading !== null) {
+    const facingHeading = player.userData.mirroredFacing
+      ? (getRotation(currentActions, true) ?? movementHeading)
+      : movementHeading
+    rotateTowards(player, facingHeading, stepDegrees, player.userData.facingOffset ?? 0)
   }
-  return targetRotation
+  return movementHeading
 }
 
 const bodyJump = (

--- a/packages/animation/src/index.ts
+++ b/packages/animation/src/index.ts
@@ -1128,6 +1128,32 @@ const getRotation = (
   return key ? (map[key] ?? null) : null
 }
 
+/**
+ * Resolve the target heading from directional input and smoothly turn the model
+ * to face it. Movement should be applied toward the returned heading (forward, via
+ * getMovementDirection's headingDegrees) so movement direction and model facing stay
+ * consistent across games. Per-model front/back inversion is corrected with modelOffset.
+ * @param player The player model to face toward the input direction
+ * @param currentActions Record of active control actions
+ * @param modelOffset Degrees added to the visual facing for a front/back-inverted model
+ * @param stepDegrees Maximum degrees to rotate this step
+ * @param mirrored Whether to use the mirrored directional map
+ * @returns Target heading in degrees, or null when there is no directional input
+ */
+const updatePlayerFacing = (
+  player: ComplexModel,
+  currentActions: Record<string, unknown>,
+  modelOffset: number = 0,
+  stepDegrees: number = DEFAULT_ROTATION_STEP_DEGREES,
+  mirrored: boolean = false
+): number | null => {
+  const targetRotation = getRotation(currentActions, mirrored)
+  if (targetRotation !== null) {
+    rotateTowards(player, targetRotation, stepDegrees, modelOffset)
+  }
+  return targetRotation
+}
+
 const bodyJump = (
   model: ComplexModel,
   bodies: ComplexModel[],
@@ -1178,6 +1204,7 @@ export {
   rotateTowards,
   DEFAULT_ROTATION_STEP_DEGREES,
   getRotation,
+  updatePlayerFacing,
   bodyJump,
   checkGroundAtPosition,
   getMovementDirection,

--- a/packages/animation/src/types.ts
+++ b/packages/animation/src/types.ts
@@ -45,6 +45,8 @@ export interface ComplexModel extends Model {
     gravityScale?: number
     actions: Record<string, THREE.AnimationAction | undefined>
     mixer?: THREE.AnimationMixer
+    /** Degrees added to the model's facing to correct a front/back-inverted model */
+    facingOffset?: number
   }
 }
 

--- a/packages/animation/src/types.ts
+++ b/packages/animation/src/types.ts
@@ -47,6 +47,8 @@ export interface ComplexModel extends Model {
     mixer?: THREE.AnimationMixer
     /** Degrees added to the model's facing to correct a front/back-inverted model */
     facingOffset?: number
+    /** Face the model along the mirrored (left/right-swapped) heading */
+    mirroredFacing?: boolean
   }
 }
 

--- a/packages/threejs/src/models.ts
+++ b/packages/threejs/src/models.ts
@@ -408,6 +408,7 @@ export const getModel = async (
       characterController,
       hasGravity,
       gravityScale,
+      facingOffset: options.facingOffset,
       onSpawn
     }
   })

--- a/packages/threejs/src/models.ts
+++ b/packages/threejs/src/models.ts
@@ -409,6 +409,7 @@ export const getModel = async (
       hasGravity,
       gravityScale,
       facingOffset: options.facingOffset,
+      mirroredFacing: options.mirroredFacing,
       onSpawn
     }
   })

--- a/packages/threejs/src/types.ts
+++ b/packages/threejs/src/types.ts
@@ -65,6 +65,8 @@ export interface ModelOptions extends CommonOptions {
   materialColors?: number[]
   /** Degrees to add to the model's facing so a front/back-inverted model faces its travel direction (e.g. 180) */
   facingOffset?: number
+  /** Face the model along the mirrored (left/right-swapped) heading, for models authored to turn the mirror-image way */
+  mirroredFacing?: boolean
   onSpawn?: () => boolean
   onProgress?: OnProgress
 }

--- a/packages/threejs/src/types.ts
+++ b/packages/threejs/src/types.ts
@@ -63,6 +63,8 @@ export interface ModelOptions extends CommonOptions {
   envMapIntensity?: number
   animations?: string[]
   materialColors?: number[]
+  /** Degrees to add to the model's facing so a front/back-inverted model faces its travel direction (e.g. 180) */
+  facingOffset?: number
   onSpawn?: () => boolean
   onProgress?: OnProgress
 }

--- a/src/views/Experiments/ContinuousWorld/ContinuousWorld.vue
+++ b/src/views/Experiments/ContinuousWorld/ContinuousWorld.vue
@@ -27,7 +27,6 @@ import { setNestedValueImmutable } from '@/utils/nestedObjects'
 import {
   setupConfig,
   playerSettings,
-  MODEL_FACING_OFFSET,
   controlBindings,
   generatorConfig,
   noiseConfig,
@@ -140,6 +139,7 @@ const initializeWorld = async (scene: THREE.Scene, world: Parameters<typeof getM
     position: playerSettings.model.position,
     rotation: playerSettings.model.rotation,
     scale: playerSettings.model.scale,
+    facingOffset: playerSettings.model.facingOffset,
     castShadow: true
   })
 
@@ -222,7 +222,7 @@ const TERRAIN_RAYCAST_ORIGIN_Y = 200
 let lastPlayerHeadingDegrees = playerSettings.model.rotation[1] / DEGREES_TO_RADIANS
 
 const applyRotation = (mesh: ComplexModel, degrees: number) => {
-  rotateTowards(mesh, degrees, DEFAULT_ROTATION_STEP_DEGREES, MODEL_FACING_OFFSET)
+  rotateTowards(mesh, degrees, DEFAULT_ROTATION_STEP_DEGREES, mesh.userData.facingOffset ?? 0)
 }
 
 const moveForward = (mesh: THREE.Object3D, distance: number, headingDegrees: number) => {

--- a/src/views/Experiments/ContinuousWorld/ContinuousWorld.vue
+++ b/src/views/Experiments/ContinuousWorld/ContinuousWorld.vue
@@ -1,8 +1,14 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, toRaw, watch } from 'vue'
 import { useRoute } from 'vue-router'
-import { cameraFollowPlayer, getModel } from '@webgamekit/threejs'
-import { getRotation, createTimelineManager, updateAnimation } from '@webgamekit/animation'
+import { cameraFollowPlayer, getModel, type ComplexModel } from '@webgamekit/threejs'
+import {
+  getRotation,
+  createTimelineManager,
+  updateAnimation,
+  rotateTowards,
+  DEFAULT_ROTATION_STEP_DEGREES
+} from '@webgamekit/animation'
 import { createControls } from '@webgamekit/controls'
 import { useSceneViewStore } from '@/stores/sceneView'
 import { useDebugSceneStore } from '@/stores/debugScene'
@@ -21,6 +27,7 @@ import { setNestedValueImmutable } from '@/utils/nestedObjects'
 import {
   setupConfig,
   playerSettings,
+  MODEL_FACING_OFFSET,
   controlBindings,
   generatorConfig,
   noiseConfig,
@@ -212,14 +219,16 @@ const HALF_CIRCLE_DEGREES = 180
 const DEGREES_TO_RADIANS = Math.PI / HALF_CIRCLE_DEGREES
 const TERRAIN_RAYCAST_ORIGIN_Y = 200
 
-const applyRotation = (mesh: THREE.Object3D, degrees: number) => {
-  mesh.rotation.y = degrees * DEGREES_TO_RADIANS
+let lastPlayerHeadingDegrees = playerSettings.model.rotation[1] / DEGREES_TO_RADIANS
+
+const applyRotation = (mesh: ComplexModel, degrees: number) => {
+  rotateTowards(mesh, degrees, DEFAULT_ROTATION_STEP_DEGREES, MODEL_FACING_OFFSET)
 }
 
-const moveForward = (mesh: THREE.Object3D, distance: number) => {
-  const direction = new THREE.Vector3(0, 0, -1)
-  direction.applyQuaternion(mesh.quaternion)
-  mesh.position.addScaledVector(direction, distance)
+const moveForward = (mesh: THREE.Object3D, distance: number, headingDegrees: number) => {
+  const radians = headingDegrees * DEGREES_TO_RADIANS
+  mesh.position.x += -Math.sin(radians) * distance
+  mesh.position.z += -Math.cos(radians) * distance
 }
 
 const snapToTerrain = (
@@ -305,7 +314,10 @@ const applyPlayerMove = (
   isMoving: boolean
 ): void => {
   if (!playerMeshReference || !getDeltaReference) return
-  if (targetRotation !== null) applyRotation(playerMeshReference, targetRotation)
+  if (targetRotation !== null) {
+    applyRotation(playerMeshReference, targetRotation)
+    lastPlayerHeadingDegrees = targetRotation
+  }
   updateAnimation({
     actionName: isMoving ? 'walk' : 'idle',
     player: playerMeshReference,
@@ -314,7 +326,7 @@ const applyPlayerMove = (
       ((reactiveConfig.value.movementSpeed as number | undefined) ?? playerSettings.game.distance) *
       10
   })
-  if (isMoving) moveForward(playerMeshReference, moveSpeed)
+  if (isMoving) moveForward(playerMeshReference, moveSpeed, lastPlayerHeadingDegrees)
   applyTerrainSnap()
   cameraFrameCounter++
   const followFrequency =

--- a/src/views/Experiments/ContinuousWorld/config.ts
+++ b/src/views/Experiments/ContinuousWorld/config.ts
@@ -19,6 +19,10 @@ export const TREES_PER_CHUNK = 2
 export const MOVEMENT_SPEED_SCALE = 1 / 8
 export const GRASS_DENSITY_MULTIPLIER = 200
 export const PLAYER_MODEL_SCALE = 4
+// Degrees added to the player's visual rotation to correct a model whose front
+// and back are inverted. The shared stickboy model's front is +Z, but this view
+// travels along -Z, so it needs a 180 flip to face its movement direction.
+export const MODEL_FACING_OFFSET = 180
 
 export const noiseConfig: NoiseConfig = {
   seed: 50,

--- a/src/views/Experiments/ContinuousWorld/config.ts
+++ b/src/views/Experiments/ContinuousWorld/config.ts
@@ -19,10 +19,6 @@ export const TREES_PER_CHUNK = 2
 export const MOVEMENT_SPEED_SCALE = 1 / 8
 export const GRASS_DENSITY_MULTIPLIER = 200
 export const PLAYER_MODEL_SCALE = 4
-// Degrees added to the player's visual rotation to correct a model whose front
-// and back are inverted. The shared stickboy model's front is +Z, but this view
-// travels along -Z, so it needs a 180 flip to face its movement direction.
-export const MODEL_FACING_OFFSET = 180
 
 export const noiseConfig: NoiseConfig = {
   seed: 50,
@@ -78,6 +74,8 @@ export const playerSettings = {
     path: 'stickboy_maze.glb',
     position: [0, 0, 0] as CoordinateTuple,
     rotation: [0, Math.PI, 0] as CoordinateTuple,
+    // This view travels along -Z, so face the model 180 to match its movement.
+    facingOffset: 180,
     scale: [PLAYER_MODEL_SCALE, PLAYER_MODEL_SCALE, PLAYER_MODEL_SCALE] as CoordinateTuple,
     groundOffset: 0.5,
     restitution: -10,

--- a/src/views/Experiments/ForestGame/ForestGame.vue
+++ b/src/views/Experiments/ForestGame/ForestGame.vue
@@ -7,14 +7,12 @@ import {
   type CoordinateTuple,
   type AnimationData,
   updateAnimation,
-  rotateTowards,
-  getRotation,
+  updatePlayerFacing,
   createTimelineManager,
   createPopUpBounce,
   createSlideInFromSides,
   sortOrder,
-  calculateSequentialDelays,
-  DEFAULT_ROTATION_STEP_DEGREES
+  calculateSequentialDelays
 } from '@webgamekit/animation'
 import { createGame, type GameState } from '@webgamekit/game'
 import { createControls, isMobile } from '@webgamekit/controls'
@@ -209,7 +207,7 @@ const registerGameTimeline = (
     name: 'Walk',
     category: 'user-input',
     action: () => {
-      const targetRotation = getRotation(currentActions, true)
+      const targetRotation = updatePlayerFacing(player, currentActions, MODEL_FACING_OFFSET)
       const isMoving = targetRotation !== null
       const actionName = isMoving ? 'Esqueleto|walking' : 'Esqueleto|idle'
       logControllerForward(movement.debug, currentActions, targetRotation)
@@ -218,12 +216,10 @@ const registerGameTimeline = (
         player,
         delta: getDelta() * 2,
         speed: 20,
-        backward: true,
         distance,
         targetRotation: targetRotation ?? undefined
       }
       if (isMoving) {
-        rotateTowards(player, targetRotation, DEFAULT_ROTATION_STEP_DEGREES, MODEL_FACING_OFFSET)
         controllerForward(obstacles, groundBodies, animationData, movement)
         if (!orbitReference)
           orbitReference = toRaw(store.orbitReference) as Parameters<typeof cameraFollowPlayer>[3]

--- a/src/views/Experiments/ForestGame/ForestGame.vue
+++ b/src/views/Experiments/ForestGame/ForestGame.vue
@@ -7,13 +7,14 @@ import {
   type CoordinateTuple,
   type AnimationData,
   updateAnimation,
-  setRotation,
+  rotateTowards,
   getRotation,
   createTimelineManager,
   createPopUpBounce,
   createSlideInFromSides,
   sortOrder,
-  calculateSequentialDelays
+  calculateSequentialDelays,
+  DEFAULT_ROTATION_STEP_DEGREES
 } from '@webgamekit/animation'
 import { createGame, type GameState } from '@webgamekit/game'
 import { createControls, isMobile } from '@webgamekit/controls'
@@ -30,7 +31,8 @@ import {
   assets,
   illustrationAreas,
   illustrationAreaGroupConfigs,
-  configControls
+  configControls,
+  MODEL_FACING_OFFSET
 } from './config'
 
 const route = useRoute()
@@ -217,10 +219,11 @@ const registerGameTimeline = (
         delta: getDelta() * 2,
         speed: 20,
         backward: true,
-        distance
+        distance,
+        targetRotation: targetRotation ?? undefined
       }
       if (isMoving) {
-        setRotation(player, targetRotation)
+        rotateTowards(player, targetRotation, DEFAULT_ROTATION_STEP_DEGREES, MODEL_FACING_OFFSET)
         controllerForward(obstacles, groundBodies, animationData, movement)
         if (!orbitReference)
           orbitReference = toRaw(store.orbitReference) as Parameters<typeof cameraFollowPlayer>[3]

--- a/src/views/Experiments/ForestGame/ForestGame.vue
+++ b/src/views/Experiments/ForestGame/ForestGame.vue
@@ -29,8 +29,7 @@ import {
   assets,
   illustrationAreas,
   illustrationAreaGroupConfigs,
-  configControls,
-  MODEL_FACING_OFFSET
+  configControls
 } from './config'
 
 const route = useRoute()
@@ -207,7 +206,7 @@ const registerGameTimeline = (
     name: 'Walk',
     category: 'user-input',
     action: () => {
-      const targetRotation = updatePlayerFacing(player, currentActions, MODEL_FACING_OFFSET)
+      const targetRotation = updatePlayerFacing(player, currentActions)
       const isMoving = targetRotation !== null
       const actionName = isMoving ? 'Esqueleto|walking' : 'Esqueleto|idle'
       logControllerForward(movement.debug, currentActions, targetRotation)

--- a/src/views/Experiments/ForestGame/config.ts
+++ b/src/views/Experiments/ForestGame/config.ts
@@ -42,14 +42,12 @@ import illustrationBush12Img from '@/assets/images/illustrations/Bush1-2.webp'
 
 // import grassTextureImg from "@/assets/images/illustrations/ground.webp";
 
-// Degrees added to the player's visual rotation to correct a model whose front
-// and back are inverted. 0 = no correction; set to 180 for a flipped model.
-export const MODEL_FACING_OFFSET = 0
-
 export const playerSettings = {
   model: {
     position: [0, -1, 0] as CoordinateTuple,
     rotation: [0, 0, 0] as CoordinateTuple,
+    // The mushroom model's front is on -Z, so face it 180 to match its travel direction.
+    facingOffset: 180,
     scale: [1, 1, 1] as CoordinateTuple,
     restitution: -10,
     boundary: 0.5,

--- a/src/views/Experiments/ForestGame/config.ts
+++ b/src/views/Experiments/ForestGame/config.ts
@@ -42,6 +42,10 @@ import illustrationBush12Img from '@/assets/images/illustrations/Bush1-2.webp'
 
 // import grassTextureImg from "@/assets/images/illustrations/ground.webp";
 
+// Degrees added to the player's visual rotation to correct a model whose front
+// and back are inverted. 0 = no correction; set to 180 for a flipped model.
+export const MODEL_FACING_OFFSET = 0
+
 export const playerSettings = {
   model: {
     position: [0, -1, 0] as CoordinateTuple,
@@ -131,8 +135,8 @@ export const controlBindings = {
       ' ': 'jump',
       a: 'move-left',
       d: 'move-right',
-      w: 'move-down',
-      s: 'move-up',
+      w: 'move-up',
+      s: 'move-down',
       p: 'print-log'
     },
     gamepad: {
@@ -140,18 +144,18 @@ export const controlBindings = {
       cross: 'jump',
       'dpad-left': 'move-left',
       'dpad-right': 'move-right',
-      'dpad-down': 'move-up',
-      'dpad-up': 'move-down',
+      'dpad-down': 'move-down',
+      'dpad-up': 'move-up',
       'axis0-left': 'move-left',
       'axis0-right': 'move-right',
-      'axis1-up': 'move-down',
-      'axis1-down': 'move-up'
+      'axis1-up': 'move-up',
+      'axis1-down': 'move-down'
     },
     'faux-pad': {
       left: 'move-left',
       right: 'move-right',
-      up: 'move-down',
-      down: 'move-up',
+      up: 'move-up',
+      down: 'move-down',
       click: 'jump'
     }
   },

--- a/src/views/Experiments/ForestGame/config.ts
+++ b/src/views/Experiments/ForestGame/config.ts
@@ -46,8 +46,9 @@ export const playerSettings = {
   model: {
     position: [0, -1, 0] as CoordinateTuple,
     rotation: [0, 0, 0] as CoordinateTuple,
-    // The mushroom model's front is on -Z, so face it 180 to match its travel direction.
-    facingOffset: 180,
+    // The mushroom is authored to turn the mirror-image way, so face it along the
+    // mirrored (left/right-swapped) heading. Movement direction is unaffected.
+    mirroredFacing: true,
     scale: [1, 1, 1] as CoordinateTuple,
     restitution: -10,
     boundary: 0.5,

--- a/src/views/Experiments/ForestGame/config.ts
+++ b/src/views/Experiments/ForestGame/config.ts
@@ -135,8 +135,8 @@ export const controlBindings = {
       ' ': 'jump',
       a: 'move-left',
       d: 'move-right',
-      w: 'move-up',
-      s: 'move-down',
+      w: 'move-down',
+      s: 'move-up',
       p: 'print-log'
     },
     gamepad: {
@@ -144,18 +144,18 @@ export const controlBindings = {
       cross: 'jump',
       'dpad-left': 'move-left',
       'dpad-right': 'move-right',
-      'dpad-down': 'move-down',
-      'dpad-up': 'move-up',
+      'dpad-down': 'move-up',
+      'dpad-up': 'move-down',
       'axis0-left': 'move-left',
       'axis0-right': 'move-right',
-      'axis1-up': 'move-up',
-      'axis1-down': 'move-down'
+      'axis1-up': 'move-down',
+      'axis1-down': 'move-up'
     },
     'faux-pad': {
       left: 'move-left',
       right: 'move-right',
-      up: 'move-up',
-      down: 'move-down',
+      up: 'move-down',
+      down: 'move-up',
       click: 'jump'
     }
   },

--- a/src/views/Experiments/MultiplayerP2P/MultiplayerP2P.vue
+++ b/src/views/Experiments/MultiplayerP2P/MultiplayerP2P.vue
@@ -13,7 +13,7 @@ import {
   type CoordinateTuple,
   type AnimationData,
   updateAnimation,
-  setRotation,
+  rotateTowards,
   getRotation,
   createTimelineManager,
   playActionTimeline
@@ -383,10 +383,11 @@ const init = async (): Promise<void> => {
 
           if (isMoving) {
             if (localPlayer.userData.allowRotation || !localPlayer.userData.performing) {
-              setRotation(localPlayer, targetRotation)
+              rotateTowards(localPlayer, targetRotation)
             }
             if (localPlayer.userData.allowMovement || !localPlayer.userData.performing) {
-              localPlayer.getWorldDirection(movementDirection)
+              const headingRadians = THREE.MathUtils.degToRad(targetRotation)
+              movementDirection.set(Math.sin(headingRadians), 0, Math.cos(headingRadians))
               localPlayer.position.x += movementDirection.x * MOVEMENT_SPEED
               localPlayer.position.z += movementDirection.z * MOVEMENT_SPEED
               localPlayer.position.y = PLAYER_Y_OFFSET

--- a/src/views/Games/MazeGame/config.ts
+++ b/src/views/Games/MazeGame/config.ts
@@ -47,6 +47,9 @@ export const HELPER_COLOR_ELEVATOR = 0x0088ff
 export const PLAYER_SPEED = 10
 export const PLAYER_DISTANCE = 0.5
 export const PLAYER_MODEL = 'stickboy_maze.glb'
+// Degrees added to the player's visual rotation to correct a model whose front
+// and back are inverted. 0 = no correction; set to 180 for a flipped model.
+export const PLAYER_MODEL_FACING_OFFSET = 0
 const PLAYER_Y = -1.15
 const MAZE_HALF = ISLAND_SIZE / 2
 export const MAZE_ENTRANCE_OFFSET = MAZE_HALF - MAZE_CELL_SIZE / 2

--- a/src/views/Games/MazeGame/config.ts
+++ b/src/views/Games/MazeGame/config.ts
@@ -47,9 +47,6 @@ export const HELPER_COLOR_ELEVATOR = 0x0088ff
 export const PLAYER_SPEED = 10
 export const PLAYER_DISTANCE = 0.5
 export const PLAYER_MODEL = 'stickboy_maze.glb'
-// Degrees added to the player's visual rotation to correct a model whose front
-// and back are inverted. 0 = no correction; set to 180 for a flipped model.
-export const PLAYER_MODEL_FACING_OFFSET = 0
 const PLAYER_Y = -1.15
 const MAZE_HALF = ISLAND_SIZE / 2
 export const MAZE_ENTRANCE_OFFSET = MAZE_HALF - MAZE_CELL_SIZE / 2

--- a/src/views/Games/MazeGame/config.ts
+++ b/src/views/Games/MazeGame/config.ts
@@ -202,30 +202,34 @@ export const setupConfig: SetupConfig = {
   }
 }
 
+// The camera sits on the +Z side looking toward -Z, and getRotation treats
+// "up" (0deg) as +Z. So "away from the camera" is -Z: pressing up must map to
+// move-down. All +Z-camera games (MazeGame, ForestGame, MixamoPlayground) share
+// this convention so movement and facing behave identically.
 export const controlBindings = {
   mapping: {
     keyboard: {
       a: 'move-left',
       d: 'move-right',
-      w: 'move-up',
-      s: 'move-down'
+      w: 'move-down',
+      s: 'move-up'
     },
     gamepad: {
       'dpad-left': 'move-left',
       'dpad-right': 'move-right',
-      'dpad-down': 'move-down',
-      'dpad-up': 'move-up',
+      'dpad-down': 'move-up',
+      'dpad-up': 'move-down',
       'axis0-left': 'move-left',
       'axis0-right': 'move-right',
-      'axis1-up': 'move-up',
-      'axis1-down': 'move-down',
+      'axis1-up': 'move-down',
+      'axis1-down': 'move-up',
       cross: 'toggle-auto'
     },
     'faux-pad': {
       left: 'move-left',
       right: 'move-right',
-      up: 'move-up',
-      down: 'move-down'
+      up: 'move-down',
+      down: 'move-up'
     }
   },
   axisThreshold: 0.5

--- a/src/views/Games/MazeGame/helpers/player.ts
+++ b/src/views/Games/MazeGame/helpers/player.ts
@@ -7,13 +7,7 @@ import {
   getMovementDirection,
   type AnimationData
 } from '@webgamekit/animation'
-import {
-  PLAYER_MODEL,
-  playerModelOptions,
-  PLAYER_SPEED,
-  PLAYER_DISTANCE,
-  PLAYER_MODEL_FACING_OFFSET
-} from '../config'
+import { PLAYER_MODEL, playerModelOptions, PLAYER_SPEED, PLAYER_DISTANCE } from '../config'
 
 export const createPlayer = async (
   scene: THREE.Scene,
@@ -31,7 +25,7 @@ export const updatePlayerMovement = (
   speed: number = PLAYER_SPEED,
   filterPredicate?: (collider: object) => boolean
 ): void => {
-  const targetRotation = updatePlayerFacing(player, currentActions, PLAYER_MODEL_FACING_OFFSET)
+  const targetRotation = updatePlayerFacing(player, currentActions)
   const isMoving = targetRotation !== null
   const delta = getDelta()
 

--- a/src/views/Games/MazeGame/helpers/player.ts
+++ b/src/views/Games/MazeGame/helpers/player.ts
@@ -3,10 +3,8 @@ import * as THREE from 'three'
 import { getModel, moveController, type ComplexModel } from '@webgamekit/threejs'
 import {
   updateAnimation,
-  rotateTowards,
-  getRotation,
+  updatePlayerFacing,
   getMovementDirection,
-  DEFAULT_ROTATION_STEP_DEGREES,
   type AnimationData
 } from '@webgamekit/animation'
 import {
@@ -33,7 +31,7 @@ export const updatePlayerMovement = (
   speed: number = PLAYER_SPEED,
   filterPredicate?: (collider: object) => boolean
 ): void => {
-  const targetRotation = getRotation(currentActions, false)
+  const targetRotation = updatePlayerFacing(player, currentActions, PLAYER_MODEL_FACING_OFFSET)
   const isMoving = targetRotation !== null
   const delta = getDelta()
 
@@ -46,7 +44,6 @@ export const updatePlayerMovement = (
   }
 
   if (isMoving) {
-    rotateTowards(player, targetRotation, DEFAULT_ROTATION_STEP_DEGREES, PLAYER_MODEL_FACING_OFFSET)
     const { direction } = getMovementDirection(player, 1, false, targetRotation)
     moveController(
       player,

--- a/src/views/Games/MazeGame/helpers/player.ts
+++ b/src/views/Games/MazeGame/helpers/player.ts
@@ -3,12 +3,19 @@ import * as THREE from 'three'
 import { getModel, moveController, type ComplexModel } from '@webgamekit/threejs'
 import {
   updateAnimation,
-  setRotation,
+  rotateTowards,
   getRotation,
   getMovementDirection,
+  DEFAULT_ROTATION_STEP_DEGREES,
   type AnimationData
 } from '@webgamekit/animation'
-import { PLAYER_MODEL, playerModelOptions, PLAYER_SPEED, PLAYER_DISTANCE } from '../config'
+import {
+  PLAYER_MODEL,
+  playerModelOptions,
+  PLAYER_SPEED,
+  PLAYER_DISTANCE,
+  PLAYER_MODEL_FACING_OFFSET
+} from '../config'
 
 export const createPlayer = async (
   scene: THREE.Scene,
@@ -39,8 +46,8 @@ export const updatePlayerMovement = (
   }
 
   if (isMoving) {
-    setRotation(player, targetRotation)
-    const { direction } = getMovementDirection(player, 1, false)
+    rotateTowards(player, targetRotation, DEFAULT_ROTATION_STEP_DEGREES, PLAYER_MODEL_FACING_OFFSET)
+    const { direction } = getMovementDirection(player, 1, false, targetRotation)
     moveController(
       player,
       {

--- a/src/views/Tests/Timeline/Timeline.vue
+++ b/src/views/Tests/Timeline/Timeline.vue
@@ -17,7 +17,7 @@ import LoadingOverlay from '@/components/LoadingOverlay.vue'
 import {
   bindAnimatedElements,
   createTimelineManager,
-  setRotation,
+  rotateTowards,
   type Timeline,
   type CoordinateTuple
 } from '@webgamekit/animation'
@@ -225,7 +225,7 @@ const navigateWalkingFollower = (tick: ActivePathTick, getDelta: () => number): 
   const dx = targetX - model.position.x
   const dz = targetZ - model.position.z
   const distanceXZ = Math.hypot(dx, dz)
-  setRotation(model, THREE.MathUtils.radToDeg(Math.atan2(dx, -dz)))
+  rotateTowards(model, THREE.MathUtils.radToDeg(Math.atan2(dx, -dz)))
 
   const blocked = stepFollowerHorizontal(model, dx, dz, distanceXZ, entry.config.speed * delta)
   const dy = targetY - model.position.y
@@ -292,7 +292,7 @@ const advanceSteppedFollower = (tick: ActivePathTick, getDelta: () => number): v
   const previousProgress = state.progress
   state.progress = Math.min(1, state.progress + (speed * delta) / segmentLength(a, b, type))
   if (type !== 'jump')
-    setRotation(model, THREE.MathUtils.radToDeg(Math.atan2(b[0] - a[0], -(b[2] - a[2]))))
+    rotateTowards(model, THREE.MathUtils.radToDeg(Math.atan2(b[0] - a[0], -(b[2] - a[2]))))
   // A walk must not cross a wall (e.g. after the path is dragged into one): hold
   // position and progress while a brick blocks the way. Jumps arc over, so skip.
   if (type === 'walk' && wallBlocksWalk(model, a, b, state.progress)) {

--- a/src/views/Tools/MixamoPlayground.vue
+++ b/src/views/Tools/MixamoPlayground.vue
@@ -7,7 +7,7 @@ import {
   type CoordinateTuple,
   type AnimationData,
   updateAnimation,
-  setRotation,
+  rotateTowards,
   getRotation,
   createTimelineManager,
   playActionTimeline
@@ -261,9 +261,10 @@ const init = async (): Promise<void> => {
           )
 
           if (isMoving) {
+            animationData.targetRotation = targetRotation
             // Only rotate if allowed
             if (player.userData.allowRotation || !player.userData.performing) {
-              setRotation(player, targetRotation)
+              rotateTowards(player, targetRotation)
             }
 
             // Only move if allowed

--- a/src/views/Tools/MixamoPlayground.vue
+++ b/src/views/Tools/MixamoPlayground.vue
@@ -21,10 +21,6 @@ import grassTextureImg from '@/assets/images/textures/grass.jpg'
 import { getActionName } from './MixamoPlayground.helpers'
 import { useDebugSceneStore } from '@/stores/debugScene'
 
-// Degrees added to the player's visual rotation to correct a model whose front
-// and back are inverted. 0 = no correction; set to 180 for a flipped model.
-const MODEL_FACING_OFFSET = 0
-
 const playerSettings = {
   model: {
     position: [0, -1, 0] as CoordinateTuple,
@@ -254,7 +250,7 @@ const init = async (): Promise<void> => {
             }
           }
 
-          const targetRotation = updatePlayerFacing(player, currentActions, MODEL_FACING_OFFSET)
+          const targetRotation = updatePlayerFacing(player, currentActions)
           const isMoving = targetRotation !== null
           const animationData: AnimationData = getActionData(
             player,

--- a/src/views/Tools/MixamoPlayground.vue
+++ b/src/views/Tools/MixamoPlayground.vue
@@ -7,8 +7,7 @@ import {
   type CoordinateTuple,
   type AnimationData,
   updateAnimation,
-  rotateTowards,
-  getRotation,
+  updatePlayerFacing,
   createTimelineManager,
   playActionTimeline
 } from '@webgamekit/animation'
@@ -21,6 +20,10 @@ import type { LoadProgress } from '@webgamekit/threejs'
 import grassTextureImg from '@/assets/images/textures/grass.jpg'
 import { getActionName } from './MixamoPlayground.helpers'
 import { useDebugSceneStore } from '@/stores/debugScene'
+
+// Degrees added to the player's visual rotation to correct a model whose front
+// and back are inverted. 0 = no correction; set to 180 for a flipped model.
+const MODEL_FACING_OFFSET = 0
 
 const playerSettings = {
   model: {
@@ -251,7 +254,7 @@ const init = async (): Promise<void> => {
             }
           }
 
-          const targetRotation = getRotation(currentActions)
+          const targetRotation = updatePlayerFacing(player, currentActions, MODEL_FACING_OFFSET)
           const isMoving = targetRotation !== null
           const animationData: AnimationData = getActionData(
             player,
@@ -262,10 +265,6 @@ const init = async (): Promise<void> => {
 
           if (isMoving) {
             animationData.targetRotation = targetRotation
-            // Only rotate if allowed
-            if (player.userData.allowRotation || !player.userData.performing) {
-              rotateTowards(player, targetRotation)
-            }
 
             // Only move if allowed
             if (player.userData.allowMovement || !player.userData.performing) {


### PR DESCRIPTION
Closes #66

## Summary

Adds an animation action that interpolates a model's rotation toward the target direction instead of snapping to it, giving a natural "turning to face" feel. Movement heads straight to the target direction while the mesh visually catches up, and a per-game facing offset cleanly handles models whose front/back is inverted.

## Key Changes

**`@webgamekit/animation`**
- `rotateTowards(model, degrees, stepDegrees = 25, modelOffset = 0)` — interpolates `rotation.y` along the shortest angular path, capping the change per step (default `DEFAULT_ROTATION_STEP_DEGREES = 25`); honors the existing `performing`/`allowRotation` guard. `setRotation` is kept for instant/authoritative use (e.g. remote-player sync).
- `getMovementDirection` gains an optional `headingDegrees`, and `AnimationData` gains `targetRotation`, so `controllerForward` moves toward the target heading rather than the lagging visual facing.

**Adoption**
- Player controllers migrated to smooth, target-driven turning: MazeGame, MixamoPlayground, ForestGame, MultiplayerP2P (local player), and Timeline path followers.
- `MODEL_FACING_OFFSET` config flag per game: `0` for MazeGame/ForestGame, `180` for ContinuousWorld (its shared `stickboy` model's front is `+Z` but the view travels along `-Z`). ContinuousWorld now uses smooth, target-driven rotation too.
- Fixed ForestGame's up/down control mapping that inverted the front/back axis (and its diagonals) relative to movement and facing.

## Test Plan

- Added parameterized unit tests for `rotateTowards` (shortest-path, step capping, alignment, wrap-around, `modelOffset`, default step, block guard) and for `getMovementDirection`'s `headingDegrees` (direction per heading, target-vs-facing, `getWorldDirection` parity, backward, fallback).
- `pnpm test:unit` — 1277 passing
- `pnpm type-check` — clean
- `pnpm lint` — 0 errors