### PR TITLE
Marble Editor: Endless Drop descending track, test-ball spawner, and turn/physics/visual fixes (#205)

### DIFF
--- a/src/views/Games/MarbleEditor/MarbleEditor.vue
+++ b/src/views/Games/MarbleEditor/MarbleEditor.vue
@@ -24,6 +24,8 @@ import {
   LobbyUIFocusHint,
   LobbyUIConfirm
 } from '@/components/LobbyUI'
+import { useRoute } from 'vue-router'
+import { registerViewConfig, unregisterViewConfig, createReactiveConfig } from '@/stores/viewConfig'
 import { isMobile } from '@webgamekit/controls'
 import TouchControl from '@/components/TouchControl.vue'
 import { useMenuFocus } from '@/composables/useMenuFocus'
@@ -256,6 +258,25 @@ const canRestart = computed(() => store.solo || isHost.value)
 
 const cameraLabel = computed(() => CAMERA_MODE_LABELS[race.cameraMode.value])
 
+// Test-ball spawner lives in the app Config panel (top-right): a count slider
+// plus an "Add balls" action that drops that many uncontrolled marbles.
+const route = useRoute()
+const testConfig = createReactiveConfig({ testBalls: { count: 10, randomTextures: false } })
+const testConfigSchema = {
+  testBalls: {
+    count: { min: 1, max: 50, step: 1, label: 'Count' },
+    randomTextures: { checkbox: false, label: 'Random textures' },
+    add: { callback: 'addBalls', label: 'Add balls' }
+  }
+}
+const testConfigCallbacks = {
+  addBalls: () =>
+    race.spawnTestMarbles(
+      Number(testConfig.value.testBalls.count),
+      Boolean(testConfig.value.testBalls.randomTextures)
+    )
+}
+
 const namingNewTrack = ref(false)
 
 const handleCreateTrack = (name: string): void => {
@@ -349,12 +370,20 @@ onMounted(async () => {
     'https://fonts.googleapis.com/css2?family=Darumadrop+One&display=swap',
     ME_FONT_KEY
   )
+  registerViewConfig(
+    route.name as string,
+    testConfig,
+    testConfigSchema,
+    undefined,
+    testConfigCallbacks
+  )
   await nextTick()
   if (phase.value === 'lobby') await editor.init({ backdrop: true })
 })
 
 onUnmounted(() => {
   removeGoogleFont(ME_FONT_KEY)
+  unregisterViewConfig(route.name as string)
 })
 </script>
 
@@ -474,10 +503,11 @@ onUnmounted(() => {
             @click="requestBackToEditor"
           >
             Editor
+            <LobbyUIKeyPill :keyboard="['E']" :gamepad="['□']" />
           </LobbyUIButton>
           <LobbyUIButton size="sm" variant="ghost" title="Exit the game" @click="requestExitGame">
             Exit
-            <LobbyUIKeyPill :gamepad="['□']" />
+            <LobbyUIKeyPill :keyboard="['Esc']" :gamepad="['○']" />
           </LobbyUIButton>
         </div>
         <TouchControl

--- a/src/views/Games/MarbleEditor/bedroomConfig.ts
+++ b/src/views/Games/MarbleEditor/bedroomConfig.ts
@@ -28,7 +28,11 @@ export const CEILING_COLOR = 0xfdf8f0
 export const RUG_COLORS = [0xf28c6b, 0xf7b267, 0xfcd5a5]
 export const RUG_RADIUS_FRACTION = 0.32
 export const RUG_RING_STEP = 0.3
-export const RUG_Y_STEP = 0.06
+// The rug rings are non-overlapping annuli lifted just above the floor; the
+// depth-offset keeps them from z-fighting the giant floor plane at distance.
+export const RUG_LIFT = 0.06
+export const RUG_SEGMENTS = 64
+export const RUG_DEPTH_OFFSET = 2
 
 export const WINDOW_WIDTH_FRACTION = 0.28
 export const WINDOW_HEIGHT_FRACTION = 0.4

--- a/src/views/Games/MarbleEditor/bedroomEnvironment.ts
+++ b/src/views/Games/MarbleEditor/bedroomEnvironment.ts
@@ -18,7 +18,9 @@ import {
   RUG_COLORS,
   RUG_RADIUS_FRACTION,
   RUG_RING_STEP,
-  RUG_Y_STEP,
+  RUG_LIFT,
+  RUG_SEGMENTS,
+  RUG_DEPTH_OFFSET,
   WINDOW_WIDTH_FRACTION,
   WINDOW_HEIGHT_FRACTION,
   WINDOW_SILL_FRACTION,
@@ -272,16 +274,32 @@ const buildFloor = (layout: RoomLayout): THREE.Mesh => {
   return floor
 }
 
+// Concentric rings are non-overlapping annuli (the innermost a full disc) so no
+// two rug surfaces are coplanar; a single lift plus a polygon depth-offset lifts
+// the whole rug clear of the giant floor plane without z-fighting it.
 const buildRug = (layout: RoomLayout): THREE.Group => {
   const group = new THREE.Group()
   const baseRadius = Math.min(layout.width, layout.depth) * RUG_RADIUS_FRACTION
+  const ringCount = RUG_COLORS.length
   RUG_COLORS.forEach((color, ring) => {
+    const outerRadius = baseRadius * (1 - ring * RUG_RING_STEP)
+    const innerRadius = ring === ringCount - 1 ? 0 : baseRadius * (1 - (ring + 1) * RUG_RING_STEP)
+    const geometry =
+      innerRadius === 0
+        ? new THREE.CircleGeometry(outerRadius, RUG_SEGMENTS)
+        : new THREE.RingGeometry(innerRadius, outerRadius, RUG_SEGMENTS)
     const disc = new THREE.Mesh(
-      new THREE.CircleGeometry(baseRadius * (1 - ring * RUG_RING_STEP), 48),
-      new THREE.MeshStandardMaterial({ color, roughness: 1 })
+      geometry,
+      new THREE.MeshStandardMaterial({
+        color,
+        roughness: 1,
+        polygonOffset: true,
+        polygonOffsetFactor: -RUG_DEPTH_OFFSET,
+        polygonOffsetUnits: -RUG_DEPTH_OFFSET
+      })
     )
     disc.rotation.x = -Math.PI / 2
-    disc.position.set(layout.centerX, layout.floorY + 0.05 + ring * RUG_Y_STEP, layout.centerZ)
+    disc.position.set(layout.centerX, layout.floorY + RUG_LIFT, layout.centerZ)
     disc.receiveShadow = true
     group.add(disc)
   })

--- a/src/views/Games/MarbleEditor/chainTransforms.test.ts
+++ b/src/views/Games/MarbleEditor/chainTransforms.test.ts
@@ -4,6 +4,7 @@ import { PIECE_CATALOG } from './pieceCatalog'
 import {
   STRAIGHT_SHORT_LENGTH,
   CURVE_RADIUS,
+  CURVE_DROP,
   RAMP_LENGTH,
   RAMP_ANGLE,
   RAMP_LIP_LENGTH,
@@ -73,13 +74,13 @@ describe('computeChainTransforms', () => {
     expect(transforms[2].yaw).toBeCloseTo(Math.PI / 2)
   })
 
-  it('closes a full circle after four curve-lefts', () => {
+  it('spirals a full turn after four curve-lefts, closing in x/z and dropping in y', () => {
     const transforms = computeChainTransforms(
       makePieces(['curve-left', 'curve-left', 'curve-left', 'curve-left', 'straight-short'])
     )
     const closing = transforms[4]
     expect(closing.position[0]).toBeCloseTo(0)
-    expect(closing.position[1]).toBeCloseTo(0)
+    expect(closing.position[1]).toBeCloseTo(-4 * CURVE_DROP)
     expect(closing.position[2]).toBeCloseTo(0)
     expect(closing.yaw).toBeCloseTo(2 * Math.PI)
   })

--- a/src/views/Games/MarbleEditor/config.ts
+++ b/src/views/Games/MarbleEditor/config.ts
@@ -25,6 +25,9 @@ export const FINISH_LENGTH = 16
 export const STRAIGHT_SHORT_LENGTH = 12
 export const STRAIGHT_LONG_LENGTH = 24
 export const CURVE_RADIUS = 10
+// Curves and banked curves descend across the arc (a helix) so the marble keeps
+// losing height through every turn instead of stalling on a flat 180.
+export const CURVE_DROP = 4
 export const RAMP_LENGTH = 20
 export const RAMP_ANGLE = 0.25
 export const FUNNEL_DROP_HEIGHT = 8
@@ -37,8 +40,10 @@ export const BUMPER_FIELD_LENGTH = 16
 
 export const CURVE_SEGMENTS = 12
 export const CURVE_CHORD_OVERLAP = 1.06
-export const BANK_ANGLE = 0.3
-export const BANK_BLEND_ANGLE = 0.35
+// Banked curves are the flat curve deck with a taller wall on the turn's outer
+// edge: it contains a fast marble through the arc instead of a rolled surface
+// launching it off the track.
+export const BANK_WALL_HEIGHT = 3.6
 export const RAMP_LIP_LENGTH = 1.5
 
 export const FUNNEL_TONGUE_LENGTH = 2
@@ -70,6 +75,10 @@ export const BUMPER_SPACING_Z = 4
 export const BUMPER_CLEARANCE_MARGIN = 0.3
 
 export const DECK_FRICTION = 0.9
+// The swept curve is one solid (deck and walls share a friction), so it uses a
+// lower value than the flat deck: a marble leaning on the outer wall through a
+// turn would grind and snag at the higher deck friction.
+export const CURVE_FRICTION = 0.3
 export const DECK_RESTITUTION = 0.004
 export const MARBLE_RESTITUTION = 0.002
 export const WALL_FRICTION = 0.05
@@ -123,6 +132,8 @@ export const KEYBOARD_MAPPING = {
     d: 'right',
     ArrowRight: 'right',
     c: 'camera',
+    e: 'editor',
+    Escape: 'exit',
     z: 'undo',
     y: 'redo'
   },
@@ -136,7 +147,8 @@ export const KEYBOARD_MAPPING = {
     'dpad-left': 'left',
     'dpad-right': 'right',
     triangle: 'camera',
-    square: 'exit',
+    square: 'editor',
+    circle: 'exit',
     options: 'back',
     l1: 'undo',
     r1: 'redo'
@@ -255,10 +267,14 @@ export const FIRST_PERSON_HEIGHT = 1.4
 export const FIRST_PERSON_LOOK_AHEAD = 8
 export const FIRST_PERSON_DIRECTION_LERP = 0.12
 export const FIRST_PERSON_MIN_SPEED = 1
+// Free camera drops the player in high and far back on entry so the whole track
+// is in view; the orbit controls then let them zoom and pan from there.
+export const FREE_CAM_HEIGHT = 70
+export const FREE_CAM_BACK = 70
 export const CHECKPOINT_RADIUS = 9
 export const BOOST_ZONE_MAX_HEIGHT = 3
-export const BOOST_MAX_SPEED = 30
-export const BOOST_IMPULSE = 3
+export const BOOST_MAX_SPEED = 48
+export const BOOST_IMPULSE = 14
 export const FALL_MARGIN = 15
 export const TIME_PENALTY_FALL = 5
 

--- a/src/views/Games/MarbleEditor/game/raceCameras.ts
+++ b/src/views/Games/MarbleEditor/game/raceCameras.ts
@@ -6,7 +6,9 @@ import {
   FIRST_PERSON_HEIGHT,
   FIRST_PERSON_LOOK_AHEAD,
   FIRST_PERSON_DIRECTION_LERP,
-  FIRST_PERSON_MIN_SPEED
+  FIRST_PERSON_MIN_SPEED,
+  FREE_CAM_HEIGHT,
+  FREE_CAM_BACK
 } from '../config'
 import { CAMERA_HEIGHT, CAMERA_BACK, CAMERA_LERP } from '../../MarbleMadness/config'
 
@@ -71,15 +73,25 @@ export type RaceCameraOptions = {
   marble: ComplexModel | null
   orbit: OrbitControls | null
   smoothedDirection: THREE.Vector3
+  justEnteredFree?: boolean
 }
 
 export const applyRaceCamera = (options: RaceCameraOptions): void => {
-  const { mode, camera, marble, orbit, smoothedDirection } = options
+  const { mode, camera, marble, orbit, smoothedDirection, justEnteredFree } = options
   if (!marble) return
   if (mode === 'free') {
     if (orbit) {
       orbit.enabled = true
       orbit.target.copy(marble.position)
+    }
+    // On entry, drop the camera high and far back so the whole track is framed;
+    // the orbit controls preserve that offset and let the player zoom in.
+    if (justEnteredFree) {
+      camera.position.set(
+        marble.position.x - smoothedDirection.x * FREE_CAM_BACK,
+        marble.position.y + FREE_CAM_HEIGHT,
+        marble.position.z - smoothedDirection.z * FREE_CAM_BACK
+      )
     }
     return
   }

--- a/src/views/Games/MarbleEditor/game/useMarbleRace.ts
+++ b/src/views/Games/MarbleEditor/game/useMarbleRace.ts
@@ -35,7 +35,8 @@ import type {
   BuiltTrack,
   CameraMode,
   BallPosPayload,
-  BedroomEnvironment
+  BedroomEnvironment,
+  BoostZone
 } from '../types'
 import {
   SPAWN_HEIGHT,
@@ -58,6 +59,7 @@ import {
   LIGHT_DIRECTIONAL_POSITION
 } from '../config'
 import {
+  MARBLE_OPTIONS,
   MARBLE_RADIUS,
   MARBLE_LINEAR_DAMPING,
   MARBLE_ANGULAR_DAMPING,
@@ -68,6 +70,8 @@ import {
   LIGHT_SHADOW_BIAS,
   LIGHT_SHADOW_CAMERA
 } from '../../MarbleMadness/config'
+
+const TEST_TEXTURE_POOL = MARBLE_OPTIONS.map((option) => option.url)
 
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T
 type GetToolsResult = UnwrapPromise<ReturnType<typeof getTools>>
@@ -91,6 +95,8 @@ export type UseMarbleRaceDeps = {
 
 type RaceState = {
   marble: ComplexModel | null
+  testMarbles: ComplexModel[]
+  world: WorldReference | null
   controls: ControlsExtras | null
   builtTrack: BuiltTrack | null
   checkpointIndex: number
@@ -98,6 +104,7 @@ type RaceState = {
   directionalLight: THREE.DirectionalLight | null
   smoothedDirection: THREE.Vector3
   cameraActionHeld: boolean
+  prevCameraMode: CameraMode
   localLabel: THREE.Sprite | null
   scene: THREE.Scene | null
   bedroom: BedroomEnvironment | null
@@ -105,8 +112,78 @@ type RaceState = {
   posAccumulator: number
 }
 
+// Test helper: drops `count` uncontrolled marbles onto the start, staggered in
+// a grid so they don't spawn on top of each other, to observe the track's
+// physics without steering. They roll under gravity only and are torn down with
+// the scene.
+const randomTestTexture = (): string | undefined =>
+  TEST_TEXTURE_POOL.length === 0
+    ? undefined
+    : TEST_TEXTURE_POOL[Math.floor(Math.random() * TEST_TEXTURE_POOL.length)]
+
+const spawnTestMarblesInto = (
+  state: RaceState,
+  deps: UseMarbleRaceDeps,
+  count: number,
+  randomTexture: boolean
+): void => {
+  const { scene, world, builtTrack } = state
+  if (!scene || !world || !builtTrack) return
+  const start = builtTrack.startTransform ?? { position: [0, 0, 0] as CoordinateTuple, yaw: 0 }
+  const clamped = Math.max(1, Math.min(Math.floor(count), MAX_TEST_MARBLES))
+  Array.from({ length: clamped }).forEach((_, index) => {
+    const column = index % TEST_MARBLE_COLUMNS
+    const row = Math.floor(index / TEST_MARBLE_COLUMNS)
+    const localX = (column - (TEST_MARBLE_COLUMNS - 1) / 2) * TEST_MARBLE_SPACING
+    const localZ = SPAWN_Z_INSET + row * TEST_MARBLE_SPACING
+    const position = applyPieceTransform(start, [localX, SPAWN_HEIGHT + MARBLE_RADIUS, localZ])
+    const texture = randomTexture ? randomTestTexture() : deps.marbleTexture.value
+    state.testMarbles.push(spawnMarble(scene, world, position, texture))
+  })
+}
+
+type BoostableBody = {
+  translation: () => { x: number; y: number; z: number }
+  linvel: () => { x: number; y: number; z: number }
+  applyImpulse: (impulse: { x: number; y: number; z: number }, wake: boolean) => void
+}
+
+// Boost pads redirect the body along its own heading up to BOOST_MAX_SPEED.
+// Shared by the player marble and the uncontrolled test marbles so a boost pad
+// flings every ball, not just the driven one.
+const applyBoostImpulse = (body: BoostableBody, boostZones: BoostZone[]): boolean => {
+  const onBoost = boostZones.some((zone) => isOnBoostZone(body.translation(), zone))
+  if (!onBoost) return false
+  const velocity = body.linvel()
+  const speed = Math.hypot(velocity.x, velocity.z)
+  if (speed > 0 && speed < BOOST_MAX_SPEED) {
+    const scale = BOOST_IMPULSE / speed
+    body.applyImpulse({ x: velocity.x * scale, y: 0, z: velocity.z * scale }, true)
+  }
+  return onBoost
+}
+
+// Drives the uncontrolled test marbles each frame: applies boost pads (they get
+// no player input) and copies each Rapier body transform onto its mesh,
+// mirroring createPhysicsSyncAction for the single player marble.
+const updateTestMarbles = (state: RaceState): void => {
+  const boostZones = state.builtTrack?.boostZones ?? []
+  state.testMarbles.forEach((marble) => {
+    const body = marble.userData.body
+    applyBoostImpulse(body, boostZones)
+    const pos = body.translation()
+    marble.position.set(pos.x, pos.y, pos.z)
+    const rot = body.rotation()
+    marble.quaternion.set(rot.x, rot.y, rot.z, rot.w)
+  })
+}
+
 const VERTICAL_INPUT_REDIRECT_VY = 1
 const VERTICAL_INPUT_REDIRECT_SPEED = 4
+
+const MAX_TEST_MARBLES = 50
+const TEST_MARBLE_COLUMNS = 4
+const TEST_MARBLE_SPACING = MARBLE_RADIUS * 2.4
 
 const computeImpulse = (
   currentActions: ControlsCurrents,
@@ -257,6 +334,12 @@ const buildRaceTimeline = (wiring: TimelineWiring) => {
     action: wiring.applyInputAndBoost
   })
   timeline.addAction(createPhysicsSyncAction(() => state.marble))
+  timeline.addAction({
+    name: 'test-marbles-update',
+    category: 'physics',
+    start: 0,
+    action: () => updateTestMarbles(state)
+  })
   timeline.addAction(
     createDirectionalLightFollowAction(
       () => state.directionalLight,
@@ -268,14 +351,18 @@ const buildRaceTimeline = (wiring: TimelineWiring) => {
     name: 'race-camera',
     category: 'camera',
     start: 0,
-    action: () =>
+    action: () => {
+      const mode = wiring.cameraMode.value
       applyRaceCamera({
-        mode: wiring.cameraMode.value,
+        mode,
         camera,
         marble: state.marble,
         orbit,
-        smoothedDirection: state.smoothedDirection
+        smoothedDirection: state.smoothedDirection,
+        justEnteredFree: mode === 'free' && state.prevCameraMode !== 'free'
       })
+      state.prevCameraMode = mode
+    }
   })
   timeline.addAction(
     createFallCheckAction(
@@ -398,18 +485,10 @@ const createRaceActions = (
     handleCameraAction()
     if (refs.finished.value || refs.countdown.value > 0) return
     const body = state.marble.userData.body
-    const position = body.translation()
     updateSmoothedDirection(state.smoothedDirection, body.linvel())
     applyTurn(state, state.controls.currentActions)
-    const onBoost =
-      state.builtTrack?.boostZones.some((zone) => isOnBoostZone(position, zone)) ?? false
+    const onBoost = applyBoostImpulse(body, state.builtTrack?.boostZones ?? [])
     const impulse = computeImpulse(state.controls.currentActions, body.linvel(), inputForward())
-    if (onBoost) {
-      const velocity = body.linvel()
-      const speed = Math.hypot(velocity.x, velocity.z)
-      const scale = speed > 0 ? BOOST_IMPULSE / speed : 0
-      body.applyImpulse({ x: velocity.x * scale, y: 0, z: velocity.z * scale }, true)
-    }
     if (impulse.x !== 0 || impulse.z !== 0) {
       moveDynamic(state.marble, impulse, onBoost ? BOOST_MAX_SPEED : MARBLE_MAX_SPEED)
     }
@@ -457,6 +536,7 @@ const buildRaceScene = ({
 }: RaceSceneParameters): void => {
   if (!tools.world) return
   const scene = tools.scene
+  state.world = tools.world
   applyBedroomAtmosphere(scene)
   state.directionalLight =
     (scene.children.find(
@@ -500,6 +580,8 @@ export const useMarbleRace = (deps: UseMarbleRaceDeps) => {
 
   const state: RaceState = {
     marble: null,
+    testMarbles: [],
+    world: null,
     controls: null,
     builtTrack: null,
     checkpointIndex: 0,
@@ -507,6 +589,7 @@ export const useMarbleRace = (deps: UseMarbleRaceDeps) => {
     directionalLight: null,
     smoothedDirection: createSmoothedDirection(),
     cameraActionHeld: false,
+    prevCameraMode: 'third',
     localLabel: null,
     scene: null,
     bedroom: null,
@@ -527,7 +610,9 @@ export const useMarbleRace = (deps: UseMarbleRaceDeps) => {
     state.checkpointIndex = 0
     state.smoothedDirection.set(0, 0, -1)
     state.cameraActionHeld = false
+    state.prevCameraMode = 'third'
     state.posAccumulator = 0
+    state.testMarbles = []
     localStartTime = Date.now()
     actions.updateCountdown()
   }
@@ -589,6 +674,8 @@ export const useMarbleRace = (deps: UseMarbleRaceDeps) => {
     state.occlusionFader = null
     state.scene = null
     state.marble = null
+    state.testMarbles = []
+    state.world = null
     state.builtTrack = null
     state.directionalLight = null
     state.bedroom?.dispose()
@@ -598,6 +685,9 @@ export const useMarbleRace = (deps: UseMarbleRaceDeps) => {
       cleanupTools = null
     }
   }
+
+  const spawnTestMarbles = (count: number, randomTexture: boolean): void =>
+    spawnTestMarblesInto(state, deps, count, randomTexture)
 
   const updateGhostPosition = (placement: GhostPlacement): void =>
     placeGhost(ghostRegistry, placement)
@@ -615,6 +705,7 @@ export const useMarbleRace = (deps: UseMarbleRaceDeps) => {
     currentActions,
     setCameraMode: actions.setCameraMode,
     cycleCameraMode: actions.cycleCameraMode,
+    spawnTestMarbles,
     updateGhostPosition,
     removeGhost: removeGhostMarble,
     init,

--- a/src/views/Games/MarbleEditor/pieceCatalog.ts
+++ b/src/views/Games/MarbleEditor/pieceCatalog.ts
@@ -1,6 +1,7 @@
 import type { PieceSpec, TrackPieceType } from './types'
 import {
   LANE_WIDTH,
+  CURVE_DROP,
   START_LENGTH,
   FINISH_LENGTH,
   STRAIGHT_SHORT_LENGTH,
@@ -65,28 +66,28 @@ export const PIECE_CATALOG: Record<TrackPieceType, PieceSpec> = {
     type: 'curve-left',
     label: 'Curve left',
     defaultColor: COLOR_CURVE,
-    exitOffset: [-CURVE_RADIUS, 0, -CURVE_RADIUS],
+    exitOffset: [-CURVE_RADIUS, -CURVE_DROP, -CURVE_RADIUS],
     exitYawDelta: Math.PI / 2
   },
   'curve-right': {
     type: 'curve-right',
     label: 'Curve right',
     defaultColor: COLOR_CURVE,
-    exitOffset: [CURVE_RADIUS, 0, -CURVE_RADIUS],
+    exitOffset: [CURVE_RADIUS, -CURVE_DROP, -CURVE_RADIUS],
     exitYawDelta: -Math.PI / 2
   },
   'banked-left': {
     type: 'banked-left',
     label: 'Banked left',
     defaultColor: COLOR_BANKED,
-    exitOffset: [-CURVE_RADIUS, 0, -CURVE_RADIUS],
+    exitOffset: [-CURVE_RADIUS, -CURVE_DROP, -CURVE_RADIUS],
     exitYawDelta: Math.PI / 2
   },
   'banked-right': {
     type: 'banked-right',
     label: 'Banked right',
     defaultColor: COLOR_BANKED,
-    exitOffset: [CURVE_RADIUS, 0, -CURVE_RADIUS],
+    exitOffset: [CURVE_RADIUS, -CURVE_DROP, -CURVE_RADIUS],
     exitYawDelta: -Math.PI / 2
   },
   'ramp-up': {

--- a/src/views/Games/MarbleEditor/pieceGeometry.test.ts
+++ b/src/views/Games/MarbleEditor/pieceGeometry.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import * as THREE from 'three'
-import { buildArcSweepGeometry, buildFunnelGeometry } from './pieceGeometry'
+import { buildArcSweepGeometry, bankedCrossSection, buildFunnelGeometry } from './pieceGeometry'
 import {
-  BANK_ANGLE,
   LANE_WIDTH,
   BUMPER_LATERAL_OFFSET,
   BUMPER_SIZE_XZ,
@@ -36,48 +35,73 @@ const signedVolume = (geometry: THREE.BufferGeometry): number =>
     0
   )
 
-const ARC_CASES: { label: string; side: 1 | -1; roll: number }[] = [
-  { label: 'curve-left', side: 1, roll: 0 },
-  { label: 'curve-right', side: -1, roll: 0 },
-  { label: 'banked-left', side: 1, roll: BANK_ANGLE },
-  { label: 'banked-right', side: -1, roll: BANK_ANGLE }
+const ARC_CASES: { label: string; side: 1 | -1; crossSection?: [number, number][] }[] = [
+  { label: 'curve-left', side: 1 },
+  { label: 'curve-right', side: -1 },
+  { label: 'banked-left', side: 1, crossSection: bankedCrossSection(1) },
+  { label: 'banked-right', side: -1, crossSection: bankedCrossSection(-1) }
 ]
 
 describe('buildArcSweepGeometry orientation', () => {
   it.each(ARC_CASES)(
     '$label winds triangles outward so the closed sweep has positive volume',
-    ({ side, roll }) => {
-      const geometry = buildArcSweepGeometry(side, roll)
+    ({ side, crossSection }) => {
+      const geometry = buildArcSweepGeometry(side, crossSection)
       expect(signedVolume(geometry)).toBeGreaterThan(0)
     }
   )
 
-  it.each(ARC_CASES.filter(({ roll }) => roll === 0))(
-    '$label faces every deck-top triangle upward',
-    ({ side, roll }) => {
-      const geometry = buildArcSweepGeometry(side, roll)
-      const deckTriangles = geometryTriangles(geometry).filter((triangle) =>
-        triangle.every((vertex) => Math.abs(vertex.y) < 1e-4)
+  it.each(ARC_CASES)(
+    '$label winds its deck-top surface to face upward',
+    ({ side, crossSection }) => {
+      const geometry = buildArcSweepGeometry(side, crossSection)
+      const averageY = (triangles: Triangle[]): number =>
+        triangles.reduce((sum, [a, b, c]) => sum + (a.y + b.y + c.y) / 3, 0) / triangles.length
+      // The descending helix tilts the deck, so select the near-horizontal
+      // surfaces (deck top and deck bottom) by their normal instead of by height.
+      const horizontal = geometryTriangles(geometry).filter((triangle) => {
+        const normal = triangleNormal(triangle)
+        const length = normal.length()
+        return length > 0 && Math.abs(normal.y) / length > 0.9
+      })
+      const upFacing = horizontal.filter((triangle) => triangleNormal(triangle).y > 0)
+      const downFacing = horizontal.filter((triangle) => triangleNormal(triangle).y < 0)
+      expect(upFacing.length).toBeGreaterThan(0)
+      expect(downFacing.length).toBeGreaterThan(0)
+      // Correct outward winding: the up-facing surface is the deck the marble
+      // rolls on, and it sits above the down-facing underside.
+      expect(averageY(upFacing)).toBeGreaterThan(averageY(downFacing))
+    }
+  )
+
+  it.each(ARC_CASES)(
+    '$label faces the entry cap toward the previous piece',
+    ({ side, crossSection }) => {
+      const geometry = buildArcSweepGeometry(side, crossSection)
+      const entryZ = Math.max(
+        ...geometryTriangles(geometry).flatMap((triangle) => triangle.map((vertex) => vertex.z))
       )
-      expect(deckTriangles.length).toBeGreaterThan(0)
-      deckTriangles.forEach((triangle) => {
-        expect(triangleNormal(triangle).y).toBeGreaterThan(0)
+      const entryCapTriangles = geometryTriangles(geometry).filter((triangle) =>
+        triangle.every((vertex) => Math.abs(vertex.z - entryZ) < 1e-4)
+      )
+      expect(entryCapTriangles.length).toBeGreaterThan(0)
+      entryCapTriangles.forEach((triangle) => {
+        expect(triangleNormal(triangle).z).toBeGreaterThan(0)
       })
     }
   )
 
-  it.each(ARC_CASES)('$label faces the entry cap toward the previous piece', ({ side, roll }) => {
-    const geometry = buildArcSweepGeometry(side, roll)
-    const entryZ = Math.max(
-      ...geometryTriangles(geometry).flatMap((triangle) => triangle.map((vertex) => vertex.z))
-    )
-    const entryCapTriangles = geometryTriangles(geometry).filter((triangle) =>
-      triangle.every((vertex) => Math.abs(vertex.z - entryZ) < 1e-4)
-    )
-    expect(entryCapTriangles.length).toBeGreaterThan(0)
-    entryCapTriangles.forEach((triangle) => {
-      expect(triangleNormal(triangle).z).toBeGreaterThan(0)
-    })
+  it.each([
+    { label: 'banked-left', side: 1 as const },
+    { label: 'banked-right', side: -1 as const }
+  ])('$label raises its outer wall above a plain curve to hold the marble', ({ side }) => {
+    const maxVertexY = (geometry: THREE.BufferGeometry): number =>
+      Math.max(
+        ...geometryTriangles(geometry).flatMap((triangle) => triangle.map((vertex) => vertex.y))
+      )
+    const curveTop = maxVertexY(buildArcSweepGeometry(side))
+    const bankedTop = maxVertexY(buildArcSweepGeometry(side, bankedCrossSection(side)))
+    expect(bankedTop).toBeGreaterThan(curveTop)
   })
 })
 

--- a/src/views/Games/MarbleEditor/pieceGeometry.ts
+++ b/src/views/Games/MarbleEditor/pieceGeometry.ts
@@ -12,8 +12,9 @@ import {
   STRAIGHT_SHORT_LENGTH,
   STRAIGHT_LONG_LENGTH,
   CURVE_RADIUS,
-  BANK_ANGLE,
-  BANK_BLEND_ANGLE,
+  CURVE_DROP,
+  CURVE_FRICTION,
+  BANK_WALL_HEIGHT,
   RAMP_LENGTH,
   RAMP_ANGLE,
   RAMP_LIP_LENGTH,
@@ -80,7 +81,6 @@ type PieceParts = {
 
 const Y_AXIS = new THREE.Vector3(0, 1, 0)
 const X_AXIS = new THREE.Vector3(1, 0, 0)
-const Z_AXIS = new THREE.Vector3(0, 0, 1)
 const IDENTITY_QUATERNION = new THREE.Quaternion()
 
 const vec = (x: number, y: number, z: number): THREE.Vector3 => new THREE.Vector3(x, y, z)
@@ -88,8 +88,6 @@ const yawQuaternion = (yaw: number): THREE.Quaternion =>
   new THREE.Quaternion().setFromAxisAngle(Y_AXIS, yaw)
 const pitchQuaternion = (pitch: number): THREE.Quaternion =>
   new THREE.Quaternion().setFromAxisAngle(X_AXIS, pitch)
-const rollQuaternion = (roll: number): THREE.Quaternion =>
-  new THREE.Quaternion().setFromAxisAngle(Z_AXIS, roll)
 
 const box = (
   size: CoordinateTuple,
@@ -183,23 +181,32 @@ const rampSpecs = (direction: 1 | -1): BoxSpec[] => {
   ]
 }
 
-// The roll eases in and out across the arc so banked curves start and end
-// perfectly level against neighbouring pieces.
-const bankEnvelope = (phi: number): number =>
-  Math.max(0, Math.min(1, phi / BANK_BLEND_ANGLE, (Math.PI / 2 - phi) / BANK_BLEND_ANGLE))
-
 // Closed outline of the lane profile (deck plus both walls), swept along the
-// arc to produce a single smooth solid instead of segmented boxes.
-const LANE_CROSS_SECTION: [number, number][] = [
+// arc to produce a single smooth solid instead of segmented boxes. The wall
+// tops are parameterised so a banked curve can raise its outer wall.
+const laneCrossSection = (
+  leftWallHeight: number = WALL_HEIGHT,
+  rightWallHeight: number = WALL_HEIGHT
+): [number, number][] => [
   [-(LANE_WIDTH / 2 + WALL_THICKNESS), -DECK_THICKNESS],
-  [-(LANE_WIDTH / 2 + WALL_THICKNESS), WALL_HEIGHT],
-  [-LANE_WIDTH / 2, WALL_HEIGHT],
+  [-(LANE_WIDTH / 2 + WALL_THICKNESS), leftWallHeight],
+  [-LANE_WIDTH / 2, leftWallHeight],
   [-LANE_WIDTH / 2, 0],
   [LANE_WIDTH / 2, 0],
-  [LANE_WIDTH / 2, WALL_HEIGHT],
-  [LANE_WIDTH / 2 + WALL_THICKNESS, WALL_HEIGHT],
+  [LANE_WIDTH / 2, rightWallHeight],
+  [LANE_WIDTH / 2 + WALL_THICKNESS, rightWallHeight],
   [LANE_WIDTH / 2 + WALL_THICKNESS, -DECK_THICKNESS]
 ]
+
+const LANE_CROSS_SECTION: [number, number][] = laneCrossSection()
+
+// A left turn (side 1) curves toward -x so its outer edge is +x (the right
+// wall); a right turn mirrors it. The outer wall is raised to hold a fast
+// marble in the arc.
+export const bankedCrossSection = (side: 1 | -1): [number, number][] =>
+  side === 1
+    ? laneCrossSection(WALL_HEIGHT, BANK_WALL_HEIGHT)
+    : laneCrossSection(BANK_WALL_HEIGHT, WALL_HEIGHT)
 
 const ARC_SWEEP_STATIONS = 49
 
@@ -212,18 +219,16 @@ type SweepStation = {
 // JOINT_OVERLAP is non-zero. With flush junctions (overlap 0) the extensions
 // would coincide with the first/last arc stations and produce degenerate
 // zero-area quads, so they are omitted and the sweep butts up exactly.
-const arcSweepStations = (side: 1 | -1, roll: number): SweepStation[] => {
+const arcSweepStations = (side: 1 | -1): SweepStation[] => {
   const arc = Array.from({ length: ARC_SWEEP_STATIONS }, (_, index) => {
     const phi = (index / (ARC_SWEEP_STATIONS - 1)) * (Math.PI / 2)
     return {
       origin: vec(
         side * (CURVE_RADIUS * Math.cos(phi) - CURVE_RADIUS),
-        0,
+        -CURVE_DROP * (phi / (Math.PI / 2)),
         -CURVE_RADIUS * Math.sin(phi)
       ),
-      orientation: yawQuaternion(side * phi).multiply(
-        rollQuaternion(side * roll * bankEnvelope(phi))
-      )
+      orientation: yawQuaternion(side * phi)
     }
   })
   if (JOINT_OVERLAP === 0) return arc
@@ -241,10 +246,10 @@ const arcSweepStations = (side: 1 | -1, roll: number): SweepStation[] => {
 
 // Each cross-section edge gets its own vertex pair per station: profile
 // corners stay hard while the sweep direction shades smoothly.
-const sweepPositions = (stations: SweepStation[]): number[] =>
+const sweepPositions = (stations: SweepStation[], crossSection: [number, number][]): number[] =>
   stations.flatMap((station) =>
-    LANE_CROSS_SECTION.flatMap((current, pointIndex) => {
-      const nextPoint = LANE_CROSS_SECTION[(pointIndex + 1) % LANE_CROSS_SECTION.length]
+    crossSection.flatMap((current, pointIndex) => {
+      const nextPoint = crossSection[(pointIndex + 1) % crossSection.length]
       return [current, nextPoint].flatMap(([x, y]) => {
         const point = vec(x, y, 0).applyQuaternion(station.orientation).add(station.origin)
         return [point.x, point.y, point.z]
@@ -254,8 +259,8 @@ const sweepPositions = (stations: SweepStation[]): number[] =>
 
 // Winding matters: Rapier's FIX_INTERNAL_EDGES corrects contact normals using
 // the triangles' face normals, so every face must point outward (deck up).
-const sweepIndices = (stationCount: number): number[] => {
-  const edgeCount = LANE_CROSS_SECTION.length
+const sweepIndices = (stationCount: number, crossSection: [number, number][]): number[] => {
+  const edgeCount = crossSection.length
   const perStation = edgeCount * 2
   const sideQuads = Array.from({ length: stationCount - 1 }, (_, station) =>
     Array.from({ length: edgeCount }, (_, edge) => {
@@ -267,7 +272,7 @@ const sweepIndices = (stationCount: number): number[] => {
     }).flat()
   ).flat()
   const capTriangles = THREE.ShapeUtils.triangulateShape(
-    LANE_CROSS_SECTION.map(([x, y]) => new THREE.Vector2(x, y)),
+    crossSection.map(([x, y]) => new THREE.Vector2(x, y)),
     []
   )
   const endBase = (stationCount - 1) * perStation
@@ -282,19 +287,28 @@ const sweepIndices = (stationCount: number): number[] => {
   return [...sideQuads, ...caps]
 }
 
-export const buildArcSweepGeometry = (side: 1 | -1, roll: number): THREE.BufferGeometry => {
-  const stations = arcSweepStations(side, roll)
+export const buildArcSweepGeometry = (
+  side: 1 | -1,
+  crossSection: [number, number][] = LANE_CROSS_SECTION
+): THREE.BufferGeometry => {
+  const stations = arcSweepStations(side)
   const geometry = new THREE.BufferGeometry()
-  geometry.setAttribute('position', new THREE.Float32BufferAttribute(sweepPositions(stations), 3))
-  geometry.setIndex(sweepIndices(stations.length))
+  geometry.setAttribute(
+    'position',
+    new THREE.Float32BufferAttribute(sweepPositions(stations, crossSection), 3)
+  )
+  geometry.setIndex(sweepIndices(stations.length, crossSection))
   geometry.computeVertexNormals()
   return geometry
 }
 
-const arcTrimeshSpec = (side: 1 | -1, roll: number): TrimeshSpec => ({
-  geometry: buildArcSweepGeometry(side, roll),
+const arcTrimeshSpec = (
+  side: 1 | -1,
+  crossSection: [number, number][] = LANE_CROSS_SECTION
+): TrimeshSpec => ({
+  geometry: buildArcSweepGeometry(side, crossSection),
   center: new THREE.Vector3(0, 0, 0),
-  friction: DECK_FRICTION,
+  friction: CURVE_FRICTION,
   restitution: DECK_RESTITUTION
 })
 
@@ -476,10 +490,10 @@ const PIECE_PARTS_BUILDERS: Record<TrackPieceType, () => PieceParts> = {
     ]),
   'straight-short': () => boxesOnly(straightSpecs(STRAIGHT_SHORT_LENGTH)),
   'straight-long': () => boxesOnly(straightSpecs(STRAIGHT_LONG_LENGTH)),
-  'curve-left': () => ({ boxes: [], trimeshes: [arcTrimeshSpec(1, 0)] }),
-  'curve-right': () => ({ boxes: [], trimeshes: [arcTrimeshSpec(-1, 0)] }),
-  'banked-left': () => ({ boxes: [], trimeshes: [arcTrimeshSpec(1, BANK_ANGLE)] }),
-  'banked-right': () => ({ boxes: [], trimeshes: [arcTrimeshSpec(-1, BANK_ANGLE)] }),
+  'curve-left': () => ({ boxes: [], trimeshes: [arcTrimeshSpec(1)] }),
+  'curve-right': () => ({ boxes: [], trimeshes: [arcTrimeshSpec(-1)] }),
+  'banked-left': () => ({ boxes: [], trimeshes: [arcTrimeshSpec(1, bankedCrossSection(1))] }),
+  'banked-right': () => ({ boxes: [], trimeshes: [arcTrimeshSpec(-1, bankedCrossSection(-1))] }),
   'ramp-up': () => boxesOnly(rampSpecs(1)),
   'ramp-down': () => boxesOnly(rampSpecs(-1)),
   funnel: () => ({ boxes: funnelBoxSpecs(), trimeshes: [funnelTrimeshSpec()] }),

--- a/src/views/Games/MarbleEditor/sampleMaps.ts
+++ b/src/views/Games/MarbleEditor/sampleMaps.ts
@@ -45,4 +45,27 @@ const JUMP_CANYON = makeSampleMap('Jump Canyon', 'jump-canyon', [
   'finish'
 ])
 
-export const SAMPLE_MAPS: MarbleMap[] = [FUNNEL_FALLS, LOOP_LINE, JUMP_CANYON]
+const ENDLESS_DROP_SEGMENTS = 15
+const ENDLESS_DROP_RAMPS_PER_RUN = 5
+
+// A serpentine descent: runs of downward ramps chained by flat 180-degree banked
+// U-turns that alternate direction each segment, so the track keeps losing height
+// and never climbs while folding back and forth instead of stacking. Yields
+// 1 + 15 * (5 + 2) + 1 = 107 pieces.
+const endlessDropTypes = (): TrackPieceType[] =>
+  Array.from({ length: ENDLESS_DROP_SEGMENTS }, (_, segment) => {
+    const bank: TrackPieceType = segment % 2 === 0 ? 'banked-left' : 'banked-right'
+    return [
+      ...Array.from({ length: ENDLESS_DROP_RAMPS_PER_RUN }, () => 'ramp-down' as TrackPieceType),
+      bank,
+      bank
+    ]
+  }).flat()
+
+const ENDLESS_DROP = makeSampleMap('Endless Drop', 'endless-drop', [
+  'start',
+  ...endlessDropTypes(),
+  'finish'
+])
+
+export const SAMPLE_MAPS: MarbleMap[] = [FUNNEL_FALLS, LOOP_LINE, JUMP_CANYON, ENDLESS_DROP]


### PR DESCRIPTION
Closes #205

## Summary

Adds a long always-descending Marble Editor track and a test-ball spawner, and fixes the turn physics and visual issues found while testing it.

## Key Changes

- **Endless Drop track** (`sampleMaps.ts`): a 107-piece downward spiral — runs of `ramp-down` joined by descending banked U-turns (alternating L/R). Registered as a selectable sample map.
- **Descending turns** (`pieceGeometry.ts`, `pieceCatalog.ts`, `config.ts`): curves and banked curves now descend across the arc (a helix, `CURVE_DROP`), so the marble keeps losing height through every turn instead of being pushed to the outside and stalling. Curve trimesh friction lowered (`CURVE_FRICTION`) so a marble leaning on the outer wall no longer grinds.
- **Banked pieces rebuilt from the curve** (`pieceGeometry.ts`): removed the deck-roll (it launched the marble); banked is now the flat curve deck with a taller outer wall (`BANK_WALL_HEIGHT`) that contains a fast marble.
- **Test-ball spawner in the CONFIG panel** (`MarbleEditor.vue`, `useMarbleRace.ts`): a Test Balls section with a Count slider, a Random textures toggle, and an Add balls action that drops uncontrolled marbles at the start. Boost pads now fling the spawned balls too (shared `applyBoostImpulse`).
- **Race key/gamepad bindings** (`config.ts`, `MarbleEditor.vue`): Editor = E / square, Exit = Esc / circle, with key pills in the HUD.
- **Booster pad** (`config.ts`): `BOOST_IMPULSE` 3 -> 14, `BOOST_MAX_SPEED` 30 -> 48.
- **Free camera** (`raceCameras.ts`, `useMarbleRace.ts`): enters high and far back (`FREE_CAM_HEIGHT/BACK`) to frame the whole track, then orbit lets the player zoom in.
- **Rug z-fighting** (`bedroomEnvironment.ts`, `bedroomConfig.ts`): concentric rings rebuilt as non-overlapping annuli with a polygon depth-offset.

## Test Plan

- `pnpm test:unit` — 1471 pass (geometry, chain-transform and physics tests updated for the descending arcs and new banked wall).
- `pnpm type-check` — clean.
- `pnpm lint` on touched files — 0 errors.

## Added on top of the initial plan

- **Descending turns + lower curve friction** — added after testing showed balls stalling and piling in flat 180 U-turns and grinding on high-friction curve walls (the original plan assumed flat curves were acceptable).
- **Banked rebuilt as taller-outer-wall** — added after banked pieces launched the marble off the track.
- **Boost pads affect spawned balls** + **higher booster impulse** — requested during testing; boost logic extracted to a shared helper used by the player and test marbles.
- **Add Balls moved from the HUD into the app CONFIG panel** + **random-textures toggle** — the control started as an in-race HUD widget and was relocated per feedback, then gained the random-texture option.
- **Race Editor/Exit key + gamepad bindings**, **free-camera zoom-out**, and **rug z-fighting fix** — all surfaced during testing and added on top of the original track + spawner scope.
