### PR TITLE
Rock Runner: self driving on by default, hands back on player steering

### DIFF
--- a/documentation/docs/journey/rock-runner-self-driving-centering.md
+++ b/documentation/docs/journey/rock-runner-self-driving-centering.md
@@ -11,8 +11,8 @@ height are each a sum of sine terms evaluated against the distance travelled,
 so the curve shape is a pure function of the seed (see
 [Rock Runner's endless track](./rock-runner-endless-track.md)). Sharp bends
 are common, and a player who steers a beat late clips the outer wall. "Self
-driving" is a Config-panel toggle that continuously tries to hold the rock to
-the middle of the track, without taking control away from the player.
+driving" is a Config-panel toggle, on by default, that continuously tries to
+hold the rock to the middle of the track until the player takes over.
 
 ## Velocity, not impulse
 
@@ -31,7 +31,7 @@ flowchart LR
     A[Rock's current offset from centreline] --> B[autopilotLateralVelocity]
     B --> C["Clamped target lateral velocity, opposing the offset"]
     C --> D["body.setLinvel: forward + vertical kept, lateral replaced"]
-    D --> E[Player's own steering impulse applies on top]
+    E[Player presses left/right] -->|turns autopilot off| D
 ```
 
 Each frame, while the toggle is on, the rock's current velocity is
@@ -46,15 +46,24 @@ rather than building up over several frames, and a jump or a wall bounce
 still behaves exactly as it would without the assist, since only the lateral
 axis is touched.
 
-## Blending with the player
+## Handing control back, not fighting for it
 
-The centering command runs first each frame, then the player's own
-steering impulse is applied on top exactly as it always was — so holding
-left or right still moves the rock further than the assist alone would,
-rather than fighting a competing correction. The rock is a normal dynamic
-physics body throughout: collisions, restitution and jumping are unaffected,
-since the assist only ever overwrites the lateral component of velocity, one
-axis out of three.
+An earlier version ran the centering command every frame and let the
+player's own steering impulse apply on top of it, so the two blended
+continuously. In practice that meant the assist was always at least a
+little bit active, second-guessing a player who was already steering
+exactly where they wanted to go — a hands-off default should get out of
+the way the moment the player takes the wheel, not keep contributing
+alongside them.
+
+`autopilot` now turns itself off the instant `steerDirection` reads
+anything but zero — the very first frame the player presses left or right.
+It's a one-way latch: once handed back, control stays with the player until
+they re-enable the toggle from the Config panel themselves, it doesn't
+reactivate the moment the player lets go of the key. The rock is a normal
+dynamic physics body throughout either way: collisions, restitution and
+jumping are unaffected, since the assist only ever overwrites the lateral
+component of velocity, one axis out of three.
 
 ## Where it lives
 
@@ -62,7 +71,7 @@ Rock Runner's tunables already follow one pattern: a single reactive
 `RockConfig` object is read directly by the run loop every frame, and
 registered into both the elements panel and the Config panel from the same
 field schema. The toggle is one more field on that object —
-`autopilot: boolean`, defaulting off — following the boolean-field
+`autopilot: boolean`, defaulting **on** — following the boolean-field
 convention already used by Maze Game's own auto-mode toggle. The correction
 gain and maximum centering speed are tuned constants, not exposed controls:
 this is one on/off option, not a tuning surface.
@@ -75,6 +84,7 @@ and clamping to the maximum centering speed), plus the small
 `lateralPushAllowed` / `clampLateralMagnitude` helpers pulled out of the
 player's own `steerImpulseMagnitude` along the way, with the existing suite
 serving as a regression check that player-only steering is unchanged. In the
-browser: toggle Self driving on mid-run from the Config panel and watch the
-rock hold to the middle through a run of curves with no input, then confirm
-manual steering still moves it further without fighting the assist.
+browser: confirm the Config panel's checkbox starts checked; watch the rock
+hold to the middle through a run of curves with no input; tap left or right
+and confirm the checkbox unchecks itself the instant the key is pressed and
+the rock stays under manual control from then on.

--- a/src/views/Games/RockRunner/game/useRockRun.ts
+++ b/src/views/Games/RockRunner/game/useRockRun.ts
@@ -465,6 +465,11 @@ const createDriveAction =
     const sample = state.path.sampleAt(state.distance)
     const body = state.rock.userData.body
     const rock = state.rockConfig
+    const steer = steerDirection(state.controls.currentActions)
+    // Self driving is a hands-off default, not an assist the player has to
+    // fight: the first steering press hands control back rather than adding
+    // to it, so it only ever turns off on its own, never back on.
+    if (rock.autopilot && steer !== 0) rock.autopilot = false
     // The self-driving assist is a velocity servo rather than an impulse: it
     // directly commands the lateral component of the body's own velocity
     // toward the centreline every frame, leaving the forward and vertical
@@ -495,16 +500,12 @@ const createDriveAction =
     // full force for as long as the key was held. That normal force against the
     // rock's grip is what brought it to a halt at the track edge, so steering
     // stops at the wall itself rather than only at a speed.
-    const lateralMagnitude = steerImpulseMagnitude(
-      steerDirection(state.controls.currentActions),
-      rock.steerImpulse,
-      {
-        lateralSpeed: speedAlong(velocity, sample.right),
-        speedCap: rock.maxLateralSpeed,
-        offset: lateralOffset(body.translation(), sample.position, sample.right),
-        standoff: wallStandoff(state.track?.deckWidth() ?? TRACK_WIDTH, rock.radius)
-      }
-    )
+    const lateralMagnitude = steerImpulseMagnitude(steer, rock.steerImpulse, {
+      lateralSpeed: speedAlong(velocity, sample.right),
+      speedCap: rock.maxLateralSpeed,
+      offset: lateralOffset(body.translation(), sample.position, sample.right),
+      standoff: wallStandoff(state.track?.deckWidth() ?? TRACK_WIDTH, rock.radius)
+    })
     if (forwardMagnitude === 0 && lateralMagnitude === 0) return
     const forward = frameScaledImpulse(forwardMagnitude, delta)
     const lateral = frameScaledImpulse(lateralMagnitude, delta)

--- a/src/views/Games/RockRunner/panel/rockPanel.ts
+++ b/src/views/Games/RockRunner/panel/rockPanel.ts
@@ -162,7 +162,7 @@ export const registerRockElements = (options: RockPanelOptions): RockPanel => {
     strokeWidth: ROCK_STROKE_WIDTH,
     strokeWobble: ROCK_STROKE_WOBBLE,
     strokeColor: ROCK_STROKE_COLOR,
-    autopilot: false
+    autopilot: true
   })
 
   const apply = (): void => {


### PR DESCRIPTION
Closes #226

## Summary

Two behavior changes to the self-driving centering assist shipped in #223:

1. `autopilot` now defaults to `true` — self driving is on from the start of every run instead of requiring a manual opt-in.
2. Replaces the additive blend-under-player-input design with a one-way hand-back: `autopilot` turns itself off the instant the player presses left or right, and stays off until they re-enable it from the Config panel — it doesn't reactivate when the key is released.

## Key Changes

- `rockPanel.ts`: default flipped `false` → `true` in the `reactive<RockConfig>` initializer.
- `useRockRun.ts` (`createDriveAction`): `steerDirection` is now computed once at the top and reused; if `rock.autopilot && steer !== 0`, `rock.autopilot` is set `false` before the centering correction runs that frame, so the player's first press is never fought by a competing correction.
- `documentation/docs/journey/rock-runner-self-driving-centering.md`: updated to describe the hand-back design in place of the additive-blend section it previously had.

## Test plan

- [x] `pnpm test:unit` — 1986 tests passing, unchanged (no new pure-function surface — this is a two-line integration change reusing already-tested `steerDirection`)
- [x] `pnpm type-check` / lint — clean
- [x] Manual: Config panel's "Self driving" checkbox starts checked on a fresh run
- [x] Manual: pressing right unchecks it live in the panel; rock stays under manual control from then on