### PR TITLE
Fix mobile bugs: horizontal lobby list, fauxpad wiring gap, Rock Runner jump button

### DIFF
--- a/src/components/TouchControl.test.ts
+++ b/src/components/TouchControl.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TouchControl from './TouchControl.vue'
+
+describe('TouchControl — button mode', () => {
+  it('marks the action held on press and clears it on release', async () => {
+    const currentActions: Record<string, unknown> = {}
+    const wrapper = mount(TouchControl, {
+      props: {
+        mode: 'button',
+        mapping: { Jump: 'jump' },
+        currentActions,
+        onAction: vi.fn()
+      }
+    })
+
+    await wrapper.find('.touch-control').trigger('touchstart')
+    expect(currentActions).toHaveProperty('jump')
+
+    await wrapper.find('.touch-control').trigger('touchend')
+    expect(currentActions).not.toHaveProperty('jump')
+  })
+
+  it('calls onAction on release, not on press', async () => {
+    const onAction = vi.fn()
+    const wrapper = mount(TouchControl, {
+      props: { mode: 'button', mapping: { Jump: 'jump' }, onAction }
+    })
+
+    await wrapper.find('.touch-control').trigger('touchstart')
+    expect(onAction).not.toHaveBeenCalled()
+
+    await wrapper.find('.touch-control').trigger('touchend')
+    expect(onAction).toHaveBeenCalledWith('jump')
+  })
+
+  it('clears the held action on touchcancel and mouseleave without firing onAction', async () => {
+    const onAction = vi.fn()
+    const currentActions: Record<string, unknown> = {}
+    const wrapper = mount(TouchControl, {
+      props: { mode: 'button', mapping: { Jump: 'jump' }, currentActions, onAction }
+    })
+
+    await wrapper.find('.touch-control').trigger('touchstart')
+    expect(currentActions).toHaveProperty('jump')
+
+    await wrapper.find('.touch-control').trigger('touchcancel')
+    expect(currentActions).not.toHaveProperty('jump')
+    expect(onAction).not.toHaveBeenCalled()
+
+    await wrapper.find('.touch-control').trigger('touchstart')
+    await wrapper.find('.touch-control').trigger('mouseleave')
+    expect(currentActions).not.toHaveProperty('jump')
+    expect(onAction).not.toHaveBeenCalled()
+  })
+
+  it('does not mutate currentActions when the prop is not provided', async () => {
+    const onAction = vi.fn()
+    const wrapper = mount(TouchControl, {
+      props: { mode: 'button', mapping: { Jump: 'jump' }, onAction }
+    })
+
+    await expect(wrapper.find('.touch-control').trigger('touchstart')).resolves.not.toThrow()
+    await expect(wrapper.find('.touch-control').trigger('touchend')).resolves.not.toThrow()
+    expect(onAction).toHaveBeenCalledWith('jump')
+  })
+
+  it('wires press and release per button in multi-button rows', async () => {
+    const currentActions: Record<string, unknown> = {}
+    const onAction = vi.fn()
+    const wrapper = mount(TouchControl, {
+      props: {
+        mode: 'button',
+        mapping: { Left: 'left', Right: 'right' },
+        currentActions,
+        onAction
+      }
+    })
+
+    const buttons = wrapper.findAll('.touch-control__button')
+    expect(buttons).toHaveLength(2)
+
+    await buttons[0]!.trigger('touchstart')
+    expect(currentActions).toHaveProperty('left')
+    expect(currentActions).not.toHaveProperty('right')
+
+    await buttons[0]!.trigger('touchend')
+    expect(currentActions).not.toHaveProperty('left')
+    expect(onAction).toHaveBeenCalledWith('left')
+  })
+})

--- a/src/components/TouchControl.vue
+++ b/src/components/TouchControl.vue
@@ -84,8 +84,24 @@ onUnmounted(() => {
   }
 })
 
