### PR TITLE
Cap renderer pixel ratio for mobile

### DIFF
--- a/packages/threejs/src/getters.test.ts
+++ b/packages/threejs/src/getters.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { getPixelRatio } from './getters'
+
+describe('getPixelRatio', () => {
+  it.each([
+    [1, 1],
+    [2, 2]
+  ])('leaves a device pixel ratio of %f at %f', (device, expected) => {
+    expect(getPixelRatio(device)).toBe(expected)
+  })
+
+  it.each([
+    [3, 2],
+    [4, 2]
+  ])('caps a device pixel ratio of %f down to %f', (device, expected) => {
+    expect(getPixelRatio(device)).toBe(expected)
+  })
+
+  it('respects a custom maximum', () => {
+    expect(getPixelRatio(3, 1.5)).toBe(1.5)
+  })
+})

--- a/packages/threejs/src/getters.ts
+++ b/packages/threejs/src/getters.ts
@@ -452,9 +452,21 @@ export const getPhysic = (world: RAPIER.World, options: PhysicOptions) => {
   return { rigidBody, collider, characterController }
 }
 
+/**
+ * A phone's device pixel ratio (often 3-4) renders 9-16x the fragments of a
+ * ratio of 1, and fill rate is usually what a phone runs out of first.
+ * Capping it at 2 is close to invisible on a small screen and is the
+ * cheapest, largest win available for mobile frame time.
+ * @param devicePixelRatio - The display's actual device pixel ratio
+ * @param maxPixelRatio - The highest ratio the renderer is allowed to use
+ * @returns The pixel ratio to render at
+ */
+export const getPixelRatio = (devicePixelRatio: number, maxPixelRatio = 2): number =>
+  Math.min(devicePixelRatio, maxPixelRatio)
+
 export const getRenderer = (canvas: HTMLCanvasElement): THREE.WebGLRenderer => {
   const renderer = new THREE.WebGLRenderer({ canvas, antialias: true })
-  renderer.setPixelRatio(window.devicePixelRatio)
+  renderer.setPixelRatio(getPixelRatio(window.devicePixelRatio))
   renderer.setSize(window.innerWidth, window.innerHeight)
   renderer.setClearColor(0xaaaaff)
   renderer.shadowMap.enabled = true


### PR DESCRIPTION
Closes #224

## Summary

Follow-up to #221/#222: after fixing the periodic chunk-boundary FPS spikes, re-testing on device showed FPS *still* down — but sustained (~18 FPS / 47ms flat across a full minute), not spiky. Draw calls and triangle count were unremarkable, pointing to a steady-state fill-rate problem instead.

## Key Changes

- `packages/threejs/src/getters.ts`: `getRenderer()` never capped the pixel ratio — `renderer.setPixelRatio(window.devicePixelRatio)`, uncapped. On a phone at DPR 3, that's every fragment shader in the scene running 9x over, every single frame. This is literally step 1 in the project's own `documentation/docs/guides/mobile-performance.md` guide (which uses Rock Runner as its worked example), documented as "the single largest win available" — it had just never actually been implemented.
- Added `getPixelRatio(devicePixelRatio, maxPixelRatio = 2)`, a small pure helper, and used it in `getRenderer()`. Since `getRenderer` sits behind the shared `getEnvironment`/`getTools` path, this fixes every game built on `@webgamekit/threejs`, not only Rock Runner.

## Test plan

- [x] `pnpm test:unit` — 1991 tests passing (5 new for `getPixelRatio`)
- [x] `pnpm type-check` / lint — clean
- [x] Verified in-browser (Playwright, iPhone 13 Pro emulation, devicePixelRatio 3): canvas drawing buffer is exactly 2x the CSS size, confirming the cap applies; scene renders at full visual quality, nothing looks degraded
- [ ] Confirm on the reporting device that sustained FPS improves