### PR TITLE
Add ShaderTest1 experiment with data-driven config panel

### DIFF
--- a/src/views/Experiments/ShaderTest1/ShaderTest1.vue
+++ b/src/views/Experiments/ShaderTest1/ShaderTest1.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import * as THREE from 'three'
+
+import { getTools, type SetupConfig } from '@webgamekit/threejs'
+import { createTimelineManager } from '@webgamekit/animation'
+
+import vertexShader from './vertexShader.glsl?raw'
+import fragmentShader from './fragmentShader.glsl?raw'
+
+const statsElement = ref(null)
+const canvas = ref(null)
+let initInstance: () => void
+
+onMounted(() => {
+  initInstance = () => {
+    init(canvas.value as unknown as HTMLCanvasElement, statsElement.value as unknown as HTMLElement)
+  }
+
+  initInstance()
+  window.addEventListener('resize', initInstance)
+})
+onUnmounted(() => window.removeEventListener('resize', initInstance))
+
+const config: SetupConfig = {
+  ground: false,
+  sky: false,
+  scene: { backgroundColor: 0xffffff }
+}
+
+const init = async (canvas: HTMLCanvasElement, statsElement: HTMLElement) => {
+  const createScene = async () => {
+    const { animate, setup, getDelta, scene } = await getTools({ canvas })
+    setup({
+      config,
+      defineSetup: async () => {
+        const timelineManager = createTimelineManager()
+        animate({
+          timeline: timelineManager
+        })
+        // const geometry = new THREE.PlaneGeometry(window.innerWidth, window.innerHeight, 32, 32);
+        const geometry = new THREE.PlaneGeometry(100, 100, 32, 32)
+        const shaderMaterial = new THREE.ShaderMaterial({
+          vertexShader,
+          fragmentShader,
+          uniforms: {
+            uTime: { value: 0.0 },
+            uFrequency: { value: new THREE.Vector2(10.0, 10.0) }
+          }
+        })
+        const mesh = new THREE.Mesh(geometry, shaderMaterial)
+        scene.add(mesh)
+
+        timelineManager.addAction({
+          action: () => (shaderMaterial.uniforms.uTime.value += getDelta())
+        })
+      }
+    })
+  }
+  createScene()
+}
+</script>
+
+<template>
+  <div ref="statsElement"></div>
+  <canvas ref="canvas"></canvas>
+</template>

--- a/src/views/Experiments/ShaderTest1/ShaderTest1.vue
+++ b/src/views/Experiments/ShaderTest1/ShaderTest1.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
+import { useRoute } from 'vue-router'
 import * as THREE from 'three'
 
-import { getTools, type SetupConfig } from '@webgamekit/threejs'
+import { getTools } from '@webgamekit/threejs'
 import { createTimelineManager } from '@webgamekit/animation'
+import { registerViewConfig, unregisterViewConfig, createReactiveConfig } from '@/stores/viewConfig'
+import { useViewPanelsStore } from '@/stores/viewPanels'
+import { shaderTest1Config, shaderTest1Schema, setupConfig } from './config'
 
 import vertexShader from './vertexShader.glsl?raw'
 import fragmentShader from './fragmentShader.glsl?raw'
@@ -12,47 +16,57 @@ const statsElement = ref(null)
 const canvas = ref(null)
 let initInstance: () => void
 
+const route = useRoute()
+const { setViewPanels, clearViewPanels } = useViewPanelsStore()
+const reactiveConfig = createReactiveConfig(shaderTest1Config)
+
 onMounted(() => {
   initInstance = () => {
     init(canvas.value as unknown as HTMLCanvasElement, statsElement.value as unknown as HTMLElement)
   }
 
+  setViewPanels({ showConfig: true })
+  registerViewConfig(route.name as string, reactiveConfig, shaderTest1Schema)
+
   initInstance()
   window.addEventListener('resize', initInstance)
 })