+const handleButtonPress = (action: string) => {
+  // Mirrors the faux-pad's currentActions mutation so held-state checks
+  // (e.g. jump buffering) see the button the same way they see the pad.
+  if (!props.currentActions) return
+  // eslint-disable-next-line vue/no-mutating-props
+  props.currentActions[action] = { trigger: action, device: 'faux-pad' }
+}
+
+const handleButtonRelease = (action: string) => {
+  if (props.currentActions && props.currentActions[action]) {
+    // eslint-disable-next-line vue/no-mutating-props
+    delete props.currentActions[action]
+  }
+}
+
 const handleButtonAction = (action: string, event: Event) => {
   event.preventDefault()
+  handleButtonRelease(action)
   props.onAction(action)
 }
 </script>
@@ -96,8 +112,12 @@ const handleButtonAction = (action: string, event: Event) => {
     v-if="isButtonMode && !isMultiButton"
     class="touch-control"
     :class="rootClasses"
+    @mousedown="handleButtonPress(singleEntry[1])"
+    @touchstart="handleButtonPress(singleEntry[1])"
     @click="handleButtonAction(singleEntry[1], $event)"
     @touchend="handleButtonAction(singleEntry[1], $event)"
+    @touchcancel="handleButtonRelease(singleEntry[1])"
+    @mouseleave="handleButtonRelease(singleEntry[1])"
   >
     <div class="touch-control__edge"></div>
     <div class="touch-control__inside touch-control__inside--label">{{ singleEntry[0] }}</div>
@@ -109,8 +129,12 @@ const handleButtonAction = (action: string, event: Event) => {
       v-for="(action, label) in mapping"
       :key="label"
       class="touch-control__button"
+      @mousedown="handleButtonPress(action)"
+      @touchstart="handleButtonPress(action)"
       @click="handleButtonAction(action, $event)"
       @touchend="handleButtonAction(action, $event)"
+      @touchcancel="handleButtonRelease(action)"
+      @mouseleave="handleButtonRelease(action)"
     >
       {{ label }}
     </button>

--- a/src/views/Games/Lobby/Lobby.vue
+++ b/src/views/Games/Lobby/Lobby.vue
@@ -566,11 +566,16 @@ onMounted(async () => {
 
   .lobby__picker-games {
     gap: var(--spacing-3);
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    width: 100%;
+    justify-content: flex-start;
   }
 
   .lobby__game-card {
     padding: var(--spacing-3) var(--spacing-4);
     min-width: 7rem;
+    flex: 0 0 auto;
   }
 }
 </style>

--- a/src/views/Games/MarbleEditor/MarbleEditor.vue
+++ b/src/views/Games/MarbleEditor/MarbleEditor.vue
@@ -31,7 +31,13 @@ import { isMobile } from '@webgamekit/controls'
 import TouchControl from '@/components/TouchControl.vue'
 import { useMenuFocus } from '@/composables/useMenuFocus'
 import { BALL_TYPE_LABELS, MARBLE_BALL_LABEL } from '@/utils/physicBalls'
-import { EDITOR_MENU_MAPPING, MARBLE_WEIGHT, MARBLE_RESTITUTION, MARBLE_FRICTION } from './config'
+import {
+  EDITOR_MENU_MAPPING,
+  MARBLE_WEIGHT,
+  MARBLE_RESTITUTION,
+  MARBLE_FRICTION,
+  KEYBOARD_MAPPING
+} from './config'
 import { useMarbleEditor } from './editor/useMarbleEditor'
 import { useMarbleRace } from './game/useMarbleRace'
 import { useMarbleEditorSession } from './useMarbleEditorSession'
@@ -563,7 +569,7 @@ onUnmounted(() => {
         <TouchControl
           v-if="isMobileDevice && race.currentActions.value"
           class="me__fauxpad"
-          :mapping="{ up: 'forward', down: 'backward', left: 'left', right: 'right' }"
+          :mapping="KEYBOARD_MAPPING['faux-pad']"
           :options="{ deadzone: 0.15, enableEightWay: true }"
           :current-actions="race.currentActions.value"
           :on-action="() => {}"

--- a/src/views/Games/MarbleEditor/config.ts
+++ b/src/views/Games/MarbleEditor/config.ts
@@ -152,6 +152,12 @@ export const KEYBOARD_MAPPING = {
     options: 'back',
     l1: 'undo',
     r1: 'redo'
+  },
+  'faux-pad': {
+    up: 'forward',
+    down: 'backward',
+    left: 'left',
+    right: 'right'
   }
 }
 

--- a/src/views/Games/MarbleMadness/MarbleMadnessGame.vue
+++ b/src/views/Games/MarbleMadness/MarbleMadnessGame.vue
@@ -3,7 +3,7 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { isMobile } from '@webgamekit/controls'
 import { useMenuNavigation, type MenuSource } from '@/composables/useMenuNavigation'
 import TouchControl from '@/components/TouchControl.vue'
-import { TIME_PENALTY_FALL, RUSH_TIME_BONUS } from './config'
+import { TIME_PENALTY_FALL, RUSH_TIME_BONUS, KEYBOARD_MAPPING } from './config'
 import type { GameMode } from './types'
 
 const isMobileDevice = isMobile()
@@ -189,7 +189,7 @@ onUnmounted(() => {
     <TouchControl
       v-if="isMobileDevice && currentActions"
       class="mm-game__fauxpad"
-      :mapping="{ up: 'forward', down: 'backward', left: 'left', right: 'right' }"
+      :mapping="KEYBOARD_MAPPING['faux-pad']"
       :options="{ deadzone: 0.15, enableEightWay: true }"
       :current-actions="currentActions"
       :on-action="() => {}"

--- a/src/views/Games/MarbleMadness/config.ts
+++ b/src/views/Games/MarbleMadness/config.ts
@@ -463,6 +463,12 @@ export const KEYBOARD_MAPPING = {
     'dpad-down': 'backward',
     'dpad-left': 'left',
     'dpad-right': 'right'
+  },
+  'faux-pad': {
+    up: 'forward',
+    down: 'backward',
+    left: 'left',
+    right: 'right'
   }
 }
 

--- a/src/views/Games/MazeGame/MazeGame.vue
+++ b/src/views/Games/MazeGame/MazeGame.vue
@@ -548,12 +548,7 @@ onUnmounted(() => {
   <TouchControl
     v-if="isMobileDevice"
     style="left: 25px; bottom: 25px"
-    :mapping="{
-      left: 'move-left',
-      right: 'move-right',
-      up: 'move-up',
-      down: 'move-down'
-    }"
+    :mapping="controlBindings.mapping['faux-pad']"
     :options="{ deadzone: 0.15, enableEightWay: true }"
     :current-actions="currentActions"
     :on-action="handleAction"

--- a/src/views/Games/RockRunner/RockRunner.vue
+++ b/src/views/Games/RockRunner/RockRunner.vue
@@ -28,7 +28,7 @@ import { useRockRunnerSession } from './useRockRunnerSession'
 import RockRunnerLobby from './wizard/RockRunnerLobby.vue'
 import RockRunnerRules from './wizard/RockRunnerRules.vue'
 import RockRunnerSummary from './game/RockRunnerSummary.vue'
-import { CONFIG_STORAGE_KEY } from './config'
+import { CONFIG_STORAGE_KEY, KEYBOARD_MAPPING, FAUXPAD_BUTTONS } from './config'
 import { rockSurfaceById } from './elements/rockSurfaces'
 import type { CameraMode } from './types'
 
@@ -317,8 +317,16 @@ onUnmounted(() => {
       <TouchControl
         v-if="isMobileDevice && run.currentActions.value"
         class="rr__fauxpad"
-        :mapping="{ up: 'jump', down: 'jump', left: 'left', right: 'right' }"
+        :mapping="KEYBOARD_MAPPING['faux-pad']"
         :options="{ deadzone: 0.15 }"
+        :current-actions="run.currentActions.value"
+        :on-action="() => {}"
+      />
+      <TouchControl
+        v-if="isMobileDevice && run.currentActions.value"
+        class="rr__jump-btn"
+        mode="button"
+        :mapping="FAUXPAD_BUTTONS"
         :current-actions="run.currentActions.value"
         :on-action="() => {}"
       />
@@ -451,6 +459,13 @@ onUnmounted(() => {
   position: absolute;
   bottom: var(--spacing-6);
   left: var(--spacing-6);
+  z-index: var(--z-dropdown);
+}
+
+.rr__jump-btn {
+  position: absolute;
+  bottom: var(--spacing-6);
+  right: var(--spacing-6);
   z-index: var(--z-dropdown);
 }
 

--- a/src/views/Games/RockRunner/config.ts
+++ b/src/views/Games/RockRunner/config.ts
@@ -30,7 +30,18 @@ export const KEYBOARD_MAPPING = {
     button0: 'jump',
     button3: 'camera',
     button1: 'exit'
+  },
+  'faux-pad': {
+    left: 'left',
+    right: 'right'
   }
+}
+
+// Jump gets its own on-screen button rather than a faux-pad direction: it's
+// easy to miss buried in an up/down tilt, and this is the only fauxpad
+// action outside the pad's four directions.
+export const FAUXPAD_BUTTONS: Record<string, string> = {
+  Jump: 'jump'
 }
 
 export const CONTROLS_CONFIG: ControlsMapperGameConfig = {


### PR DESCRIPTION
Closes #218

## Summary

Three mobile-specific bugs: the lobby game picker doesn't scroll horizontally, on-screen touch controls (fauxpad) are hardcoded separately per game and silently drift out of sync with keyboard/gamepad bindings, and Rock Runner has no dedicated jump button on touch.

## Key Changes

- **Lobby game list (mobile)**: `.lobby__picker-games` now scrolls horizontally at ≤720px instead of wrapping into rows.
- **Fauxpad wiring gap**: each game's touch-control mapping is now co-located in `config.ts` (`KEYBOARD_MAPPING['faux-pad']`), next to the keyboard/gamepad bindings, instead of a separate literal hardcoded in the `.vue` template. Applied to RockRunner, MarbleEditor, MarbleMadness, and MazeGame.
- **Rock Runner jump button**: added a dedicated `TouchControl mode="button"` next to the directional pad, positioned bottom-right.
- **TouchControl button mode**: added real press/release event wiring (`touchstart`/`mousedown` → `touchend`/`touchcancel`/`mouseleave`) so a button tap marks the action "held" in `currentActions` for at least one frame, matching how Rock Runner's jump-buffer logic reads input every frame. Previously button mode only fired a one-shot callback with no held-state, which doesn't work for jump.

## Added on top of the initial plan

- **Lobby picker: two extra layout bugs found while verifying in-browser.** The picker row had no bounded width (`align-items: center` on its flex parent means it never stretches), so `overflow-x: auto` had nothing to clip against and the whole page grew wider instead of scrolling internally — fixed with `width: 100%` on the row at the mobile breakpoint. Also, `justify-content: center` on an overflowing scroll container clips the first/last items with no way to scroll to them — fixed by switching to `flex-start` at the mobile breakpoint.
- **MazeGame fauxpad inversion bug.** Found while auditing all `TouchControl` usages for item 2: MazeGame's inline template mapping (`up: 'move-up', down: 'move-down'`) was inverted relative to its own `config.ts`'s documented `controlBindings.mapping['faux-pad']` (`up: 'move-down', down: 'move-up'`, the correct +Z-camera convention). Fixed as part of pointing the template at the config export instead of a separate literal.
- **`TouchControl.test.ts` (new).** No test file existed for this component. Added 5 tests covering the new button press/release behavior (held-state mutation, release firing `onAction`, `touchcancel`/`mouseleave` clearing without firing, backward compatibility when `currentActions` isn't passed, and multi-button rows wiring independently) since this was a real behavioral change with functional risk to Rock Runner's jump.

## Test plan

- [x] `pnpm test:unit` — 1969 tests passing (5 new)
- [x] `pnpm type-check` — clean
- [x] Lint — clean (pre-existing unrelated warnings only)
- [x] Verified in-browser (Playwright, iPhone 13 emulation): lobby list scrolls horizontally with no page-level overflow; Rock Runner shows pad (left/right) + separate "Jump" button in-game; MarbleEditor/MarbleMadness/MazeGame touch controls render without runtime errors