### PR TITLE
Rock Runner: self-driving curve assist

### DIFF
--- a/documentation/docs/journey/rock-runner-self-driving-centering.md
+++ b/documentation/docs/journey/rock-runner-self-driving-centering.md
@@ -1,0 +1,80 @@
+---
+sidebar_position: 116
+---
+
+# Rock Runner: a self-driving centering assist
+
+## The problem
+
+Rock Runner's track is an endless, procedurally generated ribbon: heading and
+height are each a sum of sine terms evaluated against the distance travelled,
+so the curve shape is a pure function of the seed (see
+[Rock Runner's endless track](./rock-runner-endless-track.md)). Sharp bends
+are common, and a player who steers a beat late clips the outer wall. "Self
+driving" is a Config-panel toggle that continuously tries to hold the rock to
+the middle of the track, without taking control away from the player.
+
+## Velocity, not impulse
+
+The rock's own steering is impulse-based: a discrete push added to whatever
+momentum the rock already carries, capped by a lateral speed limit and a wall
+standoff so the push can never overpower the body faster than the physics
+lets it accelerate. An assist built the same way — an added corrective
+impulse — was tried first, but an added force always has to fight whatever
+momentum is already there; a rock drifting hard toward a wall needs several
+frames of accumulated impulse before its actual velocity turns around.
+
+The assist instead commands the rock's lateral velocity directly:
+
+```mermaid
+flowchart LR
+    A[Rock's current offset from centreline] --> B[autopilotLateralVelocity]
+    B --> C["Clamped target lateral velocity, opposing the offset"]
+    C --> D["body.setLinvel: forward + vertical kept, lateral replaced"]
+    D --> E[Player's own steering impulse applies on top]
+```
+
+Each frame, while the toggle is on, the rock's current velocity is
+decomposed into its forward and lateral components against the track's local
+frame (the same `sample.forward` / `sample.right` vectors steering already
+uses). The forward and vertical (gravity, jump) components are left exactly
+as they are; only the lateral component is replaced outright with a target
+value proportional to, and opposing, the rock's current offset from the
+centreline — a proportional controller, not a nudge. Because it's a direct
+velocity command rather than a force, the correction is felt immediately
+rather than building up over several frames, and a jump or a wall bounce
+still behaves exactly as it would without the assist, since only the lateral
+axis is touched.
+
+## Blending with the player
+
+The centering command runs first each frame, then the player's own
+steering impulse is applied on top exactly as it always was — so holding
+left or right still moves the rock further than the assist alone would,
+rather than fighting a competing correction. The rock is a normal dynamic
+physics body throughout: collisions, restitution and jumping are unaffected,
+since the assist only ever overwrites the lateral component of velocity, one
+axis out of three.
+
+## Where it lives
+
+Rock Runner's tunables already follow one pattern: a single reactive
+`RockConfig` object is read directly by the run loop every frame, and
+registered into both the elements panel and the Config panel from the same
+field schema. The toggle is one more field on that object —
+`autopilot: boolean`, defaulting off — following the boolean-field
+convention already used by Maze Game's own auto-mode toggle. The correction
+gain and maximum centering speed are tuned constants, not exposed controls:
+this is one on/off option, not a tuning surface.
+
+## Verification
+
+`rockMotion.test.ts` covers `autopilotLateralVelocity` directly (sign
+correctness — an offset to one side commands velocity toward the other —
+and clamping to the maximum centering speed), plus the small
+`lateralPushAllowed` / `clampLateralMagnitude` helpers pulled out of the
+player's own `steerImpulseMagnitude` along the way, with the existing suite
+serving as a regression check that player-only steering is unchanged. In the
+browser: toggle Self driving on mid-run from the Config panel and watch the
+rock hold to the middle through a run of curves with no input, then confirm
+manual steering still moves it further without fighting the assist.

--- a/src/views/Games/RockRunner/config.ts
+++ b/src/views/Games/RockRunner/config.ts
@@ -315,6 +315,12 @@ export const STEER_IMPULSE = 75
 // forward speed without letting the rock slide across the whole track at once.
 export const MAX_LATERAL_SPEED = 12
 
+// Self driving: how strongly the rock's offset from the centreline converts
+// into a commanded centering velocity, and the fastest it will ever servo
+// back toward the middle.
+export const AUTOPILOT_GAIN = 1.5
+export const AUTOPILOT_MAX_SPEED = 10
+
 // An impulse is momentum, so it is divided by the rock's mass rather than
 // producing a speed directly. Raised alongside the gravity above and measured
 // against the solver with it: the pair clear 8.5 units in 0.3s of rise.

--- a/src/views/Games/RockRunner/game/rockMotion.test.ts
+++ b/src/views/Games/RockRunner/game/rockMotion.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import {
   advanceDistance,
+  autopilotLateralVelocity,
+  clampLateralMagnitude,
   debrisBurstSize,
   debrisLifetime,
   speedCapAt,
@@ -12,6 +14,7 @@ import {
   jumpReady,
   forwardImpulseMagnitude,
   frameScaledImpulse,
+  lateralPushAllowed,
   steerImpulseMagnitude,
   wallStandoff,
   lateralOffset
@@ -212,6 +215,64 @@ describe('steerImpulseMagnitude', () => {
         standoff: Infinity
       })
     ).toBe(4)
+  })
+})
+
+describe('lateralPushAllowed', () => {
+  it.each([
+    [1, { lateralSpeed: 0, speedCap: 12, offset: 0, standoff: Infinity }, true],
+    [1, { lateralSpeed: 12, speedCap: 12, offset: 0, standoff: Infinity }, false],
+    [1, { lateralSpeed: 0, speedCap: 12, offset: 5, standoff: 5 }, false],
+    [-1, { lateralSpeed: 0, speedCap: 12, offset: 0, standoff: Infinity }, true],
+    [-1, { lateralSpeed: -12, speedCap: 12, offset: 0, standoff: Infinity }, false],
+    [-1, { lateralSpeed: 0, speedCap: 12, offset: -5, standoff: 5 }, false],
+    [0, { lateralSpeed: 100, speedCap: 12, offset: 100, standoff: 5 }, true]
+  ])('direction %i under %o is allowed: %s', (direction, limits, expected) => {
+    expect(lateralPushAllowed(direction, limits)).toBe(expected)
+  })
+})
+
+describe('clampLateralMagnitude', () => {
+  it('passes a magnitude through when the push is allowed', () => {
+    expect(
+      clampLateralMagnitude(4, { lateralSpeed: 0, speedCap: 12, offset: 0, standoff: Infinity })
+    ).toBe(4)
+  })
+
+  it('zeroes a magnitude already at the wall in that direction', () => {
+    expect(
+      clampLateralMagnitude(4, { lateralSpeed: 0, speedCap: 12, offset: 5, standoff: 5 })
+    ).toBe(0)
+  })
+
+  it('zeroes a magnitude already at the speed cap in that direction', () => {
+    expect(
+      clampLateralMagnitude(-4, { lateralSpeed: -12, speedCap: 12, offset: 0, standoff: Infinity })
+    ).toBe(0)
+  })
+
+  it('leaves zero as zero', () => {
+    expect(
+      clampLateralMagnitude(0, { lateralSpeed: 0, speedCap: 12, offset: 0, standoff: Infinity })
+    ).toBe(0)
+  })
+})
+
+describe('autopilotLateralVelocity', () => {
+  it.each([
+    [4, 2, 20, -8],
+    [-4, 2, 20, 8],
+    [0, 2, 20, 0]
+  ])('offset %f at gain %f commands %f', (offset, gain, max, expected) => {
+    expect(autopilotLateralVelocity(offset, gain, max)).toBeCloseTo(expected)
+  })
+
+  it('clamps to the maximum centering speed on a large offset', () => {
+    expect(autopilotLateralVelocity(1000, 2, 20)).toBe(-20)
+  })
+
+  it('clamps to the negative maximum on a large negative offset', () => {
+    expect(autopilotLateralVelocity(-1000, 2, 20)).toBe(20)
   })
 })
 

