### PR TITLE
feat(#207): physic-ball types and tunable marble physics in the Marble Editor

### DIFF
--- a/documentation/docs/guides/spawning-ball-types.md
+++ b/documentation/docs/guides/spawning-ball-types.md
@@ -1,0 +1,135 @@
+---
+sidebar_position: 12
+---
+
+# Spawning Multiple Balls and Adding Ball Types
+
+The Marble Editor race can drop uncontrolled test balls onto the start to observe
+a track's physics without steering. Each ball is either the default **marble**
+(with tunable physics) or one of the **physic presets** borrowed from the Physic
+Examples experiment — Rubber, Balloon, Bowling, Paper, Tennis and Ping Pong —
+each with its own weight, restitution, friction and damping.
+
+The ball definitions live in a single shared catalog so the Physic Examples
+playground and the Marble Editor spawner stay in sync.
+
+## Source files
+
+- `src/utils/physicBalls.ts` — the `PHYSIC_BALLS` catalog, spawning and selection helpers
+- `src/types/physicBalls.ts` — the `PhysicBallPreset` type
+- `src/views/Games/MarbleEditor/game/useMarbleRace.ts` — the editor spawner (`spawnTestBalls`)
+- `src/views/Games/MarbleEditor/MarbleEditor.vue` — the Config panel controls
+- `src/views/Experiments/PhysicExamples.vue` — the experiment that shares the catalog
+
+## Spawning multiple balls in the editor
+
+Start a race in the Marble Editor and open the app **Config** panel (top-right).
+The **Test balls** section drives the spawner:
+
+| Control             | Effect                                                              |
+| ------------------- | ------------------------------------------------------------------- |
+| **Count**           | How many balls to drop (1–50).                                      |
+| **Ball type**       | Which type to spawn: **Marble** plus the six physic presets.        |
+| **Random type**     | When on, every ball gets a random type instead of the selected one. |
+| **Random textures** | Randomises the marble skin (only affects the **Marble** type).      |
+| **Add balls**       | Drops that many balls onto the start.                               |
+
+Balls spawn as a tight 2×2 footprint centred on the start lane and stack upward
+in layers, so they rain straight down onto the start instead of spreading wide
+and falling off the sides. They roll under gravity only and are torn down with
+the scene.
+
+## Adding a new ball type
+
+Append a `PhysicBallPreset` to `PHYSIC_BALLS` in `src/utils/physicBalls.ts`. It
+appears automatically in the Config panel dropdown and in the random-type pool —
+no other wiring is needed.
+
+```ts
+{
+  id: 'beach-ball',
+  label: 'Beach Ball',
+  kind: 'ball', // 'ball' → getBall (primitive sphere); 'model' → getModel (GLB)
+  options: {
+    size: 6,
+    weight: 8,
+    restitution: 0.6,
+    friction: 1,
+    color: 0x33aaff
+  },
+  editor: { size: 0.8 } // marble-scale override, editor only
+}
+```
+
+Key fields:
+
+- **`id` / `label`** — `id` is stable internal identity; `label` is what the
+  dropdown shows and what selection is keyed on (labels must be unique).
+- **`kind`** — `'ball'` spawns a primitive sphere via `getBall`; `'model'` loads
+  a GLB via `getModel` and requires a `model` filename.
+- **`options`** — the render and physics settings (`weight`, `restitution`,
+  `friction`, `damping`, `angular`, colour, material, …), authored at the large
+  Physic Examples arena scale.
+- **`editor`** — optional marble-scale `size` (and `scale` for GLB models) applied
+  **only** inside the Marble Editor; see below.
+- **`randomColor` / `randomRotation`** — set either flag to vary the colour or
+  rotation per spawn (e.g. balloons get a random colour, crumpled paper a random
+  rotation).
+
+A GLB-model preset looks like this:
+
+```ts
+{
+  id: 'balloon',
+  label: 'Balloon',
+  kind: 'model',
+  model: 'balloon.glb',
+  randomColor: true,
+  options: {
+    scale: [70, 70, 70],
+    size: 10,
+    weight: 5,
+    restitution: -0.5,
+    material: 'MeshPhysicalMaterial',
+    transparent: true,
+    opacity: 0.55,
+    roughness: 0.05,
+    clearcoat: 1,
+    transmission: 0.35
+  },
+  editor: { size: 1.3, scale: [9, 9, 9] }
+}
+```
+
+## Editor-scale overrides
+
+Physic presets are authored for the large Physic Examples arena (a bowling ball
+has a radius of 15), so dropping them verbatim onto a marble track would dwarf
+it. The `editor` block shrinks the **visual and collider size** to marble scale
+while leaving the physics character — weight, restitution, friction, damping —
+untouched, so a bowling ball still feels heavy and a ping-pong ball light.
+
+The merge is handled by `mergeBallOptions(preset, position, useEditorScale)`:
+
+- The Marble Editor spawns with `useEditorScale = true` (applies the overrides).
+- The Physic Examples experiment spawns with `useEditorScale = false` (keeps the
+  original arena sizes).
+
+For a GLB model, override **both** `size` (the collider radius) and `scale` (the
+visual mesh) together so the physics body and the rendered model stay matched.
+
+Very small, bouncy balls (ping-pong, paper) enable continuous collision
+detection when spawned in the editor so they do not tunnel through the thin track
+colliders between physics steps.
+
+## Tunable default marble physics
+
+The Config panel's **Marble physics** section exposes sliders for the default
+marble — weight, restitution, friction, linear/angular damping and size. These
+values are shared by:
+
+- the **player marble** (applied on the next race), and
+- spawned **Marble**-type test balls (applied immediately).
+
+The physic presets keep their own baked physics; the sliders only affect the
+default marble.

--- a/packages/threejs/src/models.test.ts
+++ b/packages/threejs/src/models.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import * as THREE from 'three'
 import RAPIER from '@dimforge/rapier3d-compat'
-import { getCube, getBall, getTrimesh } from './models'
+import { getCube, getBall, getTrimesh, applyMaterial } from './models'
 import type { CoordinateTuple } from './types'
 
 describe('getCube', () => {
@@ -344,5 +344,106 @@ describe('getTrimesh', () => {
     const body = ball.userData.body as RAPIER.RigidBody
     expect(body.translation().y).toBeGreaterThan(0.5)
     expect(body.translation().y).toBeLessThan(1.5)
+  })
+})
+
+describe('applyMaterial', () => {
+  const meshWith = (material: THREE.Material | THREE.Material[]): THREE.Mesh =>
+    new THREE.Mesh(new THREE.SphereGeometry(1, 8, 8), material)
+
+  describe('mutate in place (no material option)', () => {
+    it('updates color on the existing material without replacing it', () => {
+      const original = new THREE.MeshStandardMaterial({ color: 0x111111 })
+      original.map = new THREE.Texture()
+      const mesh = meshWith(original)
+
+      applyMaterial(mesh, { color: 0xff0000 })
+
+      expect(mesh.material).toBe(original)
+      expect((mesh.material as THREE.MeshStandardMaterial).color.getHex()).toBe(0xff0000)
+      expect((mesh.material as THREE.MeshStandardMaterial).map).toBe(original.map)
+    })
+
+    it('makes the material transparent when opacity is below one', () => {
+      const original = new THREE.MeshStandardMaterial()
+      const mesh = meshWith(original)
+
+      applyMaterial(mesh, { opacity: 0.9 })
+
+      expect(mesh.material).toBe(original)
+      expect(original.transparent).toBe(true)
+      expect(original.opacity).toBeCloseTo(0.9)
+      expect(original.depthWrite).toBe(false)
+    })
+
+    it('honors an explicit transparent flag even at full opacity', () => {
+      const original = new THREE.MeshStandardMaterial()
+      const mesh = meshWith(original)
+
+      applyMaterial(mesh, { transparent: true })
+
+      expect(original.transparent).toBe(true)
+    })
+
+    it('applies physical props only when the material supports them', () => {
+      const standard = new THREE.MeshStandardMaterial()
+      applyMaterial(meshWith(standard), { roughness: 0.2, metalness: 0.7 })
+      expect(standard.roughness).toBeCloseTo(0.2)
+      expect(standard.metalness).toBeCloseTo(0.7)
+
+      const basic = new THREE.MeshBasicMaterial()
+      expect(() => applyMaterial(meshWith(basic), { roughness: 0.2 })).not.toThrow()
+      expect('roughness' in basic).toBe(false)
+    })
+
+    it('changes only the props that were passed', () => {
+      const original = new THREE.MeshStandardMaterial({ opacity: 0.5, transparent: true })
+      const mesh = meshWith(original)
+
+      applyMaterial(mesh, { color: 0x00ff00 })
+
+      expect(original.opacity).toBeCloseTo(0.5)
+      expect(original.transparent).toBe(true)
+      expect(original.color.getHex()).toBe(0x00ff00)
+    })
+
+    it('mutates every sub-material of a multi-material mesh', () => {
+      const a = new THREE.MeshStandardMaterial()
+      const b = new THREE.MeshStandardMaterial()
+      const mesh = meshWith([a, b])
+
+      applyMaterial(mesh, { opacity: 0.4 })
+
+      expect(a.transparent).toBe(true)
+      expect(a.opacity).toBeCloseTo(0.4)
+      expect(b.transparent).toBe(true)
+      expect(b.opacity).toBeCloseTo(0.4)
+    })
+
+    it('leaves the material untouched when no appearance options are given', () => {
+      const original = new THREE.MeshStandardMaterial({ color: 0x123456, opacity: 1 })
+      const mesh = meshWith(original)
+
+      applyMaterial(mesh, { position: [1, 2, 3] })
+
+      expect(mesh.material).toBe(original)
+      expect(original.color.getHex()).toBe(0x123456)
+      expect(original.transparent).toBe(false)
+      expect(original.opacity).toBe(1)
+    })
+  })
+
+  describe('swap (material option provided)', () => {
+    it('replaces the material with a new instance built from options', () => {
+      const original = new THREE.MeshStandardMaterial()
+      const mesh = meshWith(original)
+
+      applyMaterial(mesh, { material: 'MeshPhysicalMaterial', color: 0x0000ff, opacity: 0.5 })
+
+      expect(mesh.material).not.toBe(original)
+      expect(mesh.material).toBeInstanceOf(THREE.MeshPhysicalMaterial)
+      expect((mesh.material as THREE.MeshPhysicalMaterial).transparent).toBe(true)
+      expect((mesh.material as THREE.MeshPhysicalMaterial).color.getHex()).toBe(0x0000ff)
+    })
   })
 })

--- a/packages/threejs/src/models.ts
+++ b/packages/threejs/src/models.ts
@@ -124,17 +124,18 @@ const hasAppearanceOptions = (options: ModelOptions): boolean =>
   APPEARANCE_OPTION_KEYS.some((key) => options[key] !== undefined)
 
 const mutateMaterialInPlace = (material: THREE.Material, options: ModelOptions): void => {
-  const typed = material as THREE.Material & Record<string, unknown> & { color?: THREE.Color }
-  if (options.color !== undefined && typed.color instanceof THREE.Color)
-    typed.color.set(options.color)
+  const colored = material as THREE.Material & { color?: THREE.Color }
+  if (options.color !== undefined && colored.color instanceof THREE.Color)
+    colored.color.set(options.color)
   if (options.opacity !== undefined || options.transparent !== undefined) {
     const isTransparent = options.transparent ?? (options.opacity ?? 1) < 1
     material.transparent = isTransparent
     if (options.opacity !== undefined) material.opacity = options.opacity
     if (options.depthWrite === undefined) material.depthWrite = !isTransparent
   }
+  const record = material as unknown as Record<string, unknown>
   MUTABLE_MATERIAL_PROPS.forEach((key) => {
-    if (options[key] !== undefined && key in typed) typed[key] = options[key]
+    if (options[key] !== undefined && key in material) record[key] = options[key]
   })
   material.needsUpdate = true
 }

--- a/packages/threejs/src/models.ts
+++ b/packages/threejs/src/models.ts
@@ -94,6 +94,59 @@ const createMeshMaterial = (
   return null
 }
 
+// Appearance props that can be written straight onto an existing material,
+// letting getModel recolor or fade a loaded model without swapping (and losing)
+// its authored material — mirrors the props buildBaseMaterialProperties sets.
+const MUTABLE_MATERIAL_PROPS = [
+  'wireframe',
+  'depthWrite',
+  'alphaTest',
+  'reflectivity',
+  'roughness',
+  'metalness',
+  'transmission',
+  'clearcoat',
+  'clearcoatRoughness',
+  'ior',
+  'thickness',
+  'envMapIntensity',
+  'displacementScale'
+] as const
+
+const APPEARANCE_OPTION_KEYS = [
+  'color',
+  'opacity',
+  'transparent',
+  ...MUTABLE_MATERIAL_PROPS
+] as const
+
+const hasAppearanceOptions = (options: ModelOptions): boolean =>
+  APPEARANCE_OPTION_KEYS.some((key) => options[key] !== undefined)
+
+const mutateMaterialInPlace = (material: THREE.Material, options: ModelOptions): void => {
+  const typed = material as THREE.Material & Record<string, unknown> & { color?: THREE.Color }
+  if (options.color !== undefined && typed.color instanceof THREE.Color)
+    typed.color.set(options.color)
+  if (options.opacity !== undefined || options.transparent !== undefined) {
+    const isTransparent = options.transparent ?? (options.opacity ?? 1) < 1
+    material.transparent = isTransparent
+    if (options.opacity !== undefined) material.opacity = options.opacity
+    if (options.depthWrite === undefined) material.depthWrite = !isTransparent
+  }
+  MUTABLE_MATERIAL_PROPS.forEach((key) => {
+    if (options[key] !== undefined && key in typed) typed[key] = options[key]
+  })
+  material.needsUpdate = true
+}
+
+const mutateMaterialAppearance = (
+  material: THREE.Material | THREE.Material[],
+  options: ModelOptions
+): void => {
+  const materials = Array.isArray(material) ? material : [material]
+  materials.forEach((mat) => mutateMaterialInPlace(mat, options))
+}
+
 /**
  * Apply material to a mesh based on model options
  * @param mesh The mesh to apply material to
@@ -110,6 +163,8 @@ export const applyMaterial = (mesh: THREE.Mesh, options: ModelOptions) => {
     const base = buildBaseMaterialProperties(options, oldMaterial)
     const newMaterial = createMeshMaterial(material, base, options)
     if (newMaterial) mesh.material = newMaterial
+  } else if (hasAppearanceOptions(options)) {
+    mutateMaterialAppearance(mesh.material, options)
   }
   return mesh
 }

--- a/src/types/physicBalls.ts
+++ b/src/types/physicBalls.ts
@@ -1,0 +1,24 @@
+import type { ModelOptions, CoordinateTuple } from '@webgamekit/threejs'
+
+export type PhysicBallKind = 'ball' | 'model'
+
+/**
+ * A reusable ball definition with its own physics, shared by the PhysicExamples
+ * playground and the marble editor spawner. `options` holds the physics/render
+ * settings as authored for the large PhysicExamples arena; `editor` shrinks the
+ * visual/collider size to marble scale while leaving the physics untouched.
+ */
+export interface PhysicBallPreset {
+  id: string
+  label: string
+  kind: PhysicBallKind
+  /** GLB filename, required when kind is 'model'. */
+  model?: string
+  /** Randomise the colour per spawn (e.g. balloons). */
+  randomColor?: boolean
+  /** Randomise the rotation per spawn (e.g. crumpled paper). */
+  randomRotation?: boolean
+  options: ModelOptions
+  /** Marble-scale size/scale overrides applied only inside the marble editor. */
+  editor?: { size?: number; scale?: CoordinateTuple }
+}

--- a/src/utils/physicBalls.test.ts
+++ b/src/utils/physicBalls.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PHYSIC_BALLS,
+  BALL_TYPE_LABELS,
+  MARBLE_BALL_LABEL,
+  findPresetByLabel,
+  pickBallType,
+  mergeBallOptions
+} from './physicBalls'
+import type { PhysicBallPreset } from '@/types/physicBalls'
+
+const preset = (over: Partial<PhysicBallPreset> = {}): PhysicBallPreset => ({
+  id: 'x',
+  label: 'X',
+  kind: 'ball',
+  options: { size: 4, weight: 10 },
+  editor: { size: 0.9, scale: [2, 2, 2] },
+  ...over
+})
+
+describe('catalog', () => {
+  it('lists the marble plus all six physic balls as selectable types', () => {
+    expect(PHYSIC_BALLS).toHaveLength(6)
+    expect(BALL_TYPE_LABELS).toHaveLength(7)
+    expect(BALL_TYPE_LABELS[0]).toBe(MARBLE_BALL_LABEL)
+  })
+
+  it('resolves a preset by label and returns undefined for the marble', () => {
+    expect(findPresetByLabel('Bowling')?.id).toBe('bowling')
+    expect(findPresetByLabel(MARBLE_BALL_LABEL)).toBeUndefined()
+    expect(findPresetByLabel('Nope')).toBeUndefined()
+  })
+})
+
+describe('pickBallType', () => {
+  it('returns the selected label when randomType is off', () => {
+    expect(pickBallType(BALL_TYPE_LABELS, 'Tennis', false, () => 0.99)).toBe('Tennis')
+  })
+
+  it('returns a random label from the list when randomType is on', () => {
+    expect(pickBallType(['A', 'B', 'C', 'D'], 'A', true, () => 0.5)).toBe('C')
+    expect(pickBallType(['A', 'B', 'C', 'D'], 'A', true, () => 0)).toBe('A')
+  })
+})
+
+describe('mergeBallOptions', () => {
+  const position: [number, number, number] = [1, 2, 3]
+
+  it('keeps original size/scale and sets position when editor scale is off', () => {
+    const merged = mergeBallOptions(preset(), position, false)
+    expect(merged.size).toBe(4)
+    expect(merged.position).toEqual(position)
+    expect(merged.scale).toBeUndefined()
+  })
+
+  it('applies marble-scale size and scale overrides when editor scale is on', () => {
+    const merged = mergeBallOptions(preset(), position, true)
+    expect(merged.size).toBe(0.9)
+    expect(merged.scale).toEqual([2, 2, 2])
+    expect(merged.position).toEqual(position)
+  })
+
+  it('leaves options unchanged when a preset has no editor overrides', () => {
+    const merged = mergeBallOptions(preset({ editor: undefined }), position, true)
+    expect(merged.size).toBe(4)
+  })
+
+  it('does not mutate the preset options', () => {
+    const p = preset()
+    mergeBallOptions(p, position, true)
+    expect(p.options.size).toBe(4)
+    expect(p.options.position).toBeUndefined()
+  })
+})

