### PR TITLE
fix: serve production build instead of the Vite dev server (#203)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ WORKDIR /usr/src/app
 
 COPY . .
 
-RUN npm install -g pnpm && pnpm install
+RUN npm install -g pnpm && pnpm install && pnpm build
 
 CMD ["pnpm", "run", "host"]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "host": "vite --host --port 3000",
+    "host": "vite preview --host --port 3000",
     "build": "vue-tsc --noEmit && vite build && node scripts/generate-route-html.mjs",
     "preview": "vite preview",
     "test:unit": "vitest run",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,8 @@ const packages = [
   'chat',
   'canvas-editor'
 ]
+const allowedHosts = ['cnotv.xyz', 'test.cnotv.xyz', 'game.cnotv.xyz', 'cnotv.github.io']
+
 const packageAliases = Object.fromEntries(
   packages.map((package_) => [
     `@webgamekit/${package_}`,
@@ -55,6 +57,9 @@ export default defineConfig({
     exclude: ['@dimforge/rapier3d-compat', 'trystero', 'trystero/nostr']
   },
   server: {
-    allowedHosts: ['cnotv.xyz', 'test.cnotv.xyz', 'game.cnotv.xyz', 'cnotv.github.io']
+    allowedHosts
+  },
+  preview: {
+    allowedHosts
   }
 })


### PR DESCRIPTION
Closes #203

## Summary

Production served the **Vite dev server** (`vite --host`) instead of a built app, so every request was transformed on the fly by `@vitejs/plugin-vue`. A probe request for `/.env.local?vue&src` (bots routinely scan public hosts for leaked env files) drove the plugin's `load` hook to `readFileSync` a file that `.dockerignore` guarantees never exists, producing an `ENOENT` that the dev-only HMR error overlay showed to real users on first load.

This builds the app in the Docker image and serves `dist/` via `vite preview`.

## Key Changes

- **`Dockerfile`** — run `pnpm build` when building the image so `dist/` exists before the container starts.
- **`package.json`** — `host` now runs `vite preview --host --port 3000` (only the Dockerfile references it; the container `CMD` is unchanged).
- **`vite.config.ts`** — add `preview.allowedHosts` (preview does not inherit `server.allowedHosts`), sharing a single `allowedHosts` const between `server` and `preview`.

## Test Plan

- `pnpm build` succeeds and pre-renders all 48 routes into `dist/`.
- `pnpm run host` serves the built assets on port 3000 (`assets/index-*.js`).
- `GET /` returns `200`; `GET /.env.local` and `GET /.env.local?vue&type=style&src=true` return a plain `200` SPA fallback with no transform, no `ENOENT`, and no dev overlay — the exact request that produced the 500 + overlay under the dev server.
- Husky type-check, prettier, and eslint passed on commit.

## Added on top of the initial plan

Nothing beyond the original issue scope — the three files above are the complete change.