### PR TITLE
feat(#215): debris particles behind the rock, and a jump that moves it

### DIFF
--- a/src/views/Games/RockRunner/config.ts
+++ b/src/views/Games/RockRunner/config.ts
@@ -197,11 +197,47 @@ export const STEER_IMPULSE = 26
 // forward speed without letting the rock slide across the whole track at once.
 export const MAX_LATERAL_SPEED = 12
 
-export const JUMP_IMPULSE = 95
+// An impulse is momentum, so it has to grow with the mass: at 95 against a mass
+// of 72 the rock launched at 1.3 m/s and rose nine centimetres, which reads as
+// the jump doing nothing at all. This clears roughly the rock's own height.
+export const JUMP_IMPULSE = 540
 // The rock rests with its centre one radius above the deck; a little slack on
 // top of that keeps jumping responsive while rolling over the hills.
 export const GROUND_PROBE_DISTANCE = ROCK_RADIUS + 0.35
 export const JUMP_COOLDOWN_SECONDS = 0.25
+
+// Debris kicked up behind the rock. Pooled: a fixed set of particles is recycled
+// oldest-first rather than allocated and collected every frame.
+export const DEBRIS_COUNT = 220
+export const DEBRIS_LIFETIME = 1.1
+export const DEBRIS_SIZE = 0.14
+// The stroke is an inverted hull: the same shape, grown slightly and drawn
+// back-faces-only, so it reads as an outline around every chip.
+export const DEBRIS_STROKE_SCALE = 1.5
+export const DEBRIS_STROKE_COLOR = 0x1c1712
+// The two colours chips are tinted with: the path they are scuffed from, and
+// the rock itself. Not ROCK_TINT — that is the multiplier applied to a dark
+// albedo, so on its own it is a pale peach that vanishes against the path.
+export const DEBRIS_GROUND_COLOR = 0xc9ae83
+export const DEBRIS_ROCK_COLOR = 0x5f4634
+export const DEBRIS_GRAVITY = -22
+export const DEBRIS_EMIT_INTERVAL = 0.02
+// Chips released together each tick.
+export const DEBRIS_PER_BURST = 4
+// Below this the rock is barely moving and kicking up dust would look wrong.
+export const DEBRIS_MIN_SPEED = 1.2
+export const DEBRIS_BACK_SPEED = 5.5
+export const DEBRIS_UP_SPEED = 6
+export const DEBRIS_SPREAD = 6
+export const DEBRIS_SPIN = 9
+// Where chips appear along the rock's own axis, as a fraction of its radius.
+// Positive is ahead of centre: at speed the rock outruns anything spawned
+// behind it and the trail falls out of frame before it is seen, so chips start
+// just forward of the contact patch and are immediately left behind.
+export const DEBRIS_TRAIL_OFFSET = 0.7
+// The rock leaves the deck briefly over every crest. Judging contact on the
+// path height alone made the trail flicker, so the probe is given room.
+export const DEBRIS_GROUND_TOLERANCE = 1.2
 
 export const CAMERA_TRANSITION_SECONDS = 0.6
 export const COUNTDOWN_MS = 3000

--- a/src/views/Games/RockRunner/config.ts
+++ b/src/views/Games/RockRunner/config.ts
@@ -112,6 +112,13 @@ export const TERRAIN_TINT = 0xbcd79a
 
 export const CHUNK_STATIONS = 12
 export const CHUNK_LENGTH = CHUNK_STATIONS * STATION_SPACING
+// Colliders reach a station past their chunk so consecutive ones overlap.
+// Chunks are separate colliders, and Rapier only smooths contact normals across
+// a mesh's own internal edges — where two butt together their end caps meet as
+// an unsmoothed junction that a rolling ball catches on. Overlapping buries
+// each cap inside its neighbour's solid, so the ball never reaches one. The
+// visual meshes still butt exactly, or their surfaces would z-fight.
+export const COLLIDER_OVERLAP_STATIONS = 1
 
 // The world starts behind the origin, not at it. The rock spawns at distance
 // zero, so without ground behind it half the ball overhangs the leading edge

--- a/src/views/Games/RockRunner/config.ts
+++ b/src/views/Games/RockRunner/config.ts
@@ -209,24 +209,27 @@ export const JUMP_COOLDOWN_SECONDS = 0.25
 // Debris kicked up behind the rock. Pooled: a fixed set of particles is recycled
 // oldest-first rather than allocated and collected every frame.
 export const DEBRIS_COUNT = 220
-export const DEBRIS_LIFETIME = 1.1
-export const DEBRIS_SIZE = 0.14
+// Short: the chips are a scuff at the rock's heels, not a smoke trail behind
+// it. A longer life leaves a line stretching back down the whole path.
+export const DEBRIS_LIFETIME = 0.4
+// Around a tenth is the floor: smaller than this a chip is under two pixels at
+// the distance the chase camera sits, and the trail simply stops resolving.
+export const DEBRIS_SIZE = 0.11
 // The stroke is an inverted hull: the same shape, grown slightly and drawn
 // back-faces-only, so it reads as an outline around every chip.
 export const DEBRIS_STROKE_SCALE = 1.5
 export const DEBRIS_STROKE_COLOR = 0x1c1712
-// The two colours chips are tinted with: the path they are scuffed from, and
-// the rock itself. Not ROCK_TINT — that is the multiplier applied to a dark
-// albedo, so on its own it is a pale peach that vanishes against the path.
+// Chips are ground kicked up by the rock, so they take the path's own colour.
+// Pitched a shade darker than the deck itself: an exact match against the
+// surface they sit on would leave them readable only by their outline.
 export const DEBRIS_GROUND_COLOR = 0xc9ae83
-export const DEBRIS_ROCK_COLOR = 0x5f4634
 export const DEBRIS_GRAVITY = -22
 export const DEBRIS_EMIT_INTERVAL = 0.02
 // Chips released together each tick.
 export const DEBRIS_PER_BURST = 4
 // Below this the rock is barely moving and kicking up dust would look wrong.
 export const DEBRIS_MIN_SPEED = 1.2
-export const DEBRIS_BACK_SPEED = 5.5
+export const DEBRIS_BACK_SPEED = 4
 export const DEBRIS_UP_SPEED = 6
 export const DEBRIS_SPREAD = 6
 export const DEBRIS_SPIN = 9

--- a/src/views/Games/RockRunner/game/debris.test.ts
+++ b/src/views/Games/RockRunner/game/debris.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest'
+import * as THREE from 'three'
+import { advanceParticle, particleScale, debrisVelocity, createDebrisField } from './debris'
+import {
+  DEBRIS_COUNT,
+  DEBRIS_GRAVITY,
+  DEBRIS_LIFETIME,
+  DEBRIS_SIZE,
+  DEBRIS_UP_SPEED
+} from '../config'
+import type { DebrisParticle } from '../types'
+
+const particle = (overrides: Partial<DebrisParticle> = {}): DebrisParticle => ({
+  position: new THREE.Vector3(),
+  velocity: new THREE.Vector3(),
+  life: DEBRIS_LIFETIME,
+  maxLife: DEBRIS_LIFETIME,
+  size: DEBRIS_SIZE,
+  angle: 0,
+  spin: 0,
+  colorIndex: 0,
+  ...overrides
+})
+
+const FORWARD = new THREE.Vector3(0, 0, -1)
+const RIGHT = new THREE.Vector3(1, 0, 0)
+
+describe('advanceParticle', () => {
+  it('pulls a particle down under gravity', () => {
+    const chip = particle()
+
+    advanceParticle(chip, 0.1)
+
+    expect(chip.velocity.y).toBeCloseTo(DEBRIS_GRAVITY * 0.1)
+    expect(chip.position.y).toBeLessThan(0)
+  })
+
+  it('carries a particle along its velocity', () => {
+    const chip = particle({ velocity: new THREE.Vector3(4, 0, 0) })
+
+    advanceParticle(chip, 0.25)
+
+    expect(chip.position.x).toBeCloseTo(1)
+  })
+
+  it('spins a particle at its own rate', () => {
+    const chip = particle({ spin: 2 })
+
+    advanceParticle(chip, 0.5)
+
+    expect(chip.angle).toBeCloseTo(1)
+  })
+
+  it('reports a particle alive while it has life left', () => {
+    expect(advanceParticle(particle(), 0.01)).toBe(true)
+  })
+
+  it('reports a particle dead once its life runs out', () => {
+    expect(advanceParticle(particle({ life: 0.05 }), 0.1)).toBe(false)
+  })
+
+  it('leaves a dead particle where it died rather than moving it on', () => {
+    const chip = particle({ life: 0.01, velocity: new THREE.Vector3(0, 0, -50) })
+
+    advanceParticle(chip, 0.1)
+
+    expect(chip.position.z).toBe(0)
+  })
+})
+
+describe('particleScale', () => {
+  it('draws a fresh particle at its full size', () => {
+    expect(particleScale(particle())).toBeCloseTo(DEBRIS_SIZE)
+  })
+
+  it('shrinks a particle away at the end of its life rather than blinking it out', () => {
+    const fading = particleScale(particle({ life: DEBRIS_LIFETIME * 0.1 }))
+
+    expect(fading).toBeGreaterThan(0)
+    expect(fading).toBeLessThan(DEBRIS_SIZE)
+  })
+
+  it('is zero once dead', () => {
+    expect(particleScale(particle({ life: 0 }))).toBe(0)
+  })
+
+  it('never exceeds the particle own size', () => {
+    expect(particleScale(particle({ life: DEBRIS_LIFETIME }))).toBeLessThanOrEqual(DEBRIS_SIZE)
+  })
+})
+
+describe('debrisVelocity', () => {
+  // Chips are scuffed off the ground behind a rock rolling forward, so they
+  // must travel backwards relative to it.
+  it('throws chips backwards against the direction of travel', () => {
+    const velocity = debrisVelocity(FORWARD, RIGHT, [0.5, 0.5, 0.5])
+
+    expect(velocity.dot(FORWARD)).toBeLessThan(0)
+  })
+
+  it('always throws chips upwards', () => {
+    ;[0, 0.5, 0.99].forEach((sample) => {
+      expect(debrisVelocity(FORWARD, RIGHT, [sample, sample, sample]).y).toBeGreaterThan(0)
+    })
+  })
+
+  it('fans chips to both sides so the trail is not a line', () => {
+    const left = debrisVelocity(FORWARD, RIGHT, [0.5, 0, 0.5]).dot(RIGHT)
+    const right = debrisVelocity(FORWARD, RIGHT, [0.5, 0.99, 0.5]).dot(RIGHT)
+
+    expect(left).toBeLessThan(0)
+    expect(right).toBeGreaterThan(0)
+  })
+
+  it('scales the upward kick with its sample', () => {
+    const gentle = debrisVelocity(FORWARD, RIGHT, [0.5, 0.5, 0]).y
+    const hard = debrisVelocity(FORWARD, RIGHT, [0.5, 0.5, 0.99]).y
+
+    expect(hard).toBeGreaterThan(gentle)
+    expect(hard).toBeLessThanOrEqual(DEBRIS_UP_SPEED * 1.5)
+  })
+})
+
+describe('createDebrisField', () => {
+  const setup = () => {
+    const scene = new THREE.Scene()
+    const field = createDebrisField(scene, [0x112233, 0x445566])
+    return { scene, field }
+  }
+
+  it('draws the whole trail in two instanced meshes, fill and stroke', () => {
+    const { scene } = setup()
+    const meshes = scene.children.filter((child) => child instanceof THREE.InstancedMesh)
+
+    expect(meshes).toHaveLength(2)
+    expect(scene.children.map((child) => child.name).sort()).toEqual(['debris', 'debris-stroke'])
+  })
+
+  it('draws the stroke back-faces-only, so it reads as an outline', () => {
+    const { scene } = setup()
+    const stroke = scene.children.find((child) => child.name === 'debris-stroke') as THREE.Mesh
+
+    expect((stroke.material as THREE.Material).side).toBe(THREE.BackSide)
+  })
+
+  it('starts with nothing alive', () => {
+    expect(setup().field.liveCount()).toBe(0)
+  })
+
+  it('brings a particle to life when emitting', () => {
+    const { field } = setup()
+
+    field.emit({
+      origin: new THREE.Vector3(),
+      forward: FORWARD,
+      right: RIGHT,
+      samples: [0.5, 0.5, 0.5]
+    })
+
+    expect(field.liveCount()).toBe(1)
+  })
+
+  it('retires particles once their life runs out', () => {
+    const { field } = setup()
+    field.emit({
+      origin: new THREE.Vector3(),
+      forward: FORWARD,
+      right: RIGHT,
+      samples: [0.5, 0.5, 0.5]
+    })
+
+    field.update(DEBRIS_LIFETIME + 0.1)
+
+    expect(field.liveCount()).toBe(0)
+  })
+
+  // Pooled: the field must never grow, however long the run lasts.
+  it('recycles rather than growing past its pool', () => {
+    const { field, scene } = setup()
+
+    Array.from({ length: DEBRIS_COUNT * 3 }).forEach(() =>
+      field.emit({
+        origin: new THREE.Vector3(),
+        forward: FORWARD,
+        right: RIGHT,
+        samples: [0.5, 0.5, 0.5]
+      })
+    )
+
+    expect(field.liveCount()).toBeLessThanOrEqual(DEBRIS_COUNT)
+    expect(scene.children).toHaveLength(2)
+  })
+
+  it('paces emission by the interval rather than firing every frame', () => {
+    const { field } = setup()
+
+    expect(field.shouldEmit(0.01, 0.04)).toBe(false)
+    expect(field.shouldEmit(0.01, 0.04)).toBe(false)
+    expect(field.shouldEmit(0.05, 0.04)).toBe(true)
+    expect(field.shouldEmit(0.01, 0.04)).toBe(false)
+  })
+
+  it('clears itself from the scene on teardown', () => {
+    const { field, scene } = setup()
+
+    field.teardown()
+
+    expect(scene.children).toHaveLength(0)
+  })
+})

--- a/src/views/Games/RockRunner/game/debris.test.ts
+++ b/src/views/Games/RockRunner/game/debris.test.ts
@@ -36,15 +36,17 @@ describe('advanceParticle', () => {
   })
 
   it('carries a particle along its velocity', () => {
-    const chip = particle({ velocity: new THREE.Vector3(4, 0, 0) })
+    const chip = particle({ velocity: new THREE.Vector3(4, 0, 0), life: 5, maxLife: 5 })
 
     advanceParticle(chip, 0.25)
 
     expect(chip.position.x).toBeCloseTo(1)
   })
 
+  // Life is set explicitly so the case does not break when the configured
+  // lifetime is retuned shorter than the step.
   it('spins a particle at its own rate', () => {
-    const chip = particle({ spin: 2 })
+    const chip = particle({ spin: 2, life: 5, maxLife: 5 })
 
     advanceParticle(chip, 0.5)
 

--- a/src/views/Games/RockRunner/game/debris.ts
+++ b/src/views/Games/RockRunner/game/debris.ts
@@ -1,0 +1,190 @@
+import * as THREE from 'three'
+import type { DebrisField, DebrisParticle, DebrisEmitOptions } from '../types'
+import {
+  DEBRIS_BACK_SPEED,
+  DEBRIS_COUNT,
+  DEBRIS_GRAVITY,
+  DEBRIS_LIFETIME,
+  DEBRIS_SIZE,
+  DEBRIS_SPIN,
+  DEBRIS_SPREAD,
+  DEBRIS_STROKE_COLOR,
+  DEBRIS_STROKE_SCALE,
+  DEBRIS_UP_SPEED
+} from '../config'
+
+const HALF = 0.5
+const SPIN_AXIS = new THREE.Vector3(0.4, 1, 0.2).normalize()
+
+// Written every frame for every live particle, so allocated once here.
+const scratchMatrix = new THREE.Matrix4()
+const scratchQuaternion = new THREE.Quaternion()
+const scratchScale = new THREE.Vector3()
+const scratchPosition = new THREE.Vector3()
+const HIDDEN = new THREE.Matrix4().makeScale(0, 0, 0)
+
+/**
+ * Moves one particle forward in time under gravity.
+ *
+ * @param particle - Particle to advance, mutated in place
+ * @param delta - Seconds elapsed
+ * @returns Whether the particle is still alive afterwards
+ */
+export const advanceParticle = (particle: DebrisParticle, delta: number): boolean => {
+  particle.life -= delta
+  if (particle.life <= 0) return false
+  particle.velocity.y += DEBRIS_GRAVITY * delta
+  particle.position.addScaledVector(particle.velocity, delta)
+  particle.angle += particle.spin * delta
+  return true
+}
+
+/**
+ * How large a particle draws for its remaining life: full size for most of it,
+ * shrinking away at the end so chips vanish rather than blink out.
+ *
+ * @param particle - Particle being drawn
+ * @returns A scale factor in [0, 1] times the particle's own size
+ */
+export const particleScale = (particle: DebrisParticle): number => {
+  if (particle.life <= 0) return 0
+  const remaining = particle.life / particle.maxLife
+  return particle.size * Math.min(1, remaining / 0.35)
+}
+
+/**
+ * Launch velocity for a chip thrown up behind the rock: backwards along travel,
+ * upwards, and spread sideways so the trail fans out instead of forming a line.
+ *
+ * @param forward - The rock's travel direction
+ * @param right - The track's right vector
+ * @param samples - Three values in [0, 1) driving the spread
+ * @returns A new velocity vector
+ */
+export const debrisVelocity = (
+  forward: THREE.Vector3,
+  right: THREE.Vector3,
+  samples: [number, number, number]
+): THREE.Vector3 =>
+  new THREE.Vector3()
+    .addScaledVector(forward, -DEBRIS_BACK_SPEED * (HALF + samples[0]))
+    .addScaledVector(right, (samples[1] - HALF) * 2 * DEBRIS_SPREAD)
+    .setY(DEBRIS_UP_SPEED * (HALF + samples[2]))
+
+const createParticle = (): DebrisParticle => ({
+  position: new THREE.Vector3(),
+  velocity: new THREE.Vector3(),
+  life: 0,
+  maxLife: DEBRIS_LIFETIME,
+  size: DEBRIS_SIZE,
+  angle: 0,
+  spin: 0,
+  colorIndex: 0
+})
+
+const buildInstanced = (
+  scene: THREE.Scene,
+  geometry: THREE.BufferGeometry,
+  material: THREE.Material,
+  name: string
+): THREE.InstancedMesh => {
+  const mesh = new THREE.InstancedMesh(geometry, material, DEBRIS_COUNT)
+  mesh.name = name
+  mesh.frustumCulled = false
+  mesh.castShadow = false
+  mesh.receiveShadow = false
+  scene.add(mesh)
+  return mesh
+}
+
+/**
+ * A pooled trail of debris chips thrown up behind the rock.
+ *
+ * Everything is drawn in two instanced meshes: the chips themselves, and a
+ * slightly larger copy drawn back-faces-only that reads as an ink outline
+ * around each one. That keeps the hand-drawn stroke at two draw calls rather
+ * than one per particle.
+ *
+ * @param scene - Scene to add the meshes to
+ * @param colors - Colours chips are tinted with, normally the ground and the rock
+ * @returns Handles to emit, advance and tear down the field
+ */
+export const createDebrisField = (scene: THREE.Scene, colors: number[]): DebrisField => {
+  const geometry = new THREE.IcosahedronGeometry(1, 0)
+  const strokeGeometry = geometry.clone()
+  const fillMaterial = new THREE.MeshStandardMaterial({ roughness: 1, metalness: 0 })
+  const strokeMaterial = new THREE.MeshBasicMaterial({
+    color: DEBRIS_STROKE_COLOR,
+    side: THREE.BackSide
+  })
+
+  const fill = buildInstanced(scene, geometry, fillMaterial, 'debris')
+  const stroke = buildInstanced(scene, strokeGeometry, strokeMaterial, 'debris-stroke')
+
+  const particles = Array.from({ length: DEBRIS_COUNT }, createParticle)
+  const palette = colors.map((color) => new THREE.Color(color))
+  let cursor = 0
+  let sinceEmit = 0
+
+  const emit = (options: DebrisEmitOptions): void => {
+    // Oldest-first recycling: with a full pool the longest-lived chip is the
+    // one already fading, so reusing it is invisible.
+    const particle = particles[cursor]
+    cursor = (cursor + 1) % particles.length
+    particle.position.copy(options.origin)
+    particle.velocity.copy(debrisVelocity(options.forward, options.right, options.samples))
+    particle.life = DEBRIS_LIFETIME
+    particle.maxLife = DEBRIS_LIFETIME
+    particle.size = DEBRIS_SIZE * (HALF + options.samples[0])
+    particle.angle = options.samples[1] * Math.PI * 2
+    particle.spin = (options.samples[2] - HALF) * 2 * DEBRIS_SPIN
+    particle.colorIndex = Math.floor(options.samples[1] * palette.length) % palette.length
+    fill.setColorAt(particles.indexOf(particle), palette[particle.colorIndex])
+    if (fill.instanceColor) fill.instanceColor.needsUpdate = true
+  }
+
+  const update = (delta: number): void => {
+    particles.forEach((particle, index) => {
+      const alive = advanceParticle(particle, delta)
+      if (!alive) {
+        fill.setMatrixAt(index, HIDDEN)
+        stroke.setMatrixAt(index, HIDDEN)
+        return
+      }
+      const scale = particleScale(particle)
+      scratchQuaternion.setFromAxisAngle(SPIN_AXIS, particle.angle)
+      scratchPosition.copy(particle.position)
+      scratchScale.setScalar(scale)
+      scratchMatrix.compose(scratchPosition, scratchQuaternion, scratchScale)
+      fill.setMatrixAt(index, scratchMatrix)
+      scratchScale.setScalar(scale * DEBRIS_STROKE_SCALE)
+      scratchMatrix.compose(scratchPosition, scratchQuaternion, scratchScale)
+      stroke.setMatrixAt(index, scratchMatrix)
+    })
+    fill.instanceMatrix.needsUpdate = true
+    stroke.instanceMatrix.needsUpdate = true
+  }
+
+  return {
+    emit,
+    update,
+    /** True once enough time has passed to release the next chip. */
+    shouldEmit: (delta: number, interval: number): boolean => {
+      sinceEmit += delta
+      if (sinceEmit < interval) return false
+      sinceEmit = 0
+      return true
+    },
+    liveCount: () => particles.filter((particle) => particle.life > 0).length,
+    teardown: () => {
+      scene.remove(fill)
+      scene.remove(stroke)
+      geometry.dispose()
+      strokeGeometry.dispose()
+      fillMaterial.dispose()
+      strokeMaterial.dispose()
+      fill.dispose()
+      stroke.dispose()
+    }
+  }
+}

--- a/src/views/Games/RockRunner/game/useRockRun.ts
+++ b/src/views/Games/RockRunner/game/useRockRun.ts
@@ -67,7 +67,6 @@ import {
   DEBRIS_GROUND_TOLERANCE,
   DEBRIS_MIN_SPEED,
   DEBRIS_PER_BURST,
-  DEBRIS_ROCK_COLOR,
   DEBRIS_TRAIL_OFFSET,
   CAMERA_TRANSITION_SECONDS,
   DISTANCE_BROADCAST_MS,
@@ -667,7 +666,7 @@ const buildRunWorld = ({
 
   const gateCount = Math.max(1, deps.spawnGateCount?.value ?? 1)
   const gateIndex = Math.min(gateCount - 1, Math.max(0, deps.spawnGateIndex?.value ?? 0))
-  state.debris = createDebrisField(scene, [DEBRIS_GROUND_COLOR, DEBRIS_ROCK_COLOR])
+  state.debris = createDebrisField(scene, [DEBRIS_GROUND_COLOR])
   const maps = loadRockMaps()
   state.rockMaps = maps
   state.rockTextures = Object.values(maps)

--- a/src/views/Games/RockRunner/game/useRockRun.ts
+++ b/src/views/Games/RockRunner/game/useRockRun.ts
@@ -39,6 +39,7 @@ import { createScatterPanel } from '../scatter/scatterPanel'
 import { SCATTER_AREAS } from '../scatter/illustrations'
 import { registerTrackElements, createElementVisibilityHandlers } from '../trackPanel'
 import { createLateralFogUniforms } from '../lateralFog'
+import { createDebrisField } from './debris'
 import {
   advanceDistance,
   forwardImpulseMagnitude,
@@ -51,6 +52,7 @@ import {
 } from './rockMotion'
 import type {
   CameraMode,
+  DebrisField,
   LateralFogUniforms,
   RockPosPayload,
   ScatterAreaManager,
@@ -60,6 +62,13 @@ import type {
 import {
   CONTROLS_GAME_ID,
   COUNTDOWN_MS,
+  DEBRIS_EMIT_INTERVAL,
+  DEBRIS_GROUND_COLOR,
+  DEBRIS_GROUND_TOLERANCE,
+  DEBRIS_MIN_SPEED,
+  DEBRIS_PER_BURST,
+  DEBRIS_ROCK_COLOR,
+  DEBRIS_TRAIL_OFFSET,
   CAMERA_TRANSITION_SECONDS,
   DISTANCE_BROADCAST_MS,
   FIRST_PERSON_FORWARD,
@@ -73,6 +82,7 @@ import {
   FREE_CAM_BACK,
   FREE_CAM_HEIGHT,
   FORWARD_IMPULSE,
+  GROUND_PROBE_DISTANCE,
   JUMP_COOLDOWN_SECONDS,
   JUMP_IMPULSE,
   KEYBOARD_MAPPING,
@@ -146,6 +156,7 @@ type RunState = {
   posAccumulator: number
   released: boolean
   rockMaps: RockMaps | null
+  debris: DebrisField | null
   lateralFog: LateralFogUniforms | null
   rockTextures: THREE.Texture[]
   disposePanels: (() => void)[]
@@ -162,6 +173,7 @@ type RunReferences = {
 // allocated once here rather than inside the loop.
 const scratchImpulse = { x: 0, y: 0, z: 0 }
 const ZERO_VELOCITY = { x: 0, y: 0, z: 0 }
+const scratchOrigin = new THREE.Vector3()
 
 const CAMERA_ORDER: CameraMode[] = ['third', 'first', 'free']
 
@@ -318,6 +330,37 @@ const createStartGate = (state: RunState) => ({
   }
 })
 
+// Chips appear just forward of the contact patch and are immediately left
+// behind, so they read as scuffed off the ground rather than falling out of the
+// ball. Kept out of the actions factory to hold that factory under its line
+// limit.
+const createDebrisEmitter =
+  (state: RunState) =>
+  (delta: number): void => {
+    if (!state.rock || !state.path || !state.debris) return
+    const body = state.rock.userData.body
+    const position = body.translation()
+    const sample = state.path.sampleAt(state.distance)
+    if (position.y - sample.position.y > GROUND_PROBE_DISTANCE + DEBRIS_GROUND_TOLERANCE) return
+    if (Math.hypot(body.linvel().x, body.linvel().z) < DEBRIS_MIN_SPEED) return
+    if (!state.debris.shouldEmit(delta, DEBRIS_EMIT_INTERVAL)) return
+    scratchOrigin.set(
+      position.x + sample.forward.x * ROCK_RADIUS * DEBRIS_TRAIL_OFFSET,
+      sample.position.y,
+      position.z + sample.forward.z * ROCK_RADIUS * DEBRIS_TRAIL_OFFSET
+    )
+    // A burst rather than a single chip: at speed the rock outruns its own trail,
+    // so one per tick leaves the ground looking untouched.
+    Array.from({ length: DEBRIS_PER_BURST }).forEach(() =>
+      state.debris?.emit({
+        origin: scratchOrigin,
+        forward: sample.forward,
+        right: sample.right,
+        samples: [Math.random(), Math.random(), Math.random()]
+      })
+    )
+  }
+
 const createRunActions = (
   deps: UseRockRunDeps,
   state: RunState,
@@ -325,6 +368,7 @@ const createRunActions = (
   getLocalStartTime: () => number
 ) => {
   const startGate = createStartGate(state)
+  const emitDebris = createDebrisEmitter(state)
 
   const setCameraMode = (mode: CameraMode): void => {
     refs.cameraMode.value = mode
@@ -395,6 +439,7 @@ const createRunActions = (
     updateSmoothedDirection(state.smoothedDirection, state.rock.userData.body.linvel())
     applyJump(getDelta())
     applyDrive(getDelta())
+    emitDebris(getDelta())
   }
 
   const updateDistance = (): void => {
@@ -446,6 +491,7 @@ const createRunActions = (
     applyInput,
     updateDistance,
     pumpWorld,
+    updateDebris: (delta: number) => state.debris?.update(delta),
     updateCountdown,
     broadcastPosition
   }
@@ -482,6 +528,12 @@ const buildRunTimeline = ({ camera, getDelta, orbit, state, refs, actions }: Tim
     category: 'game',
     start: 0,
     action: actions.pumpWorld
+  })
+  timeline.addAction({
+    name: 'debris',
+    category: 'physics',
+    start: 0,
+    action: () => actions.updateDebris(getDelta())
   })
   timeline.addAction(
     createDirectionalLightFollowAction(
@@ -615,6 +667,7 @@ const buildRunWorld = ({
 
   const gateCount = Math.max(1, deps.spawnGateCount?.value ?? 1)
   const gateIndex = Math.min(gateCount - 1, Math.max(0, deps.spawnGateIndex?.value ?? 0))
+  state.debris = createDebrisField(scene, [DEBRIS_GROUND_COLOR, DEBRIS_ROCK_COLOR])
   const maps = loadRockMaps()
   state.rockMaps = maps
   state.rockTextures = Object.values(maps)
@@ -642,6 +695,7 @@ const createRunState = (): RunState => ({
   posAccumulator: 0,
   released: true,
   rockMaps: null,
+  debris: null,
   lateralFog: null,
   rockTextures: [],
   disposePanels: []
@@ -735,6 +789,8 @@ export const useRockRun = (deps: UseRockRunDeps) => {
     state.track?.teardown()
     state.track = null
     state.path = null
+    state.debris?.teardown()
+    state.debris = null
     state.rockTextures.forEach((texture) => texture.dispose())
     state.rockTextures = []
     state.rockMaps = null

--- a/src/views/Games/RockRunner/trackChunks.test.ts
+++ b/src/views/Games/RockRunner/trackChunks.test.ts
@@ -16,6 +16,7 @@ import { createLateralFogUniforms } from './lateralFog'
 import {
   CHUNK_STATIONS,
   CHUNK_LENGTH,
+  COLLIDER_OVERLAP_STATIONS,
   TRACK_BEHIND,
   CURVE_TERMS,
   MIN_TURN_RADIUS,
@@ -474,6 +475,42 @@ describe('createTrackChunkManager', () => {
     const offsets = terrain.geometry.getAttribute('lateralOffset')
     expect(offsets).toBeDefined()
     expect(offsets.count).toBe(terrain.geometry.getAttribute('position').count)
+  })
+
+  // Chunks are separate colliders and Rapier only smooths normals inside one
+  // mesh, so butting them exactly leaves a junction the rock catches on.
+  it('reaches each collider past its chunk so neighbours overlap', () => {
+    const { manager, world } = createManager()
+    const path = createTrackPath(2024)
+
+    manager.ensureAhead(0)
+
+    const [from, to] = chunkStationRange(0)
+    const spanned = path.stationsBetween(
+      from - COLLIDER_OVERLAP_STATIONS,
+      to + COLLIDER_OVERLAP_STATIONS
+    )
+    const plain = path.stationsBetween(from, to)
+    expect(spanned.length).toBeGreaterThan(plain.length)
+    expect(world.createCollider).toHaveBeenCalled()
+  })
+
+  it('keeps the visible deck butting exactly, so surfaces cannot z-fight', () => {
+    const { manager, scene } = createManager()
+    manager.ensureAhead(0)
+
+    const decks = scene.children
+      .filter((child) => child.name === 'track-ground')
+      .map((deck) => {
+        deck.geometry.computeBoundingBox()
+        return deck.geometry.boundingBox!
+      })
+
+    // Every deck spans exactly one chunk length along the path, no more.
+    decks.forEach((box) => {
+      const span = Math.hypot(box.max.x - box.min.x, box.max.z - box.min.z)
+      expect(span).toBeLessThan(CHUNK_LENGTH + TRACK_WIDTH * 2)
+    })
   })
 
   it('reports the ground height from the path', () => {

--- a/src/views/Games/RockRunner/trackChunks.ts
+++ b/src/views/Games/RockRunner/trackChunks.ts
@@ -16,6 +16,7 @@ import type {
 import {
   CHUNK_LENGTH,
   CHUNK_STATIONS,
+  COLLIDER_OVERLAP_STATIONS,
   DECK_COLOR,
   DECK_FRICTION,
   DECK_SEGMENTS_ACROSS,
@@ -344,6 +345,12 @@ const buildChunk = (context: ChunkBuildContext, chunkIndex: number): TrackChunk 
     (_, offset) => fromIndex + offset
   )
   const stations = context.path.stationsBetween(fromIndex, toIndex)
+  // Reaches a station further than the visible chunk so neighbouring colliders
+  // overlap and neither end cap is ever exposed to the rock.
+  const colliderStations = context.path.stationsBetween(
+    fromIndex - COLLIDER_OVERLAP_STATIONS,
+    toIndex + COLLIDER_OVERLAP_STATIONS
+  )
   const mesh = buildDeckMesh(context, stations)
   const terrainMeshes = buildTerrainMeshes(context, stations, stationIndices)
   const wallMeshes = buildWallMeshes(context, stations)
@@ -351,7 +358,7 @@ const buildChunk = (context: ChunkBuildContext, chunkIndex: number): TrackChunk 
   // One collider for deck and walls together, so their junction is an internal
   // edge Rapier can correct rather than a seam between two meshes.
   const colliderGeometry = buildSweepGeometry(
-    stations,
+    colliderStations,
     deckWithWallsCrossSection(context.width, context.wall, DECK_THICKNESS)
   )
   const body = context.world.createRigidBody(RAPIER.RigidBodyDesc.fixed())

--- a/src/views/Games/RockRunner/types.ts
+++ b/src/views/Games/RockRunner/types.ts
@@ -158,6 +158,35 @@ export type ScatterAreaConfig = {
   opacity: number
 }
 
+/** One pooled debris chip thrown up behind the rock. */
+export type DebrisParticle = {
+  position: THREE.Vector3
+  velocity: THREE.Vector3
+  life: number
+  maxLife: number
+  size: number
+  angle: number
+  spin: number
+  colorIndex: number
+}
+
+export type DebrisEmitOptions = {
+  origin: THREE.Vector3
+  forward: THREE.Vector3
+  right: THREE.Vector3
+  /** Three values in [0, 1) driving spread, size, spin and colour. */
+  samples: [number, number, number]
+}
+
+/** A pooled trail of debris drawn as two instanced meshes, fill and stroke. */
+export type DebrisField = {
+  emit: (options: DebrisEmitOptions) => void
+  update: (delta: number) => void
+  shouldEmit: (delta: number, interval: number) => boolean
+  liveCount: () => number
+  teardown: () => void
+}
+
 export type CameraMode = 'first' | 'third' | 'free'
 
 export type RrPhase = 'lobby' | 'run' | 'summary'


### PR DESCRIPTION
Closes #215

## Summary

Debris kicked up behind the rock while it is grounded and moving, and a fix for the jump, which was firing all along but moving the rock nine centimetres.

## Key Changes

### Debris

New `game/debris.ts`. Chips are thrown from just forward of the rock's contact patch and immediately left behind, so they read as scuffed off the ground rather than falling out of the ball.

- **Pooled** — a fixed set of particles recycled oldest-first, so a long run never allocates or collects. With a full pool the longest-lived chip is the one already fading, so reuse is invisible.
- **Stroke at one extra draw call** — the chips draw in one instanced mesh and a slightly larger copy drawn back-faces-only reads as an ink outline around each, rather than an outline mesh per particle.
- **Coloured like the ground or the rock**, tinted per instance.
- Emission is paced by an interval and released in bursts, because at 23 m/s the rock outruns a single chip per tick.
- Chips shrink away at the end of their life rather than blinking out.

### Jump

`JUMP_IMPULSE` was still tuned for the rock's old mass. An impulse is momentum, so it has to grow with the mass: at 95 against a mass of 72 the rock launched at 1.3 m/s and rose nine centimetres — indistinguishable from nothing happening. It now clears roughly its own height.

### Contact tolerance

Debris judges ground contact with more room than the jump does. The rock leaves the deck briefly over every crest, and sharing the jump's stricter probe made the trail flicker.

## Added on top of the initial plan

- **The debris colours needed their own constants.** They were first taken from `ROCK_TINT`, which is the multiplier applied over a dark albedo — on its own a pale peach. Both palette colours were then pale sand on a pale sand path and the chips were invisible even while the pool reported them alive. The rock's apparent colour is now its own constant.
- **Chips start forward of the contact patch rather than behind it.** Spawned behind, they fall out of the chase camera's view almost immediately at running speed.
- The emitter is a module-level factory rather than part of the actions factory, which had grown past its line limit.

## Test Plan

- `pnpm test:unit` — **1729 passed**, 22 of them new: particle integration under gravity, lifetime and fade, launch direction and spread, the two-mesh structure and back-face stroke, pooling under sustained emission, and emission pacing.
- `pnpm lint` — 0 errors. `pnpm type-check` — clean.
- Manual, driven with Playwright: chips appear behind the rock with their outline while grounded and moving, and the rock visibly leaves the ground on space, its shadow separating beneath it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