--- a/src/utils/physicBalls.ts
+++ b/src/utils/physicBalls.ts
@@ -1,0 +1,207 @@
+import * as THREE from 'three'
+import RAPIER from '@dimforge/rapier3d-compat'
+import { getBall, getModel } from '@webgamekit/threejs'
+import type { ModelOptions, CoordinateTuple } from '@webgamekit/threejs'
+import type { ComplexModel } from '@webgamekit/animation'
+import type { PhysicBallPreset } from '@/types/physicBalls'
+import bowlingTexture from '@/assets/images/textures/bowling.png'
+
+// The six PhysicExamples balls, each with its own physics. Sizes/scales are the
+// original arena values; the `editor` block shrinks them to marble scale for the
+// marble editor without changing weight, restitution, friction or damping.
+export const PHYSIC_BALLS: PhysicBallPreset[] = [
+  {
+    id: 'rubber',
+    label: 'Rubber',
+    kind: 'ball',
+    options: {
+      size: 4,
+      weight: 120,
+      restitution: 0.75,
+      metalness: 0.3,
+      reflectivity: 0.2,
+      roughness: 0.8,
+      transmission: 0.5,
+      color: 0xff3333
+    },
+    editor: { size: 0.45 }
+  },
+  {
+    id: 'balloon',
+    label: 'Balloon',
+    kind: 'model',
+    model: 'balloon.glb',
+    randomColor: true,
+    options: {
+      rotation: [-0.5, 0, 1],
+      scale: [70, 70, 70],
+      size: 10,
+      damping: 0.8,
+      restitution: -0.5,
+      weight: 5,
+      material: 'MeshPhysicalMaterial',
+      transparent: true,
+      opacity: 0.55,
+      roughness: 0.05,
+      metalness: 0,
+      clearcoat: 1,
+      clearcoatRoughness: 0.08,
+      transmission: 0.35,
+      ior: 1.4,
+      reflectivity: 0.7
+    },
+    editor: { size: 1.3, scale: [9, 9, 9] }
+  },
+  {
+    id: 'bowling',
+    label: 'Bowling',
+    kind: 'ball',
+    options: {
+      size: 15,
+      weight: 50,
+      restitution: -0.3,
+      texture: bowlingTexture,
+      color: 0xffffff,
+      friction: 10
+    },
+    editor: { size: 1.8 }
+  },
+  {
+    id: 'paper',
+    label: 'Paper',
+    kind: 'model',
+    model: 'paper_low.glb',
+    randomRotation: true,
+    options: {
+      scale: [5, 5, 5],
+      size: 3,
+      friction: 100,
+      angular: 10,
+      damping: 0.2,
+      restitution: -0.5,
+      weight: 8
+    },
+    editor: { size: 0.3, scale: [0.51, 0.51, 0.51] }
+  },
+  {
+    id: 'tennis',
+    label: 'Tennis',
+    kind: 'model',
+    model: 'tennis.glb',
+    options: {
+      scale: [6, 6, 6],
+      size: 6,
+      weight: 50,
+      friction: 5,
+      angular: 1,
+      restitution: 0.6
+    },
+    editor: { size: 0.63, scale: [0.63, 0.63, 0.63] }
+  },
+  {
+    id: 'pingpong',
+    label: 'Ping Pong',
+    kind: 'ball',
+    options: {
+      size: 3,
+      weight: 40,
+      restitution: 0.8,
+      damping: 0.1,
+      color: 0xffffff,
+      roughness: 0.9
+    },
+    editor: { size: 0.15 }
+  }
+]
+
+// The default marble is a spawner ball type alongside the presets, but is built
+// by the marble race (tunable physics + player texture), not from a preset.
+export const MARBLE_BALL_LABEL = 'Marble'
+
+export const BALL_TYPE_LABELS: string[] = [
+  MARBLE_BALL_LABEL,
+  ...PHYSIC_BALLS.map((preset) => preset.label)
+]
+
+/**
+ * Resolve a preset by its dropdown label. Returns undefined for the default
+ * marble (which has no preset) or an unknown label.
+ * @param label The ball type label selected in the config panel.
+ * @returns The matching preset, or undefined.
+ */
+export const findPresetByLabel = (label: string): PhysicBallPreset | undefined =>
+  PHYSIC_BALLS.find((preset) => preset.label === label)
+
+/**
+ * Pick which ball type to spawn: a random label when randomType is on, else the
+ * selected one.
+ * @param labels The available ball type labels.
+ * @param selected The currently selected label.
+ * @param randomType When true, pick a random label instead of the selected one.
+ * @param random Random source in [0, 1); injectable for tests.
+ * @returns The chosen ball type label.
+ */
+export const pickBallType = (
+  labels: string[],
+  selected: string,
+  randomType: boolean,
+  random: () => number = Math.random
+): string => (randomType ? labels[Math.floor(random() * labels.length)] : selected)
+
+/**
+ * Merge a preset's options with a spawn position, optionally applying the
+ * marble-scale `editor` size/scale overrides. Pure — randomised colour/rotation
+ * are applied by spawnPhysicBall, not here, so this stays deterministic.
+ * @param preset The ball preset to resolve.
+ * @param position World position to spawn the ball at.
+ * @param useEditorScale Whether to apply the marble-scale editor overrides.
+ * @returns The merged model options.
+ */
+export const mergeBallOptions = (
+  preset: PhysicBallPreset,
+  position: CoordinateTuple,
+  useEditorScale: boolean
+): ModelOptions => {
+  const base: ModelOptions = { ...preset.options, position }
+  if (!useEditorScale || !preset.editor) return base
+  return {
+    ...base,
+    ...(preset.editor.size !== undefined ? { size: preset.editor.size } : {}),
+    ...(preset.editor.scale ? { scale: preset.editor.scale } : {})
+  }
+}
+
+const randomRotation = (): CoordinateTuple => [
+  Math.random() * Math.PI * 2,
+  Math.random() * Math.PI * 2,
+  Math.random() * Math.PI * 2
+]
+
+/**
+ * Spawn a physic ball into the scene from a preset, returning its ComplexModel.
+ * Handles both primitive (getBall) and GLB (getModel) presets and applies any
+ * per-spawn randomised colour/rotation.
+ * @param scene The Three.js scene.
+ * @param world The Rapier physics world.
+ * @param preset The ball preset to spawn.
+ * @param position World position to spawn at.
+ * @param options Spawn options; set `editor` to shrink to marble scale.
+ * @returns The spawned ComplexModel with physics attached.
+ */
+export const spawnPhysicBall = async (
+  scene: THREE.Scene,
+  world: RAPIER.World,
+  preset: PhysicBallPreset,
+  position: CoordinateTuple,
+  { editor = false }: { editor?: boolean } = {}
+): Promise<ComplexModel> => {
+  const options: ModelOptions = {
+    ...mergeBallOptions(preset, position, editor),
+    ...(preset.randomColor ? { color: Math.floor(Math.random() * 0xffffff) } : {}),
+    ...(preset.randomRotation ? { rotation: randomRotation() } : {})
+  }
+  if (preset.kind === 'model' && preset.model) {
+    return getModel(scene, world, preset.model, options)
+  }
+  return getBall(scene, world, options) as unknown as ComplexModel
+}