-onUnmounted(() => window.removeEventListener('resize', initInstance))
-
-const config: SetupConfig = {
-  ground: false,
-  sky: false,
-  scene: { backgroundColor: 0xffffff }
-}
+onUnmounted(() => {
+  clearViewPanels()
+  unregisterViewConfig(route.name as string)
+  window.removeEventListener('resize', initInstance)
+})
 
 const init = async (canvas: HTMLCanvasElement, statsElement: HTMLElement) => {
   const createScene = async () => {
     const { animate, setup, getDelta, scene } = await getTools({ canvas })
     setup({
-      config,
+      config: setupConfig,
       defineSetup: async () => {
         const timelineManager = createTimelineManager()
         animate({
           timeline: timelineManager
         })
-        // const geometry = new THREE.PlaneGeometry(window.innerWidth, window.innerHeight, 32, 32);
         const geometry = new THREE.PlaneGeometry(100, 100, 32, 32)
+        const initialFrequency = reactiveConfig.value.shader.frequency
+
         const shaderMaterial = new THREE.ShaderMaterial({
           vertexShader,
           fragmentShader,
           uniforms: {
             uTime: { value: 0.0 },
-            uFrequency: { value: new THREE.Vector2(10.0, 10.0) }
+            uFrequency: { value: new THREE.Vector2(initialFrequency, initialFrequency) }
           }
         })
         const mesh = new THREE.Mesh(geometry, shaderMaterial)
         scene.add(mesh)
 
         timelineManager.addAction({
-          action: () => (shaderMaterial.uniforms.uTime.value += getDelta())
+          action: () => {
+            shaderMaterial.uniforms.uTime.value += getDelta()
+            const frequency = reactiveConfig.value.shader.frequency
+            shaderMaterial.uniforms.uFrequency.value.set(frequency, frequency)
+          }
         })
       }
     })

--- a/src/views/Experiments/ShaderTest1/config.ts
+++ b/src/views/Experiments/ShaderTest1/config.ts
@@ -1,0 +1,20 @@
+import type { ConfigControlsSchema } from '@/stores/viewConfig'
+import type { SetupConfig } from '@webgamekit/threejs'
+
+export const shaderTest1Config = {
+  shader: {
+    frequency: 10
+  }
+}
+
+export const shaderTest1Schema: ConfigControlsSchema = {
+  shader: {
+    frequency: { min: 0.1, max: 50, step: 0.1 }
+  }
+}
+
+export const setupConfig: SetupConfig = {
+  ground: false,
+  sky: false,
+  scene: { backgroundColor: 0x333333 }
+}

--- a/src/views/Experiments/ShaderTest1/fragmentShader.glsl
+++ b/src/views/Experiments/ShaderTest1/fragmentShader.glsl
@@ -1,0 +1,8 @@
+varying float vElevation;
+
+void main() {
+  vec3 color = vec3(0.3, 0.3, 0.3);
+  color.rgb += vElevation * 0.01;
+
+  gl_FragColor = vec4(color, 1.0);
+}

--- a/src/views/Experiments/ShaderTest1/vertexShader.glsl
+++ b/src/views/Experiments/ShaderTest1/vertexShader.glsl
@@ -1,0 +1,34 @@
+varying vec2 vUv;
+uniform float uTime;
+uniform vec2 uFrequency;
+varying float vElevation;
+
+void main() {
+  // Basic
+  // gl_Position = projectionMatrix * viewMatrix * modelMatrix * vec4(position, 1.0);
+  
+  // Flag static
+  // vec4 modelPosition = modelMatrix * vec4(position, 1.0);
+  // modelPosition.z += sin(modelPosition.x) * 20.0;
+
+  // Waves static
+  // vec4 modelPosition = modelMatrix * vec4(position, 1.0);
+  // modelPosition.z += sin(modelPosition.x * uFrequency.x) * 20.0;  
+  // modelPosition.z += sin(modelPosition.y * uFrequency.y * 0.01) * 20.0;  
+  
+  // Waves animation
+  vec4 modelPosition = modelMatrix * vec4(position, 1.0);
+  float elevation = sin(modelPosition.x * uFrequency.x + uTime) * 10.0;  
+  elevation += sin(modelPosition.y * uFrequency.y * 0.01 + uTime) * 10.0;  
+  
+  modelPosition.z += elevation;
+
+  // Final computation
+  vec4 viewPosition = viewMatrix * modelPosition;
+  vec4 projectedPosition = projectionMatrix * viewPosition;
+
+  gl_Position = projectedPosition;
+
+  vUv = uv;
+  vElevation = elevation;
+}

--- a/src/views/Templates/ThreejsToolsShader.vue
+++ b/src/views/Templates/ThreejsToolsShader.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import * as THREE from 'three'
+
+import { getTools, type SetupConfig } from '@webgamekit/threejs'
+import { createTimelineManager } from '@webgamekit/animation'
+
+const statsElement = ref(null)
+const canvas = ref(null)
+let initInstance: () => void
+onMounted(() => {
+  initInstance = () => {
+    init(canvas.value as unknown as HTMLCanvasElement, statsElement.value as unknown as HTMLElement)
+  }
+
+  initInstance()
+  window.addEventListener('resize', initInstance)
+})
+onUnmounted(() => window.removeEventListener('resize', initInstance))
+
+const config: SetupConfig = {
+  ground: false,
+  sky: false,
+  scene: { backgroundColor: 0x999999 }
+}
+
+const shaderMaterial = new THREE.ShaderMaterial({
+  vertexShader: ``,
+  fragmentShader: ``
+})
+
+const init = async (canvas: HTMLCanvasElement, statsElement: HTMLElement) => {
+  const createScene = async () => {
+    const { animate, setup, scene } = await getTools({ canvas })
+    setup({
+      config,
+      defineSetup: async () => {
+        const timelineManager = createTimelineManager()
+        animate({
+          timeline: timelineManager
+        })
+        const geometry = new THREE.PlaneGeometry(window.innerWidth, window.innerHeight)
+        const mesh = new THREE.Mesh(geometry, shaderMaterial)
+        scene.add(mesh)
+      }
+    })
+  }
+  createScene()
+}
+</script>
+
+<template>
+  <div ref="statsElement"></div>
+  <canvas ref="canvas"></canvas>
+</template>


### PR DESCRIPTION
## Summary
- Adds a new shader experiment (`ShaderTest1`) with an animated ripple plane, plus a `ThreejsToolsShader` template
- Wires the view into the existing data-driven Config panel (same pattern as `GrassGenerator`), exposing a live `Frequency` slider bound to the shader's `uFrequency` uniform

## Key Changes
- `src/views/Experiments/ShaderTest1/` — new view, vertex/fragment shaders, and a co-located `config.ts` holding the reactive config + schema for the Config panel
- `registerViewConfig`/`unregisterViewConfig` + `setViewPanels({ showConfig: true })` wire the view into `useViewConfigStore`, so the Config tab auto-generates a "Shader → Frequency" slider from the schema; new properties can be added by extending `shaderTest1Config`/`shaderTest1Schema`, no further plumbing needed
- Frequency is read live inside the existing per-frame timeline action and pushed to `uFrequency`, so the slider updates the wave instantly without reinitializing the scene
- `src/views/Templates/ThreejsToolsShader.vue` — new template

## Test Plan
- [x] `pnpm type-check` passes
- [x] `pnpm test:unit` passes (1322 tests)
- [x] Manually verified in the browser: Config panel shows a Frequency slider defaulting to 10, dragging it reshapes the rendered wave in real time, no console errors