--- a/src/views/Games/RockRunner/game/rockMotion.ts
+++ b/src/views/Games/RockRunner/game/rockMotion.ts
@@ -234,6 +234,31 @@ export type SteerLimits = {
 }
 
 /**
+ * Whether a lateral push in the given direction is still open: not already
+ * at the lateral speed cap, and not already pinned against the wall.
+ *
+ * @param direction - Positive for a rightward push, negative for leftward, zero for neither
+ * @param limits - The speed and position the steering has to stop at
+ * @returns Whether that direction is still open
+ */
+export const lateralPushAllowed = (direction: number, limits: SteerLimits): boolean => {
+  const { lateralSpeed, speedCap, offset, standoff } = limits
+  if (direction > 0) return lateralSpeed < speedCap && offset < standoff
+  if (direction < 0) return lateralSpeed > -speedCap && offset > -standoff
+  return true
+}
+
+/**
+ * A lateral magnitude, zeroed once its direction is no longer open.
+ *
+ * @param magnitude - The signed lateral magnitude to gate
+ * @param limits - The speed and position the steering has to stop at
+ * @returns The magnitude unchanged, or zero if that direction is no longer open
+ */
+export const clampLateralMagnitude = (magnitude: number, limits: SteerLimits): number =>
+  magnitude !== 0 && lateralPushAllowed(magnitude, limits) ? magnitude : 0
+
+/**
  * Impulse that steers the rock sideways without exceeding the lateral cap or
  * driving it into a wall.
  *
@@ -246,13 +271,7 @@ export const steerImpulseMagnitude = (
   steer: number,
   impulse: number,
   limits: SteerLimits
-): number => {
-  if (steer === 0) return 0
-  const { lateralSpeed, speedCap, offset, standoff } = limits
-  if (steer > 0 && (lateralSpeed >= speedCap || offset >= standoff)) return 0
-  if (steer < 0 && (lateralSpeed <= -speedCap || offset <= -standoff)) return 0
-  return steer * impulse
-}
+): number => clampLateralMagnitude(steer * impulse, limits)
 
 /**
  * How far off the centreline the rock can sit before it is touching a wall.
@@ -277,3 +296,18 @@ export const lateralOffset = (
   origin: { x: number; z: number },
   right: { x: number; z: number }
 ): number => (position.x - origin.x) * right.x + (position.z - origin.z) * right.z
+
+/**
+ * The lateral velocity the self-driving assist commands: proportional to how
+ * far off the centreline the rock currently sits, opposing the offset, and
+ * clamped to a maximum centering speed. A direct velocity command rather than
+ * an impulse, so the rock is steered like a servo pulling back to the middle
+ * instead of being nudged by an accumulating force.
+ *
+ * @param offset - Offset from the centreline, positive towards the path's right
+ * @param gain - How strongly offset converts to a velocity command
+ * @param maxSpeed - The largest centering speed allowed, in either direction
+ * @returns The signed lateral velocity to command, opposing the offset
+ */
+export const autopilotLateralVelocity = (offset: number, gain: number, maxSpeed: number): number =>
+  Math.max(-maxSpeed, Math.min(maxSpeed, -offset * gain))