--- a/src/views/Experiments/PhysicExamples.vue
+++ b/src/views/Experiments/PhysicExamples.vue
@@ -5,16 +5,16 @@ import { useDebugSceneStore } from '@/stores/debugScene'
 import { video } from '@/utils/video'
 import { controls } from '@/utils/control'
 import { stats } from '@/utils/stats'
-import { getLights, getEnvironment, getGround, getModel, removeElements } from '@webgamekit/threejs'
+import { getLights, getEnvironment, getGround, removeElements } from '@webgamekit/threejs'
 import {
   bindAnimatedElements,
   resetAnimation,
   animateTimeline,
   createTimelineManager
 } from '@webgamekit/animation'
-import { getBall, getWalls } from '@webgamekit/threejs'
+import { getWalls } from '@webgamekit/threejs'
+import { PHYSIC_BALLS, spawnPhysicBall } from '@/utils/physicBalls'
 import { times } from '@/utils/lodash'
-import bowlingTexture from '@/assets/images/textures/bowling.png'
 import type { CoordinateTuple } from '@/types/three'
 
 const statsElement = ref(null)
@@ -66,75 +66,11 @@ const init = async (canvas: HTMLCanvasElement, statsElement: HTMLElement) => {
     registerSceneElements(camera, scene.children)
 
     let experiments = [] as any[]
-    const balls = [
-      async (position) =>
-        getBall(scene, world, {
-          position,
-          size: 4,
-          weight: 120,
-          restitution: 0.75,
-          metalness: 0.3,
-          reflectivity: 0.2,
-          roughness: 0.8,
-          transmission: 0.5,
-          color: 0xff3333
-        }), // Rubber
-      async (position) =>
-        await getModel(scene, world, 'balloon.glb', {
-          position,
-          rotation: [-0.5, 0, 1],
-          scale: [70, 70, 70],
-          size: 10,
-          damping: 0.8,
-          restitution: -0.5,
-          weight: 5,
-          color: Math.floor(Math.random() * 16777215),
-          opacity: 0.9
-        }), // Balloon
-      // async (position) => await getModel(scene, world, 'bowling.glb', { position, scale: [2,2,2], size: 2, weight: 50, restitution: -0.3}), // Bowling
-      async (position) =>
-        getBall(scene, world, {
-          position,
-          size: 15,
-          weight: 50,
-          restitution: -0.3,
-          texture: bowlingTexture,
-          color: 0xffffff,
-          friction: 10
-        }), // Bowling
-      async (position) =>
-        await getModel(scene, world, 'paper_low.glb', {
-          position,
-          rotation: [Math.random() * 100, Math.random() * 100, Math.random() * 100],
-          scale: [5, 5, 5],
-          size: 3,
-          friction: 100,
-          angular: 10,
-          damping: 0.2,
-          restitution: -0.5,
-          weight: 8
-        }), // Paper
-      async (position) =>
-        await getModel(scene, world, 'tennis.glb', {
-          position,
-          scale: [6, 6, 6],
-          size: 6,
-          weight: 50,
-          friction: 5,
-          angular: 1,
-          restitution: 0.6
-        }), // Tennis
-      async (position) =>
-        getBall(scene, world, {
-          position,
-          size: 3,
-          weight: 40,
-          restitution: 0.8,
-          damping: 0.1,
-          color: 0xffffff,
-          roughness: 0.9
-        }) // Ping Pong
-    ]
+    // Rubber, Balloon, Bowling, Paper, Tennis, Ping Pong — shared with the marble
+    // editor spawner, at their original arena sizes (no editor-scale overrides).
+    const balls = PHYSIC_BALLS.map(
+      (preset) => (position: CoordinateTuple) => spawnPhysicBall(scene, world, preset, position)
+    )
     const addBall = async (position: CoordinateTuple, pick: number, list = balls) => {
       experiments.push(await list[pick](position))
     }

--- a/src/views/Games/MarbleEditor/MarbleEditor.vue
+++ b/src/views/Games/MarbleEditor/MarbleEditor.vue
@@ -29,7 +29,8 @@ import { registerViewConfig, unregisterViewConfig, createReactiveConfig } from '
 import { isMobile } from '@webgamekit/controls'
 import TouchControl from '@/components/TouchControl.vue'
 import { useMenuFocus } from '@/composables/useMenuFocus'
-import { EDITOR_MENU_MAPPING } from './config'
+import { BALL_TYPE_LABELS, MARBLE_BALL_LABEL } from '@/utils/physicBalls'
+import { EDITOR_MENU_MAPPING, MARBLE_WEIGHT, MARBLE_RESTITUTION, MARBLE_FRICTION } from './config'
 import { useMarbleEditor } from './editor/useMarbleEditor'
 import { useMarbleRace } from './game/useMarbleRace'
 import { useMarbleEditorSession } from './useMarbleEditorSession'
@@ -38,8 +39,14 @@ import EditorToolbar from './editor/EditorToolbar.vue'
 import MarbleEditorLobby from './wizard/MarbleEditorLobby.vue'
 import MarbleEditorSummary from './game/MarbleEditorSummary.vue'
 import { SAMPLE_MAPS } from './sampleMaps'
-import { MARBLE_OPTIONS, DEFAULT_MARBLE } from '../MarbleMadness/config'
-import type { CameraMode, MePhase } from './types'
+import {
+  MARBLE_OPTIONS,
+  DEFAULT_MARBLE,
+  MARBLE_RADIUS,
+  MARBLE_LINEAR_DAMPING,
+  MARBLE_ANGULAR_DAMPING
+} from '../MarbleMadness/config'
+import type { CameraMode, MePhase, MarblePhysics } from './types'
 
 const CAMERA_MODE_LABELS: Record<CameraMode, string> = {
   third: 'Third',
@@ -144,10 +151,40 @@ const sortedPeerIds = computed(() => Object.keys(store.players).sort())
 const spawnGateCount = computed(() => Math.max(1, sortedPeerIds.value.length))
 const spawnGateIndex = computed(() => Math.max(0, sortedPeerIds.value.indexOf(localId())))
 
+// Test-ball spawner + tunable marble physics live in the app Config panel
+// (top-right). The marble physics are shared by the player marble (applied on
+// the next race) and the spawned default-marble balls (applied immediately).
+const testConfig = createReactiveConfig({
+  testBalls: {
+    count: 10,
+    ballType: MARBLE_BALL_LABEL,
+    randomType: false,
+    randomTextures: false
+  },
+  marblePhysics: {
+    weight: MARBLE_WEIGHT,
+    restitution: MARBLE_RESTITUTION,
+    friction: MARBLE_FRICTION,
+    linearDamping: MARBLE_LINEAR_DAMPING,
+    angularDamping: MARBLE_ANGULAR_DAMPING,
+    size: MARBLE_RADIUS
+  }
+})
+
+const marblePhysics = computed<MarblePhysics>(() => ({
+  weight: Number(testConfig.value.marblePhysics.weight),
+  restitution: Number(testConfig.value.marblePhysics.restitution),
+  friction: Number(testConfig.value.marblePhysics.friction),
+  linearDamping: Number(testConfig.value.marblePhysics.linearDamping),
+  angularDamping: Number(testConfig.value.marblePhysics.angularDamping),
+  size: Number(testConfig.value.marblePhysics.size)
+}))
+
 const race = useMarbleRace({
   canvas: raceCanvas,
   map: editor.currentMap,
   marbleTexture: marbleUrl,
+  marblePhysics,
   onBack: () => {
     store.phase = 'lobby'
   },
@@ -258,23 +295,33 @@ const canRestart = computed(() => store.solo || isHost.value)
 
 const cameraLabel = computed(() => CAMERA_MODE_LABELS[race.cameraMode.value])
 
-// Test-ball spawner lives in the app Config panel (top-right): a count slider
-// plus an "Add balls" action that drops that many uncontrolled marbles.
 const route = useRoute()
-const testConfig = createReactiveConfig({ testBalls: { count: 10, randomTextures: false } })
 const testConfigSchema = {
   testBalls: {
     count: { min: 1, max: 50, step: 1, label: 'Count' },
+    ballType: { options: BALL_TYPE_LABELS, label: 'Ball type' },
+    randomType: { checkbox: false, label: 'Random type' },
     randomTextures: { checkbox: false, label: 'Random textures' },
     add: { callback: 'addBalls', label: 'Add balls' }
+  },
+  marblePhysics: {
+    weight: { min: 1, max: 200, step: 1, label: 'Weight', sectionStart: true },
+    restitution: { min: 0, max: 1, step: 0.01, label: 'Restitution' },
+    friction: { min: 0, max: 5, step: 0.05, label: 'Friction' },
+    linearDamping: { min: 0, max: 2, step: 0.05, label: 'Linear damping' },
+    angularDamping: { min: 0, max: 2, step: 0.05, label: 'Angular damping' },
+    size: { min: 0.3, max: 3, step: 0.1, label: 'Size' }
   }
 }
 const testConfigCallbacks = {
-  addBalls: () =>
-    race.spawnTestMarbles(
-      Number(testConfig.value.testBalls.count),
-      Boolean(testConfig.value.testBalls.randomTextures)
-    )
+  addBalls: (): void => {
+    void race.spawnTestBalls({
+      count: Number(testConfig.value.testBalls.count),
+      ballType: String(testConfig.value.testBalls.ballType),
+      randomType: Boolean(testConfig.value.testBalls.randomType),
+      randomTextures: Boolean(testConfig.value.testBalls.randomTextures)
+    })
+  }
 }
 
 const namingNewTrack = ref(false)

--- a/src/views/Games/MarbleEditor/config.ts
+++ b/src/views/Games/MarbleEditor/config.ts
@@ -271,6 +271,9 @@ export const FIRST_PERSON_MIN_SPEED = 1
 // is in view; the orbit controls then let them zoom and pan from there.
 export const FREE_CAM_HEIGHT = 70
 export const FREE_CAM_BACK = 70
+// Seconds a camera-mode switch eases in over, so first-person and free glide to
+// their new framing instead of snapping.
+export const CAMERA_TRANSITION_SECONDS = 0.5
 export const CHECKPOINT_RADIUS = 9
 export const BOOST_ZONE_MAX_HEIGHT = 3
 export const BOOST_MAX_SPEED = 48

--- a/src/views/Games/MarbleEditor/game/raceCameras.test.ts
+++ b/src/views/Games/MarbleEditor/game/raceCameras.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import * as THREE from 'three'
+import type { OrbitControls } from 'three/addons/controls/OrbitControls.js'
+import type { ComplexModel } from '@webgamekit/animation'
+import {
+  easeTransition,
+  updateFirstPersonCamera,
+  updateFreeCamera,
+  applyRaceCamera,
+  type RaceCameraOptions
+} from './raceCameras'
+import { FIRST_PERSON_HEIGHT } from '../config'
+
+const stubOrbit = (): OrbitControls =>
+  ({ enabled: true, target: new THREE.Vector3() }) as unknown as OrbitControls
+
+const marbleAt = (x: number, y: number, z: number): ComplexModel => {
+  const object = new THREE.Object3D()
+  object.position.set(x, y, z)
+  return object as unknown as ComplexModel
+}
+
+describe('easeTransition', () => {
+  it('maps the endpoints to themselves and eases the middle', () => {
+    expect(easeTransition(0)).toBeCloseTo(0)
+    expect(easeTransition(1)).toBeCloseTo(1)
+    expect(easeTransition(0.5)).toBeCloseTo(0.875)
+  })
+
+  it('clamps out-of-range input', () => {
+    expect(easeTransition(-1)).toBeCloseTo(0)
+    expect(easeTransition(2)).toBeCloseTo(1)
+  })
+
+  it('increases monotonically', () => {
+    expect(easeTransition(0.25)).toBeLessThan(easeTransition(0.75))
+  })
+})
+
+const frame = (over: Partial<RaceCameraOptions>): RaceCameraOptions => ({
+  mode: 'first',
+  camera: new THREE.PerspectiveCamera(),
+  marble: marbleAt(0, 0, 0),
+  orbit: null,
+  smoothedDirection: new THREE.Vector3(0, 0, -1),
+  transitionStart: new THREE.Vector3(),
+  transitionAlpha: 1,
+  ...over
+})
+
+describe('updateFirstPersonCamera', () => {
+  const start = new THREE.Vector3(10, 10, 10)
+
+  it('sits at the start position at alpha 0', () => {
+    const options = frame({ transitionStart: start, transitionAlpha: 0 })
+    updateFirstPersonCamera(options)
+    expect(options.camera.position.x).toBeCloseTo(10)
+    expect(options.camera.position.y).toBeCloseTo(10)
+    expect(options.camera.position.z).toBeCloseTo(10)
+  })
+
+  it('lands exactly on the marble head at alpha 1', () => {
+    const options = frame({ marble: marbleAt(2, 3, 4), transitionStart: start, transitionAlpha: 1 })
+    updateFirstPersonCamera(options)
+    expect(options.camera.position.x).toBeCloseTo(2)
+    expect(options.camera.position.y).toBeCloseTo(3 + FIRST_PERSON_HEIGHT)
+    expect(options.camera.position.z).toBeCloseTo(4)
+  })
+
+  it('is strictly between start and goal mid-transition', () => {
+    const options = frame({ transitionStart: start, transitionAlpha: 0.5 })
+    updateFirstPersonCamera(options)
+    expect(options.camera.position.x).toBeGreaterThan(0)
+    expect(options.camera.position.x).toBeLessThan(10)
+  })
+})
+
+describe('updateFreeCamera', () => {
+  it('hands control to orbit and leaves the camera alone once the transition ends', () => {
+    const orbit = stubOrbit()
+    orbit.enabled = false
+    const options = frame({
+      mode: 'free',
+      marble: marbleAt(1, 2, 3),
+      orbit,
+      transitionAlpha: 1
+    })
+    options.camera.position.set(5, 5, 5)
+
+    updateFreeCamera(options)
+
+    expect(orbit.enabled).toBe(true)
+    expect(orbit.target.x).toBeCloseTo(1)
+    expect(orbit.target.y).toBeCloseTo(2)
+    expect(orbit.target.z).toBeCloseTo(3)
+    expect(options.camera.position.x).toBeCloseTo(5)
+    expect(options.camera.position.y).toBeCloseTo(5)
+    expect(options.camera.position.z).toBeCloseTo(5)
+  })
+
+  it('disables orbit and glides the camera up and back mid-transition', () => {
+    const orbit = stubOrbit()
+    const options = frame({ mode: 'free', orbit, transitionAlpha: 0.5 })
+    options.camera.position.set(0, 0, 0)
+
+    updateFreeCamera(options)
+
+    expect(orbit.enabled).toBe(false)
+    expect(options.camera.position.length()).toBeGreaterThan(0)
+    expect(options.camera.position.y).toBeGreaterThan(0)
+  })
+})
+
+describe('applyRaceCamera', () => {
+  it('disables orbit and targets the marble in third-person', () => {
+    const camera = new THREE.PerspectiveCamera()
+    camera.position.set(0, 20, 20)
+    const orbit = stubOrbit()
+
+    applyRaceCamera({
+      mode: 'third',
+      camera,
+      marble: marbleAt(0, 0, 0),
+      orbit,
+      smoothedDirection: new THREE.Vector3(0, 0, -1),
+      transitionStart: new THREE.Vector3(),
+      transitionAlpha: 1
+    })
+
+    expect(orbit.enabled).toBe(false)
+    expect(orbit.target.x).toBeCloseTo(0)
+    expect(orbit.target.y).toBeCloseTo(0)
+    expect(orbit.target.z).toBeCloseTo(0)
+  })
+})

--- a/src/views/Games/MarbleEditor/game/raceCameras.ts
+++ b/src/views/Games/MarbleEditor/game/raceCameras.ts
@@ -35,13 +35,35 @@ export const updateSmoothedDirection = (
   smoothedDirection.lerp(scratchDirection, FIRST_PERSON_DIRECTION_LERP).normalize()
 }
 
-export const updateFirstPersonCamera = (
-  camera: THREE.Camera,
-  marble: THREE.Object3D,
-  smoothedDirection: THREE.Vector3,
+// easeOutCubic: a mode switch glides in fast then settles, landing exactly on
+// the goal at alpha 1 (no residual snap). Clamped so callers can pass a raw
+// elapsed/duration ratio.
+export const easeTransition = (alpha: number): number => {
+  const clamped = Math.min(1, Math.max(0, alpha))
+  return 1 - (1 - clamped) ** 3
+}
+
+export type RaceCameraOptions = {
+  mode: CameraMode
+  camera: THREE.Camera
+  marble: ComplexModel | null
   orbit: OrbitControls | null
-): void => {
-  camera.position.set(marble.position.x, marble.position.y + FIRST_PERSON_HEIGHT, marble.position.z)
+  smoothedDirection: THREE.Vector3
+  transitionStart: THREE.Vector3
+  transitionAlpha: number
+}
+
+export const updateFirstPersonCamera = (options: RaceCameraOptions): void => {
+  const { camera, marble, smoothedDirection, orbit, transitionStart, transitionAlpha } = options
+  if (!marble) return
+  scratchCameraGoal.set(
+    marble.position.x,
+    marble.position.y + FIRST_PERSON_HEIGHT,
+    marble.position.z
+  )
+  // At alpha 1 this lands exactly on the marble head (no follow lag); below 1 it
+  // eases in from where the previous mode left the camera.
+  camera.position.lerpVectors(transitionStart, scratchCameraGoal, easeTransition(transitionAlpha))
   scratchLookTarget
     .copy(camera.position)
     .addScaledVector(smoothedDirection, FIRST_PERSON_LOOK_AHEAD)
@@ -51,12 +73,9 @@ export const updateFirstPersonCamera = (
   camera.lookAt(scratchLookTarget)
 }
 
-export const updateThirdPersonCamera = (
-  camera: THREE.Camera,
-  marble: THREE.Object3D,
-  smoothedDirection: THREE.Vector3,
-  orbit: OrbitControls | null
-): void => {
+export const updateThirdPersonCamera = (options: RaceCameraOptions): void => {
+  const { camera, marble, smoothedDirection, orbit } = options
+  if (!marble) return
   scratchCameraGoal.set(
     marble.position.x - smoothedDirection.x * CAMERA_BACK,
     marble.position.y + CAMERA_HEIGHT,
@@ -67,38 +86,43 @@ export const updateThirdPersonCamera = (
   camera.lookAt(marble.position)
 }
 
-export type RaceCameraOptions = {
-  mode: CameraMode
-  camera: THREE.Camera
-  marble: ComplexModel | null
-  orbit: OrbitControls | null
-  smoothedDirection: THREE.Vector3
-  justEnteredFree?: boolean
-}
-
-export const applyRaceCamera = (options: RaceCameraOptions): void => {
-  const { mode, camera, marble, orbit, smoothedDirection, justEnteredFree } = options
+// Free-cam entry frames the whole track (high and far back), then eases in and
+// hands control to orbit at alpha 1. Orbit is held disabled during the glide so
+// orbit.update() does not fight the lerp; once settled, the player owns it.
+export const updateFreeCamera = (options: RaceCameraOptions): void => {
+  const { camera, marble, smoothedDirection, orbit, transitionStart, transitionAlpha } = options
   if (!marble) return
-  if (mode === 'free') {
+  if (transitionAlpha >= 1) {
     if (orbit) {
       orbit.enabled = true
       orbit.target.copy(marble.position)
     }
-    // On entry, drop the camera high and far back so the whole track is framed;
-    // the orbit controls preserve that offset and let the player zoom in.
-    if (justEnteredFree) {
-      camera.position.set(
-        marble.position.x - smoothedDirection.x * FREE_CAM_BACK,
-        marble.position.y + FREE_CAM_HEIGHT,
-        marble.position.z - smoothedDirection.z * FREE_CAM_BACK
-      )
-    }
+    return
+  }
+  if (orbit) {
+    orbit.enabled = false
+    orbit.target.copy(marble.position)
+  }
+  scratchCameraGoal.set(
+    marble.position.x - smoothedDirection.x * FREE_CAM_BACK,
+    marble.position.y + FREE_CAM_HEIGHT,
+    marble.position.z - smoothedDirection.z * FREE_CAM_BACK
+  )
+  camera.position.lerpVectors(transitionStart, scratchCameraGoal, easeTransition(transitionAlpha))
+  camera.lookAt(marble.position)
+}
+
+export const applyRaceCamera = (options: RaceCameraOptions): void => {
+  const { mode, marble, orbit } = options
+  if (!marble) return
+  if (mode === 'free') {
+    updateFreeCamera(options)
     return
   }
   if (orbit) orbit.enabled = false
   if (mode === 'third') {
-    updateThirdPersonCamera(camera, marble, smoothedDirection, orbit)
+    updateThirdPersonCamera(options)
     return
   }
-  updateFirstPersonCamera(camera, marble, smoothedDirection, orbit)
+  updateFirstPersonCamera(options)
 }

--- a/src/views/Games/MarbleEditor/game/useMarbleRace.ts
+++ b/src/views/Games/MarbleEditor/game/useMarbleRace.ts
@@ -36,8 +36,17 @@ import type {
   CameraMode,
   BallPosPayload,
   BedroomEnvironment,
-  BoostZone
+  BoostZone,
+  MarblePhysics,
+  SpawnTestBallsOptions
 } from '../types'
+import {
+  spawnPhysicBall,
+  findPresetByLabel,
+  pickBallType,
+  MARBLE_BALL_LABEL,
+  BALL_TYPE_LABELS
+} from '@/utils/physicBalls'
 import {
   SPAWN_HEIGHT,
   SPAWN_Z_INSET,
@@ -46,13 +55,11 @@ import {
   BOOST_IMPULSE,
   FALL_MARGIN,
   TIME_PENALTY_FALL,
-  MARBLE_WEIGHT,
-  MARBLE_RESTITUTION,
-  MARBLE_FRICTION,
   MARBLE_MOVE_FORCE,
   MARBLE_MAX_SPEED,
   MARBLE_TURN_RATE,
   COUNTDOWN_MS,
+  CAMERA_TRANSITION_SECONDS,
   KEYBOARD_MAPPING,
   LIGHT_AMBIENT_INTENSITY,
   LIGHT_DIRECTIONAL_INTENSITY,
@@ -60,9 +67,6 @@ import {
 } from '../config'
 import {
   MARBLE_OPTIONS,
-  MARBLE_RADIUS,
-  MARBLE_LINEAR_DAMPING,
-  MARBLE_ANGULAR_DAMPING,
   CAMERA_HEIGHT,
   CAMERA_BACK,
   POS_BROADCAST_MS,
@@ -81,6 +85,7 @@ export type UseMarbleRaceDeps = {
   canvas: Ref<HTMLCanvasElement | null>
   map: Ref<MarbleMap>
   marbleTexture: Ref<string | undefined>
+  marblePhysics: Ref<MarblePhysics>
   onFinish: (elapsedSeconds: number) => void
   onBack?: () => void
   onEditor?: () => void
@@ -105,6 +110,8 @@ type RaceState = {
   smoothedDirection: THREE.Vector3
   cameraActionHeld: boolean
   prevCameraMode: CameraMode
+  cameraTransitionElapsed: number
+  cameraTransitionStart: THREE.Vector3
   localLabel: THREE.Sprite | null
   scene: THREE.Scene | null
   bedroom: BedroomEnvironment | null
@@ -112,34 +119,63 @@ type RaceState = {
   posAccumulator: number
 }
 
-// Test helper: drops `count` uncontrolled marbles onto the start, staggered in
-// a grid so they don't spawn on top of each other, to observe the track's
-// physics without steering. They roll under gravity only and are torn down with
-// the scene.
+// Test helper: drops `count` uncontrolled balls onto the start, staggered in a
+// grid so they don't spawn on top of each other, to observe the track's physics
+// without steering. Each ball is either the marble (with the panel's tunable
+// physics) or one of the physic presets shrunk to marble scale. They roll under
+// gravity only and are torn down with the scene.
 const randomTestTexture = (): string | undefined =>
   TEST_TEXTURE_POOL.length === 0
     ? undefined
     : TEST_TEXTURE_POOL[Math.floor(Math.random() * TEST_TEXTURE_POOL.length)]
 
-const spawnTestMarblesInto = (
+const spawnTestBall = async (
   state: RaceState,
   deps: UseMarbleRaceDeps,
-  count: number,
-  randomTexture: boolean
-): void => {
+  position: CoordinateTuple,
+  label: string,
+  randomTextures: boolean
+): Promise<void> => {
+  const { scene, world } = state
+  if (!scene || !world) return
+  if (label === MARBLE_BALL_LABEL) {
+    const texture = randomTextures ? randomTestTexture() : deps.marbleTexture.value
+    state.testMarbles.push(spawnMarble(scene, world, position, texture, deps.marblePhysics.value))
+    return
+  }
+  const preset = findPresetByLabel(label)
+  if (!preset) return
+  const ball = await spawnPhysicBall(scene, world, preset, position, { editor: true })
+  // Small, bouncy balls (ping pong, paper) tunnel through the thin track
+  // colliders between steps without continuous collision detection.
+  ball.userData.body.enableCcd(true)
+  state.testMarbles.push(ball)
+}
+
+const spawnTestBallsInto = async (
+  state: RaceState,
+  deps: UseMarbleRaceDeps,
+  options: SpawnTestBallsOptions
+): Promise<void> => {
   const { scene, world, builtTrack } = state
   if (!scene || !world || !builtTrack) return
   const start = builtTrack.startTransform ?? { position: [0, 0, 0] as CoordinateTuple, yaw: 0 }
-  const clamped = Math.max(1, Math.min(Math.floor(count), MAX_TEST_MARBLES))
-  Array.from({ length: clamped }).forEach((_, index) => {
-    const column = index % TEST_MARBLE_COLUMNS
-    const row = Math.floor(index / TEST_MARBLE_COLUMNS)
-    const localX = (column - (TEST_MARBLE_COLUMNS - 1) / 2) * TEST_MARBLE_SPACING
-    const localZ = SPAWN_Z_INSET + row * TEST_MARBLE_SPACING
-    const position = applyPieceTransform(start, [localX, SPAWN_HEIGHT + MARBLE_RADIUS, localZ])
-    const texture = randomTexture ? randomTestTexture() : deps.marbleTexture.value
-    state.testMarbles.push(spawnMarble(scene, world, position, texture))
-  })
+  const clamped = Math.max(1, Math.min(Math.floor(options.count), MAX_TEST_MARBLES))
+  await Promise.all(
+    Array.from({ length: clamped }).map((_unused, index) => {
+      const perLayer = TEST_MARBLE_COLUMNS * TEST_MARBLE_COLUMNS
+      const layer = Math.floor(index / perLayer)
+      const inLayer = index % perLayer
+      const offset = (TEST_MARBLE_COLUMNS - 1) / 2
+      const localX = ((inLayer % TEST_MARBLE_COLUMNS) - offset) * TEST_MARBLE_SPACING
+      const localZ =
+        SPAWN_Z_INSET + (Math.floor(inLayer / TEST_MARBLE_COLUMNS) - offset) * TEST_MARBLE_SPACING
+      const localY = SPAWN_HEIGHT + TEST_MARBLE_CLEARANCE + layer * TEST_MARBLE_VERTICAL_SPACING
+      const position = applyPieceTransform(start, [localX, localY, localZ])
+      const label = pickBallType(BALL_TYPE_LABELS, options.ballType, options.randomType)
+      return spawnTestBall(state, deps, position, label, options.randomTextures)
+    })
+  )
 }
 
 type BoostableBody = {
@@ -182,8 +218,13 @@ const VERTICAL_INPUT_REDIRECT_VY = 1
 const VERTICAL_INPUT_REDIRECT_SPEED = 4
 
 const MAX_TEST_MARBLES = 50
-const TEST_MARBLE_COLUMNS = 4
-const TEST_MARBLE_SPACING = MARBLE_RADIUS * 2.4
+// Balls spawn as a tight 2x2 footprint on the start lane and stack upward in
+// layers, so they rain down onto the start instead of spreading wide and
+// falling off the sides.
+const TEST_MARBLE_COLUMNS = 2
+const TEST_MARBLE_SPACING = 1.6
+const TEST_MARBLE_VERTICAL_SPACING = 3
+const TEST_MARBLE_CLEARANCE = 1.5
 
 const computeImpulse = (
   currentActions: ControlsCurrents,
@@ -270,22 +311,23 @@ const spawnMarble = (
   scene: THREE.Scene,
   world: WorldReference,
   position: CoordinateTuple,
-  texture: string | undefined
+  texture: string | undefined,
+  physics: MarblePhysics
 ): ComplexModel => {
   const marble = getBall(scene, world, {
-    size: MARBLE_RADIUS,
+    size: physics.size,
     position,
-    restitution: MARBLE_RESTITUTION,
-    friction: MARBLE_FRICTION,
-    weight: MARBLE_WEIGHT,
+    restitution: physics.restitution,
+    friction: physics.friction,
+    weight: physics.weight,
     texture,
     roughness: 0.08,
     metalness: 0.2,
     segments: 48,
     type: 'dynamic'
   }) as unknown as ComplexModel
-  marble.userData.body.setLinearDamping(MARBLE_LINEAR_DAMPING)
-  marble.userData.body.setAngularDamping(MARBLE_ANGULAR_DAMPING)
+  marble.userData.body.setLinearDamping(physics.linearDamping)
+  marble.userData.body.setAngularDamping(physics.angularDamping)
   marble.userData.body.enableCcd(true)
   return marble
 }
@@ -353,13 +395,23 @@ const buildRaceTimeline = (wiring: TimelineWiring) => {
     start: 0,
     action: () => {
       const mode = wiring.cameraMode.value
+      // A mode switch captures the camera's current position and eases from it
+      // over CAMERA_TRANSITION_SECONDS; a time-based alpha always completes so
+      // free-cam reliably hands back to orbit even while the marble is moving.
+      if (mode !== state.prevCameraMode) {
+        state.cameraTransitionElapsed = 0
+        state.cameraTransitionStart.copy(camera.position)
+      } else {
+        state.cameraTransitionElapsed += getDelta()
+      }
       applyRaceCamera({
         mode,
         camera,
         marble: state.marble,
         orbit,
         smoothedDirection: state.smoothedDirection,
-        justEnteredFree: mode === 'free' && state.prevCameraMode !== 'free'
+        transitionStart: state.cameraTransitionStart,
+        transitionAlpha: Math.min(1, state.cameraTransitionElapsed / CAMERA_TRANSITION_SECONDS)
       })
       state.prevCameraMode = mode
     }
@@ -553,7 +605,13 @@ const buildRaceScene = ({
   const gateCount = Math.max(1, deps.spawnGateCount?.value ?? 1)
   const gateIndex = Math.min(gateCount - 1, Math.max(0, deps.spawnGateIndex?.value ?? 0))
   const spawn = computeSpawnPositions(state.builtTrack.startTransform, gateCount)[gateIndex]
-  state.marble = spawnMarble(scene, tools.world, spawn, deps.marbleTexture.value)
+  state.marble = spawnMarble(
+    scene,
+    tools.world,
+    spawn,
+    deps.marbleTexture.value,
+    deps.marblePhysics.value
+  )
   state.occlusionFader = createOcclusionFader()
   if (deps.localPlayerName?.value) {
     state.localLabel = createNameLabel(
@@ -590,6 +648,8 @@ export const useMarbleRace = (deps: UseMarbleRaceDeps) => {
     smoothedDirection: createSmoothedDirection(),
     cameraActionHeld: false,
     prevCameraMode: 'third',
+    cameraTransitionElapsed: 0,
+    cameraTransitionStart: new THREE.Vector3(),
     localLabel: null,
     scene: null,
     bedroom: null,
@@ -611,6 +671,7 @@ export const useMarbleRace = (deps: UseMarbleRaceDeps) => {
     state.smoothedDirection.set(0, 0, -1)
     state.cameraActionHeld = false
     state.prevCameraMode = 'third'
+    state.cameraTransitionElapsed = 0
     state.posAccumulator = 0
     state.testMarbles = []
     localStartTime = Date.now()
@@ -686,8 +747,8 @@ export const useMarbleRace = (deps: UseMarbleRaceDeps) => {
     }
   }
 
-  const spawnTestMarbles = (count: number, randomTexture: boolean): void =>
-    spawnTestMarblesInto(state, deps, count, randomTexture)
+  const spawnTestBalls = (options: SpawnTestBallsOptions): Promise<void> =>
+    spawnTestBallsInto(state, deps, options)
 
   const updateGhostPosition = (placement: GhostPlacement): void =>
     placeGhost(ghostRegistry, placement)
@@ -705,7 +766,7 @@ export const useMarbleRace = (deps: UseMarbleRaceDeps) => {
     currentActions,
     setCameraMode: actions.setCameraMode,
     cycleCameraMode: actions.cycleCameraMode,
-    spawnTestMarbles,
+    spawnTestBalls,
     updateGhostPosition,
     removeGhost: removeGhostMarble,
     init,

--- a/src/views/Games/MarbleEditor/types.ts
+++ b/src/views/Games/MarbleEditor/types.ts
@@ -46,6 +46,22 @@ export type PieceSpec = {
 
 export type CameraMode = 'first' | 'third' | 'free'
 
+export type MarblePhysics = {
+  weight: number
+  restitution: number
+  friction: number
+  linearDamping: number
+  angularDamping: number
+  size: number
+}
+
+export type SpawnTestBallsOptions = {
+  count: number
+  ballType: string
+  randomType: boolean
+  randomTextures: boolean
+}
+
 export type MePlayer = {
   id: string
   name: string


### PR DESCRIPTION
Closes #207

## Summary

Reuses the balls from the **Physic Examples** experiment inside the **Marble Editor** race, each with its own custom physics, and lets the default marble's physics be tuned live. Ball definitions are extracted into a single shared catalog so the experiment and the editor stay in sync.

## Key Changes

- **Shared physic-ball catalog** (`src/utils/physicBalls.ts`, `src/types/physicBalls.ts`): Rubber, Balloon, Bowling, Paper, Tennis, Ping Pong, each with its authored physics. `spawnPhysicBall` dispatches to `getBall`/`getModel`; `mergeBallOptions` applies marble-scale `editor` overrides; `pickBallType`/`findPresetByLabel` handle selection.
- **Editor Config panel** (`MarbleEditor.vue`): a **Ball type** dropdown (Marble + 6 presets), a **Random type** toggle, and a **Marble physics** section (weight, restitution, friction, linear/angular damping, size).
- **Spawner** (`useMarbleRace.ts`): `spawnTestMarbles` → async `spawnTestBalls`; the player marble and spawned default-marble balls read the tunable physics; physic balls shrink to marble scale, stack vertically on the start, and enable CCD.
- **DRY**: `PhysicExamples.vue` now builds its balls from the shared catalog (original arena sizes).
- **Docs**: new guide `documentation/docs/guides/spawning-ball-types.md`.

## Test Plan

- `pnpm test:unit` — 1496 tests pass (8 new for `mergeBallOptions`/`pickBallType`/catalog, plus material and camera tests).
- `pnpm type-check` clean; ESLint clean on changed files.
- Manual: start a race, open Config → Test balls, spawn each type and Random type; tune marble physics sliders; confirm balls land on the start and small ones do not tunnel.

## Added on top of the initial plan

- **Ball material/model rendering fix** (`packages/threejs/src/models.ts`): `applyMaterial` now applies colour/opacity to a loaded GLB material in place when no `material` swap is requested, so the balloon (and any model passing colour/opacity) renders correctly instead of being ignored. Covered by new tests.
- **Balloon look**: rendered as a glassy, shining, transparent `MeshPhysicalMaterial` (per review feedback).
- **Camera transition easing** (`raceCameras.ts`, `useMarbleRace.ts`, `config.ts`): first-person and free race cameras now ease into their framing over a short time-bounded transition instead of snapping, matching third-person. Covered by new tests.
- **Tunnelling fix**: spawned physic balls enable continuous collision detection so small, bouncy balls do not pass through the track.
- **Spawn layout**: balls drop as a tight footprint stacked vertically on the start instead of spreading wide and falling off.
- **Size tuning**: per-preset editor-scale sizes adjusted from review feedback (rubber, paper, ping pong, bowling, tennis).
- **Docs**: guide on spawning multiple balls and adding new ball types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)