### PR TITLE
Rock Runner: fix FPS drops at track/scatter chunk boundaries on mobile

### DIFF
--- a/documentation/docs/journey/rock-runner-collider-construction-cost.md
+++ b/documentation/docs/journey/rock-runner-collider-construction-cost.md
@@ -1,0 +1,193 @@
+---
+sidebar_position: 117
+---
+
+# Rock Runner: what a trimesh collider costs, and what would be cheaper
+
+This is a deep dive into one lever identified while chasing a mobile FPS
+drop at track/scatter chunk boundaries, deliberately _not_ pulled: replacing
+the deck's physics collider. The streaming fix that shipped alongside this
+write-up (staggering scatter areas, capping chunk builds to one per frame —
+see the commit on `perf/rockrunner-chunk-streaming`) addresses _when_ and
+_how often_ expensive work happens. This document is about the other half:
+making the expensive work itself cheaper, which nothing in that fix touches.
+
+## Where the cost actually is
+
+Every new track chunk (`trackChunks.ts`, `buildChunk`) does two kinds of
+work: building visual meshes (deck, terrain, walls, the ink stroke), and
+building one physics collider for the deck and walls together:
+
+```typescript
+const colliderGeometry = buildSweepGeometry(
+  colliderStations,
+  deckWithWallsCrossSection(context.width, context.wall, DECK_THICKNESS)
+)
+const body = context.world.createRigidBody(RAPIER.RigidBodyDesc.fixed())
+addTrimeshCollider(context.world, body, colliderGeometry, DECK_FRICTION, DECK_RESTITUTION)
+```
+
+`addTrimeshCollider` hands Rapier raw triangle soup —
+`RAPIER.ColliderDesc.trimesh(vertices, indices, RAPIER.TriMeshFlags.FIX_INTERNAL_EDGES)`.
+That single call is the suspect: of everything a chunk build does, it's the
+only step that isn't "make some buffers and hand them to Three.js" — it's a
+physics-engine construction step that has to build an acceleration
+structure before the collider is usable at all.
+
+## What a trimesh collider is, and why the deck uses one
+
+A **trimesh** collider is exactly what it sounds like: an arbitrary soup of
+triangles, no assumptions about shape. To answer "does this ball touch this
+mesh" efficiently, Rapier can't test every triangle every physics step — it
+builds a **BVH** (bounding volume hierarchy) once, up front: a tree of
+nested bounding boxes that lets a query discard most of the mesh in a few
+comparisons instead of checking every triangle. Building that tree is what
+`ColliderDesc.trimesh(...)` actually does under the hood, and it's genuinely
+the most expensive of Rapier's collider constructors — it's also the only
+one general enough to represent _anything_, which is exactly why it was
+reached for here.
+
+The deck's cross-section (`deckWithWallsCrossSection`) is a fixed profile —
+flat deck, inset lip, two vertical walls — swept along a path that curves
+in heading, banks, and rises and falls in height, all at once
+(`buildSweepGeometry`). There's no primitive shape (box, cylinder, capsule)
+that profile fits, so a trimesh is the only collider type that represents it
+exactly. And it's built as **one** collider for deck and walls together
+deliberately: the code comment above the call site is explicit about why —
+
+> One collider for deck and walls together, so their junction is an
+> internal edge Rapier can correct rather than a seam between two meshes.
+
+`FIX_INTERNAL_EDGES` is part of the same story: it makes the mesh's winding
+physically meaningful so Rapier can smooth contact normals across a shared
+edge between triangles, which is what stops a ball catching on the crease
+where the flat deck meets the wall's base. That flag adds its own pass on
+top of the BVH build. Anything that touches this collider has to keep that
+fix intact, or the exact bug it solved comes back.
+
+## Why it's expensive regardless of triangle count
+
+The instinct is "reduce the triangle count." Worth doing the arithmetic
+first: `stationsBetween` is inclusive on both ends, and the collider spans
+`fromIndex - COLLIDER_OVERLAP_STATIONS` to `toIndex + COLLIDER_OVERLAP_STATIONS`
+— `CHUNK_STATIONS` (12) stations for the chunk itself, plus one extra
+station of overlap on each side, comes to 15 rings, each an 8-point open
+cross-section (`deckWithWallsCrossSection` — the two walls' four corners
+each, deck implicit between the inner two). A ring of 8 points connects to
+the next ring with 7 quads (it's an open profile, not a closed loop), so
+the whole collider sweeps out roughly 15 × 8 = 120 vertices and
+14 × 7 × 2 = 196 triangles. That is not a lot of geometry — a trimesh with
+a couple hundred triangles is nowhere near where naive "reduce the poly
+count" advice usually pays off.
+
+That's the actual point worth taking away: the cost here is much more likely
+the **fixed overhead of the operation type** — BVH allocation, the
+WASM call boundary, `FIX_INTERNAL_EDGES`'s extra edge-welding pass — than
+the volume of data going into it. Halving the triangle count would likely
+make a small dent, not fix the spike. This should be verified before
+trusting it, though: wrapping the `addTrimeshCollider` call in
+`performance.now()` timestamps and reading the actual milliseconds would
+turn this from "very likely" into "confirmed," and is the natural next step
+before spending real effort on any of the alternatives below.
+
+## Alternative 1: heightfield
+
+A **heightfield** collider is a regular 2D grid of height samples in a
+flat, axis-aligned local rectangle. Rapier (and every other physics engine)
+can build one in roughly linear time and query it in O(1) — "which cell is
+under this point" is array indexing, not a tree descent, and there's no BVH
+to build because the regular grid structure already tells you where
+everything is. This is the standard answer to "trimesh collider is too
+slow" for terrain, and it would very likely make chunk builds dramatically
+cheaper.
+
+The catch is real, not a technicality: a heightfield stores **one height
+per (x, z) grid cell**. It cannot represent a vertical wall, let alone the
+current profile's overhang-free-but-still-multi-height cross-section (deck,
+then a vertical jump up to the wall top). The deck alone — no walls — maps
+onto a heightfield reasonably (it's a single surface, curving and banking
+but still one height per point along the ribbon in the path's local frame).
+The walls fundamentally cannot: they'd need to become their own, separate
+colliders (a thin box or two per chunk is the obvious shape), splitting the
+single collider back into deck-plus-walls-as-three-pieces — undoing the
+exact unification the current code put in specifically to stop the rock
+catching on that internal seam.
+
+That doesn't make this a dead end, but it does mean it isn't a drop-in
+swap — it's "solve the seam problem a different way, then get the cheap
+construction." The same trick already used for the seam **between**
+chunks (`TRACK_CONTACT_SKIN`, a small collider margin that bridges the
+hairline gap at a chunk boundary) is the natural candidate: give the
+deck-heightfield and the wall-boxes a shared contact skin so a ball crossing
+from one onto the other doesn't catch on the geometric discontinuity between
+two different collider shapes, the same way it doesn't catch crossing from
+one trimesh chunk to the next today. That's a real physics-tuning task with
+its own failure modes (a skin too generous reads as a soft, spongy wall; too
+tight and the old bug is back) — it would need the same kind of iterative,
+in-browser verification the original deck/wall unification presumably went
+through.
+
+## Alternative 2: compound collider (boxes instead of one mesh)
+
+A **compound** collider is a fixed body with several simple child colliders
+— boxes, in this case — instead of one mesh. Since the deck is already
+built from discrete stations (`STATION_SPACING` = 4 world units apart), it's
+already a faceted approximation of a smooth curve, not a true curve; nothing
+stops each station-to-station segment from being its own slightly rotated
+box for the deck and two more for the walls, instead of all being welded
+into one trimesh. Boxes are one of the cheapest collider shapes there is —
+effectively free to construct, no BVH, no acceleration structure beyond the
+compound's own (much smaller, much cheaper) top-level bounding volume tree
+over a handful of children rather than hundreds of triangles.
+
+The tradeoff is the same seam problem as the heightfield option, in a
+different shape: adjacent boxes meeting at an angle (wherever the path
+curves) present a hard edge to the ball, exactly the crease the unified
+trimesh was built to avoid. A contact skin across every box-to-box junction
+is a much bigger surface of "please don't catch here" than the heightfield
+option's single deck/wall seam, since there's now one per station instead
+of one per chunk boundary. This is probably the higher-risk, lower-payoff
+option of the two shape alternatives for that reason — more seams to tune,
+for a shape that (unlike the heightfield) doesn't even solve the "can't
+represent a wall" problem, since a compound of boxes can, but only by
+keeping wall geometry as its own set of child shapes either way.
+
+## Alternative 3: build off the main thread
+
+Rapier ships as WebAssembly, which raises the question of whether the
+expensive part — specifically the BVH build — could happen in a Web Worker
+while the main thread keeps rendering. In principle, yes: WASM runs happily
+in a worker. In practice, Rapier's `World`, `RigidBody` and `Collider`
+objects aren't plain data — they're live handles into one simulation's
+internal state. There is no supported way to build a collider against a
+`World` that lives in a worker and hand the finished result to a different
+`World` on the main thread; the object model doesn't serialize across that
+boundary. Making this work would mean running the _entire_ physics
+simulation in the worker and shuttling transforms back to the main thread
+every frame for rendering — a full architecture change to how this game
+(and the physics helper package it shares with every other Rapier-based
+game in this codebase) is built, not a targeted fix. Worth knowing this
+ceiling exists; not worth pursuing for this specific spike.
+
+## What I'd actually try, in order
+
+1. **Measure the trimesh call itself first.** Wrap `addTrimeshCollider` in
+   `performance.now()` and log it for a run's worth of chunk builds. This
+   confirms or kills the hypothesis that it's the dominant cost before any
+   of the below is worth the risk.
+2. **Heightfield deck + box walls + a contact skin between them**, mirroring
+   the existing `TRACK_CONTACT_SKIN` trick used at chunk boundaries. Most
+   likely to actually move the number, and reuses a pattern the codebase has
+   already validated once for exactly this class of seam problem.
+3. **Compound boxes** only if the heightfield route turns out to need walls
+   with a shape a heightfield truly can't approximate (a genuine overhang or
+   tunnel, which the game doesn't have today but might one day).
+4. **Worker-thread physics** is a full rewrite of how physics runs in this
+   codebase, not a fix for this bug — only worth it if a future feature
+   independently demands running physics off the main thread anyway.
+
+None of this is implemented. It's a real, load-bearing change to how the
+track's ground behaves under the ball, and it should go through its own
+design pass — starting with the measurement in step 1 — rather than being
+folded into a chunk-streaming fix that didn't need to touch the collider at
+all.

--- a/src/views/Games/RockRunner/game/useRockRun.ts
+++ b/src/views/Games/RockRunner/game/useRockRun.ts
@@ -122,6 +122,7 @@ import {
   SKY_COLOR,
   TERRAIN_STAGE_TINTS,
   ROCK_STROKE_COLOR,
+  SCATTER_CHUNK_LENGTH,
   SPAWN_GATE_SPREAD,
   TRACK_WIDTH,
   WALL_ELEMENT_NAME,
@@ -552,10 +553,14 @@ const createRunActions = (
   // as a whole rather than the trees swapping inside an unchanged haze.
   const pumpWorld = (): void => {
     advanceStage()
-    state.track?.ensureAhead(state.distance)
+    // pump, not ensureAhead: at most one chunk per manager per frame, so a
+    // device that has fallen behind never has to build several trimesh
+    // colliders and InstancedMeshes in the same frame — it catches up over a
+    // few frames instead of spiking one.
+    state.track?.pump(state.distance)
     state.track?.prune(state.distance)
     state.scatter.forEach((area) => {
-      area.ensureAhead(state.distance)
+      area.pump(state.distance)
       area.prune(state.distance)
     })
   }
@@ -744,14 +749,18 @@ const buildRunWorld = ({
     lateralFog
   })
   state.track = track
-  state.scatter = SCATTER_AREAS.map((definition) =>
+  state.scatter = SCATTER_AREAS.map((definition, index) =>
     createScatterAreaManager({
       scene,
       path,
       definition,
       lateralFog,
       getConfig: () => scatterPanel.areaConfig(definition.name),
-      getTextures: (distance: number) => scatterPanel.areaTextures(definition.name, distance)
+      getTextures: (distance: number) => scatterPanel.areaTextures(definition.name, distance),
+      // Every area shares one chunk length, so left unstaggered they would all
+      // fall due for a new chunk on the same frame. Spread evenly across one
+      // chunk's length, so their rebuilds land on different frames instead.
+      chunkPhase: (index * SCATTER_CHUNK_LENGTH) / SCATTER_AREAS.length
     })
   )
 

--- a/src/views/Games/RockRunner/scatter/scatterAreas.test.ts
+++ b/src/views/Games/RockRunner/scatter/scatterAreas.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import * as THREE from 'three'
 import { createScatterAreaManager, scatterChunkSpan, groupInstancesByTexture } from './scatterAreas'
 import { createLateralFogUniforms } from '../lateralFog'
@@ -164,6 +164,49 @@ describe('createScatterAreaManager', () => {
     manager.ensureAhead(SCATTER_CHUNK_LENGTH * 5)
 
     expect(scatterMeshes(scene).length).toBeGreaterThan(before)
+  })
+
+  // A single pump only ever builds one chunk, so a device that has fallen
+  // behind never has to build several areas' worth of InstancedMeshes (and
+  // possibly compile new shaders) in the same frame — it catches up one
+  // chunk per subsequent call instead.
+  it('pump builds at most one chunk per call, so it lags a full ensureAhead', () => {
+    const { manager, scene } = createManager()
+    const { manager: fullManager, scene: fullScene } = createManager()
+
+    manager.pump(0)
+    fullManager.ensureAhead(0)
+
+    expect(scatterMeshes(scene).length).toBeLessThan(scatterMeshes(fullScene).length)
+  })
+
+  it('pump reaches the same coverage as ensureAhead after enough calls', () => {
+    const { manager, scene } = createManager()
+    const { manager: fullManager, scene: fullScene } = createManager()
+
+    Array.from({ length: EXPECTED_CHUNKS }).forEach(() => manager.pump(0))
+    fullManager.ensureAhead(0)
+
+    expect(scatterMeshes(scene).length).toBe(scatterMeshes(fullScene).length)
+  })
+
+  it('offsets its chunk boundaries by chunkPhase, so areas do not all rebuild on the same frame', () => {
+    const scene = new THREE.Scene()
+    const path = createTrackPath(11)
+    const getTextures = vi.fn(() => treeDefinition.textures)
+    const manager = createScatterAreaManager({
+      scene,
+      path,
+      definition: treeDefinition,
+      lateralFog: createLateralFogUniforms(0xffffff, 20, 40),
+      getConfig: () => config,
+      getTextures,
+      chunkPhase: 12
+    })
+
+    manager.pump(0)
+
+    expect(getTextures).toHaveBeenCalledWith(12 - SCATTER_BEHIND)
   })
 
   it('disposes chunks left behind', () => {

--- a/src/views/Games/RockRunner/scatter/scatterAreas.ts
+++ b/src/views/Games/RockRunner/scatter/scatterAreas.ts
@@ -70,6 +70,14 @@ export type ScatterAreaManagerOptions = {
   lateralFog: LateralFogUniforms
   getConfig: () => ScatterAreaConfig
   getTextures: (distance: number) => ScatterTexture[]
+  /**
+   * Offsets this area's chunk grid. Every area shares the same chunk length,
+   * so left at zero they would all fall due for a new chunk on the same
+   * distance — several new InstancedMeshes (and any first-use shader
+   * compiles) landing in one frame. A different offset per area spreads that
+   * same total work across more frames instead.
+   */
+  chunkPhase?: number
 }
 
 /**
@@ -123,6 +131,7 @@ export const createScatterAreaManager = (
 ): ScatterAreaManager => {
   const { scene, path, definition, getConfig, getTextures } = options
   const span = scatterChunkSpan()
+  const phase = options.chunkPhase ?? 0
   const cache = createMaterialCache(options.lateralFog, () => getConfig().opacity)
   let chunks: ScatterChunk[] = []
   let hidden = false
@@ -200,13 +209,22 @@ export const createScatterAreaManager = (
       mesh.dispose()
     })
 
-  // Recursive rather than a loop: one chunk per call until the lookahead is
-  // covered, matching how the track chunk manager pumps itself.
+  const chunkTail = (): number => chunks[chunks.length - 1]?.endDistance ?? phase - span.behind
+  const needsChunk = (distance: number): boolean => chunkTail() < distance + span.lookahead
+
+  // Recursive: fills the whole lookahead in one call. Used only for a
+  // deliberate rebuild; pump below builds one chunk per frame instead, so a
+  // slow device never pays for several areas' meshes in the same frame.
   const ensureAhead = (distance: number): void => {
-    const tail = chunks[chunks.length - 1]?.endDistance ?? -span.behind
-    if (tail >= distance + span.lookahead) return
-    spawnChunk(tail)
+    if (!needsChunk(distance)) return
+    spawnChunk(chunkTail())
     ensureAhead(distance)
+  }
+
+  // Called every frame: at most one chunk, so falling behind costs a few
+  // thin frames of lookahead rather than one frame building them all.
+  const pump = (distance: number): void => {
+    if (needsChunk(distance)) spawnChunk(chunkTail())
   }
 
   const prune = (distance: number): void => {
@@ -246,6 +264,7 @@ export const createScatterAreaManager = (
   return {
     name: definition.name,
     ensureAhead,
+    pump,
     prune,
     rebuild,
     setHidden,

--- a/src/views/Games/RockRunner/trackChunks.test.ts
+++ b/src/views/Games/RockRunner/trackChunks.test.ts
@@ -352,6 +352,37 @@ describe('createTrackChunkManager', () => {
     expect(after).toBeGreaterThan(before)
   })
 
+  // A single pump only ever builds one chunk, so a frame that has fallen
+  // behind (a slow device, a big hitch) never has to pay for several trimesh
+  // colliders at once — it catches up one chunk per subsequent call instead.
+  it('pump builds at most one chunk per call, however far behind it is', () => {
+    const { manager, scene } = createManager()
+
+    manager.pump(0)
+
+    const decks = scene.children.filter((child) => child.name === 'track-ground')
+    expect(decks).toHaveLength(1)
+  })
+
+  it('pump reaches full lookahead coverage after enough calls', () => {
+    const { manager, scene } = createManager()
+
+    Array.from({ length: EXPECTED_CHUNKS }).forEach(() => manager.pump(0))
+
+    const decks = scene.children.filter((child) => child.name === 'track-ground')
+    expect(decks).toHaveLength(EXPECTED_CHUNKS)
+  })
+
+  it('pump does nothing once the lookahead is already covered', () => {
+    const { manager, scene } = createManager()
+    Array.from({ length: EXPECTED_CHUNKS }).forEach(() => manager.pump(0))
+    const afterFull = scene.children.length
+
+    manager.pump(0)
+
+    expect(scene.children.length).toBe(afterFull)
+  })
+
   it('disposes chunks that fall behind the keep-alive window', () => {
     const { manager, scene, removeRigidBody } = createManager()
     manager.ensureAhead(0)

--- a/src/views/Games/RockRunner/trackChunks.ts
+++ b/src/views/Games/RockRunner/trackChunks.ts
@@ -475,13 +475,26 @@ export const createTrackChunkManager = (options: TrackChunkManagerOptions): Trac
     chunks = [...chunks, chunk]
   }
 
+  const coversLookahead = (distance: number): boolean =>
+    (chunks[chunks.length - 1]?.endDistance ?? -TRACK_BEHIND) >= distance + TRACK_LOOKAHEAD
+
   // Recursive rather than a loop: one chunk per call until the lookahead is
-  // covered, matching how the cloud chunk manager pumps itself.
+  // covered, matching how the cloud chunk manager pumps itself. Used for a
+  // deliberate one-off rebuild (a slider changed); the per-frame path below
+  // builds at most one chunk instead, so a device that has fallen behind never
+  // pays for several trimesh colliders in the same frame.
   const ensureAhead = (distance: number): void => {
-    if ((chunks[chunks.length - 1]?.endDistance ?? -TRACK_BEHIND) >= distance + TRACK_LOOKAHEAD)
-      return
+    if (coversLookahead(distance)) return
     spawnNext()
     ensureAhead(distance)
+  }
+
+  // One chunk at most, however far behind the lookahead is. Called every
+  // frame, so falling behind costs a few thinner-than-ideal frames of lookahead
+  // rather than one frame paying for all of them at once.
+  const pump = (distance: number): void => {
+    if (coversLookahead(distance)) return
+    spawnNext()
   }
 
   const prune = (distance: number): void => {
@@ -537,6 +550,7 @@ export const createTrackChunkManager = (options: TrackChunkManagerOptions): Trac
 
   return {
     ensureAhead,
+    pump,
     prune,
     rebuild,
     setWall,

--- a/src/views/Games/RockRunner/types.ts
+++ b/src/views/Games/RockRunner/types.ts
@@ -84,6 +84,8 @@ export type TrackChunk = {
 /** Spawns ground ahead of the rock and disposes it behind. */
 export type TrackChunkManager = {
   ensureAhead: (distance: number) => void
+  /** Builds at most one chunk, so a frame is never blocked catching up on several at once. */
+  pump: (distance: number) => void
   prune: (distance: number) => void
   rebuild: (distance: number) => void
   setWall: (wall: WallConfig, distance: number) => void
@@ -164,6 +166,8 @@ export type ScatterChunk = {
 export type ScatterAreaManager = {
   name: string
   ensureAhead: (distance: number) => void
+  /** Builds at most one chunk, so a frame is never blocked catching up on several at once. */
+  pump: (distance: number) => void
   prune: (distance: number) => void
   rebuild: (distance: number) => void
   setHidden: (hidden: boolean) => void


### PR DESCRIPTION
Closes #221

## Summary

- Periodic FPS drops on mobile (down to 16 FPS / 98ms frame time, reported live from cnotv.xyz) at track/scatter chunk boundaries, caused by synchronous chunk-building work: track chunks build a full Rapier trimesh physics collider, scatter areas build new InstancedMeshes (and possibly compile new shaders) — and both systems' boundaries periodically coincide.

## Key Changes

- `trackChunks.ts` / `scatterAreas.ts`: both chunk managers gain a `pump(distance)` method that builds **at most one chunk per call**, used by the per-frame game loop instead of `ensureAhead`'s recursive catch-up-in-one-call. `ensureAhead` is kept as-is for the deliberate full rebuild a slider change already triggers.
- `useRockRun.ts`: the 8 scatter areas are staggered by a `chunkPhase` offset so their chunk grids no longer all land on the same distance and rebuild in the same frame.
- `documentation/docs/journey/rock-runner-collider-construction-cost.md`: a deep-dive write-up on the bigger lever *not* pulled here — replacing the deck's trimesh collider with something cheaper to construct (heightfield, compound boxes) — including why it's a real tradeoff against a seam bug the current unified collider deliberately avoids, and a recommendation to measure before choosing a direction.

## Test plan

- [x] `pnpm test:unit` — 1975 tests passing (6 new)
- [x] `pnpm type-check` / lint — clean (hit and fixed a real `max-lines-per-function` error introduced by the new code)
- [x] Verified in-browser under 4x CPU throttling: no errors, streaming holds up across many chunk boundaries, frame-ms chart flat after the one-time startup cost
- [ ] Confirm on the reporting device (mobile Safari) that the periodic drop is gone