--- a/src/views/Games/RockRunner/game/useRockRun.ts
+++ b/src/views/Games/RockRunner/game/useRockRun.ts
@@ -46,6 +46,7 @@ import { createDebrisField } from './debris'
 import { stageColorAt } from '../scatter/textureStages'
 import {
   advanceDistance,
+  autopilotLateralVelocity,
   debrisBurstSize,
   debrisLifetime,
   forwardImpulseMagnitude,
@@ -75,6 +76,8 @@ import type {
   TrackPath
 } from '../types'
 import {
+  AUTOPILOT_GAIN,
+  AUTOPILOT_MAX_SPEED,
   CONTROLS_GAME_ID,
   COUNTDOWN_MS,
   CHASE_BACK,
@@ -194,6 +197,7 @@ type RunReferences = {
 // Impulses are recomputed every frame, so the vector they are written into is
 // allocated once here rather than inside the loop.
 const scratchImpulse = { x: 0, y: 0, z: 0 }
+const scratchVelocity = { x: 0, y: 0, z: 0 }
 const ZERO_VELOCITY = { x: 0, y: 0, z: 0 }
 const scratchOrigin = new THREE.Vector3()
 
@@ -460,8 +464,27 @@ const createDriveAction =
     if (!state.rock || !state.controls || !state.path || !state.rockConfig) return
     const sample = state.path.sampleAt(state.distance)
     const body = state.rock.userData.body
-    const velocity = body.linvel()
     const rock = state.rockConfig
+    // The self-driving assist is a velocity servo rather than an impulse: it
+    // directly commands the lateral component of the body's own velocity
+    // toward the centreline every frame, leaving the forward and vertical
+    // components untouched, so it holds the rock to the middle continuously
+    // instead of nudging it with a force that has to fight momentum.
+    if (rock.autopilot) {
+      const currentVelocity = body.linvel()
+      const forwardComponent = speedAlong(currentVelocity, sample.forward)
+      const offset = lateralOffset(body.translation(), sample.position, sample.right)
+      const centeringVelocity = autopilotLateralVelocity(
+        offset,
+        AUTOPILOT_GAIN,
+        AUTOPILOT_MAX_SPEED
+      )
+      scratchVelocity.x = sample.forward.x * forwardComponent + sample.right.x * centeringVelocity
+      scratchVelocity.y = currentVelocity.y
+      scratchVelocity.z = sample.forward.z * forwardComponent + sample.right.z * centeringVelocity
+      body.setLinvel(scratchVelocity, true)
+    }
+    const velocity = body.linvel()
     const forwardMagnitude = forwardImpulseMagnitude(
       speedAlong(velocity, sample.forward),
       speedCapFor(rock, state.distance),

--- a/src/views/Games/RockRunner/panel/rockPanel.test.ts
+++ b/src/views/Games/RockRunner/panel/rockPanel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { RR_ROCK_CONTROLS } from './rockPanel'
+import { RR_ROCK_CONTROLS, RR_ROCK_PHYSICS_CONTROLS } from './rockPanel'
 import {
   BASE_MAX_SPEED,
   FORWARD_IMPULSE,
@@ -93,4 +93,11 @@ describe('RR_ROCK_CONTROLS', () => {
       expect(controls[name].min).toBeGreaterThan(0)
     }
   )
+})
+
+describe('self-driving assist', () => {
+  it('exposes the toggle in both the elements panel and the config panel schema, sharing one definition', () => {
+    expect(RR_ROCK_CONTROLS.autopilot).toEqual({ boolean: true, label: 'Self driving' })
+    expect(RR_ROCK_PHYSICS_CONTROLS.autopilot).toBe(RR_ROCK_CONTROLS.autopilot)
+  })
 })

--- a/src/views/Games/RockRunner/panel/rockPanel.ts
+++ b/src/views/Games/RockRunner/panel/rockPanel.ts
@@ -36,7 +36,7 @@ import {
  * instead, which is what makes the rock read as heavy stone rather than rubber.
  */
 export const RR_ROCK_CONTROLS = {
-  forwardImpulse: { min: 0, max: 200, step: 1, label: 'Drive force' },
+  forwardImpulse: { min: 0, max: 1000, step: 1, label: 'Drive force' },
   baseMaxSpeed: { min: 1, max: 80, step: 1, label: 'Starting top speed' },
   maxSpeedCeiling: { min: 1, max: 120, step: 1, label: 'Final top speed' },
   speedRampDistance: { min: 100, max: 20000, step: 100, label: 'Distance to reach it' },
@@ -50,7 +50,7 @@ export const RR_ROCK_CONTROLS = {
   mass: { min: 1, max: 400, step: 5, label: 'Mass' },
   // Gravity is a multiplier on the world's, not an acceleration: Rapier has one
   // world gravity and a body's weight is expressed against it.
-  gravityScale: { min: 0.1, max: 40, step: 0.1, label: 'Gravity' },
+  gravityScale: { min: 0.1, max: 100, step: 0.1, label: 'Gravity' },
   // Reaches far higher than the rising figure because it only governs the drop.
   // Stops short of where the rock starts sinking into the deck on landing.
   friction: { min: 0, max: 40, step: 0.5, label: 'Grip' },
@@ -62,7 +62,8 @@ export const RR_ROCK_CONTROLS = {
   // proportion. Zero removes the line rather than drawing a hairline.
   strokeWidth: { min: 0, max: 0.3, step: 0.005, label: 'Outline width' },
   strokeWobble: { min: 0, max: 2, step: 0.05, label: 'Outline wobble' },
-  strokeColor: { label: 'Outline colour', color: true }
+  strokeColor: { label: 'Outline colour', color: true },
+  autopilot: { boolean: true, label: 'Self driving' }
 }
 
 /**
@@ -79,7 +80,8 @@ export const RR_ROCK_PHYSICS_CONTROLS = {
   friction: RR_ROCK_CONTROLS.friction,
   restitution: RR_ROCK_CONTROLS.restitution,
   linearDamping: RR_ROCK_CONTROLS.linearDamping,
-  angularDamping: RR_ROCK_CONTROLS.angularDamping
+  angularDamping: RR_ROCK_CONTROLS.angularDamping,
+  autopilot: RR_ROCK_CONTROLS.autopilot
 }
 
 export type RockPanelOptions = {
@@ -159,7 +161,8 @@ export const registerRockElements = (options: RockPanelOptions): RockPanel => {
     tint: ROCK_TINT,
     strokeWidth: ROCK_STROKE_WIDTH,
     strokeWobble: ROCK_STROKE_WOBBLE,
-    strokeColor: ROCK_STROKE_COLOR
+    strokeColor: ROCK_STROKE_COLOR,
+    autopilot: false
   })
 
   const apply = (): void => {

--- a/src/views/Games/RockRunner/types.ts
+++ b/src/views/Games/RockRunner/types.ts
@@ -258,6 +258,7 @@ export type RockConfig = {
   linearDamping: number
   angularDamping: number
   tint: number
+  autopilot: boolean
 }
 
 export type DebrisEmitOptions = {


### PR DESCRIPTION
Closes #220

## Summary

Adds a "Self driving" toggle to Rock Runner's Config panel: a velocity-servo assist that continuously tries to keep the rock centred on the track, additive to the player's own steering, without taking control away.

## Key Changes

- `rockMotion.ts`: extracted `lateralPushAllowed`/`clampLateralMagnitude` from `steerImpulseMagnitude` (shared wall/speed safety clamp, unchanged behavior for player steering). Added `autopilotLateralVelocity(offset, gain, maxSpeed)` — turns the rock's current offset from the centreline into a clamped target lateral velocity, opposing it.
- `useRockRun.ts` (`createDriveAction`): each frame, while `autopilot` is on, the rock's velocity is decomposed into forward/lateral/vertical against the track's local frame; the lateral component is directly `body.setLinvel`'d toward the centreline (forward and vertical untouched), *before* the player's own steering impulse is applied on top — so player input still adds to the correction rather than fighting a competing force.
- `types.ts` / `config.ts` / `rockPanel.ts`: `autopilot: boolean` added to `RockConfig`, following the same boolean-field convention as Maze Game's `autoMode.enabled` — registered into both the elements panel and the Config panel from one shared schema, defaulting off. `AUTOPILOT_GAIN` / `AUTOPILOT_MAX_SPEED` are internal tuned constants, not exposed sliders.
- Also raises the Drive force (200 → 1000) and Gravity (40 → 100) slider ceilings in the Config panel.
- `documentation/docs/journey/rock-runner-self-driving-centering.md`: journey write-up on why a direct velocity command was chosen over an additive corrective impulse (the approach tried first) — an impulse has to fight whatever momentum the rock already carries, while a direct `setLinvel` correction is felt immediately.

## Test plan

- [x] `pnpm test:unit` — 1986 tests passing (5 new: `autopilotLateralVelocity` sign correctness/clamping, extracted clamp helpers)
- [x] `pnpm type-check` / lint — clean
- [x] Manual: toggled "Self driving" on mid-run from the Config panel — rock holds tightly to centre through a run of curves with no input
- [x] Manual: player steering still moves the rock further while the assist is active, confirmed visually (holding left/right shifts the rock further than the assist alone)